### PR TITLE
update core to v0.10.0

### DIFF
--- a/opam
+++ b/opam
@@ -27,7 +27,7 @@ depends: [
   "ocamlbuild" {build}
   "menhir"
   "ppx_deriving"
-  "core" {= "v0.9.1"}
+  "core" {= "v0.10.0"}
   "uutf"
   "result"
   "bitv"

--- a/src/backend/flowGraph.ml
+++ b/src/backend/flowGraph.ml
@@ -5,7 +5,7 @@ let print_for_debug msg =
 *)
   ()
 
-module Heap = Core.Heap.Removable
+module Heap = Core.Heap
 
 
 module type VertexType =


### PR DESCRIPTION
fix #10

### Details

This commit changes `Core.Heap.Removable` into `Heap`. `Core.Heap.Removable` is removed at core v0.10.0 ([ref](https://github.com/janestreet/core_kernel/blob/0d90562db8acd4ec3658c7c7b8b655ca5644caea/CHANGES.md#v010)).
