### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Created by .ignore support plugin (hsz.mobi)
+### OCaml template
+*.annot
+*.cmo
+*.cma
+*.cmi
+*.a
+*.o
+*.cmx
+*.cmxs
+*.cmxa
+
+# ocamlbuild working directory
+_build/
+
+# ocamlbuild targets
+*.byte
+*.native
+
+# oasis generated files
+setup.data
+setup.log
+
+# Merlin configuring file for Vim and Emacs
+.merlin
+
+.dockerignore
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ocaml/opam:fedora-25_ocaml-4.05.0 as builder
+
+USER root
+
+RUN dnf -y install autoconf && dnf clean all
+
+ENV APP_HOME=/opt/SATySFi
+WORKDIR $APP_HOME
+ADD . $APP_HOME
+RUN opam pin add satysfi .
+RUN opam install satysfi
+
+
+FROM debian:latest
+
+COPY --from=builder /home/opam/.opam/4.05.0/lib-satysfi /usr/local/lib-satysfi
+COPY --from=builder /home/opam/.opam/4.05.0/bin/satysfi /usr/local/bin/satysfi
+
+ENV SATYSFI_LIB_ROOT=/usr/local/lib-satysfi/
+
+WORKDIR /opt/work
+CMD bash


### PR DESCRIPTION
Add Dockerfile for easy way to use.

## Usage
```
docker build -t satysfi .
docker run -it -v /PATH/TO/WORKING_DIR:/opt/work satysfi bash
```

## TODO
* Missing fonts. (e.g. ArnoPro-Regular)
  - I think its better to find a way to sync fonts between hosts and containers.

## Note

Build fails for now because `www.unicode.org` is unresponsive.

```
[ERROR] The compilation of satysfi failed at "make -f Makefile lib
        PREFIX=/home/opam/.opam/4.05.0 PREFIX_LIB=/home/opam/.opam/4.05.0".
[satysfi: make Makefile] Command started

#=== ERROR while installing satysfi.~unknown ==================================#
# opam-version         1.2.2 (aa258ecc06d3aea5a67f442a4ffd23f2a457180b)
# os                   linux
# command              make -f Makefile lib PREFIX=/home/opam/.opam/4.05.0 PREFIX_LIB=/home/opam/.opam/4.05.0
# path                 /home/opam/.opam/4.05.0/build/satysfi.~unknown
# compiler             4.05.0
# exit-code            2
# env-file             /home/opam/.opam/4.05.0/build/satysfi.~unknown/satysfi-1-8f73b3.env
# stdout-file          /home/opam/.opam/4.05.0/build/satysfi.~unknown/satysfi-1-8f73b3.out
# stderr-file          /home/opam/.opam/4.05.0/build/satysfi.~unknown/satysfi-1-8f73b3.err
### stdout ###
# wget -N http://www.unicode.org/Public/UNIDATA/EastAsianWidth.txt       -P lib-satysfi/dist/unidata/
# Makefile:42: recipe for target 'lib' failed
### stderr ###
# --2018-02-10 16:36:29--  http://www.unicode.org/Public/UNIDATA/EastAsianWidth.txt
# Resolving www.unicode.org... 216.97.88.9
# Connecting to www.unicode.org|216.97.88.9|:80... failed: Connection refused.
# make: *** [lib] Error 4
```
