### PR TITLE
show expanded path to SATYSFI_LIB_ROOT

### DIFF
--- a/opam
+++ b/opam
@@ -16,7 +16,7 @@ install: [
 ]
 post-messages: [
   "Please set SATYSFI_LIB_ROOT. You may want to add the following line to ~/.bashrc"
-  "export SATYSFI_LIB_ROOT=\"$(PREFIX_LIB)/lib-satysfi\""
+  "export SATYSFI_LIB_ROOT=\"%{prefix}%/lib-satysfi\""
 ]
 remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "PREFIX_LIB=%{prefix}%"]


### PR DESCRIPTION
Fix #18

This is to fix post-install message.
A post-install message is now something like this.
```
=> Please set SATYSFI_LIB_ROOT. You may want to add the following line to ~/.bashrc
=> export SATYSFI_LIB_ROOT="/somewhere/.opam/4.05.0/lib-satysfi"
```