### PR TITLE
Add more explicit installation instructions

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -9,13 +9,70 @@
 
 本ソフトウェアは2017年度IPA未踏事業の1プロジェクトとして支援のもと開発されました。
 
-## インストール
+## OPAM を使ったインストール方法
 
-### OPAMによる場合
-* インストール：
-  1. `git submodule update -i` を実行してサブモジュールをフェッチ
-  2. `opam pin add satysfi .` を実行
-  3. `opam install satysfi` を実行
+### 事前に必要なもの
+
+ビルド前に最低限，以下のソフトウェアが必要です。
+
+* bzip2
+* cc
+* git
+* m4
+* make
+* unzip
+* wget
+* [opam](https://opam.ocaml.org/) 1.2 （インストール手順は[こちら](https://opam.ocaml.org/doc/Install.html)。）
+* ocaml 4.05.0 （OPAM からインストールします）
+
+#### 準備例（Ubuntu）
+
+```sh
+sudo apt-get update
+sudo apt-get install build-essential git m4 unzip wget
+
+# 以下のコマンドは OPAM がファイルに追記してもよいか聞いてきます。
+# 必ず説明を読み，環境変数を適切に設定してください。
+wget https://raw.github.com/ocaml/opam/master/shell/opam_installer.sh -O - | sh -s /usr/local/bin
+
+opam switch 4.05.0
+eval `opam config env`
+opam update
+```
+
+#### 準備例（OS X Mavericks 以降）
+
+```sh
+# このスクリプトを実行する前に，GCC や Make などの基本的なソフトウェアをインストールしておいてください。これらは Xcode Command Line Tools からインストールできます。
+# また，Homebrew もインストールしてください。
+
+brew update
+brew install unzip wget git opam
+
+# 以下のコマンドは OPAM がファイルに追記してもよいか聞いてきます。
+# 必ず説明を読み，環境変数を適切に設定してください。
+opam init
+
+opam switch 4.05.0
+eval `opam config env`
+opam update
+```
+
+### ビルド
+
+まず，このレポジトリとサブモジュールを clone します。その後 OPAM を使って SATySFi をビルドします。
+
+```sh
+# clone
+git clone https://github.com/gfngfn/SATySFi.git
+cd SATySFi
+git submodule update --init --recursive
+
+# build
+opam pin add satysfi .
+opam install satysfi
+```
+
 * 再インストール： `opam reinstall satysfi` を実行
 * アンインストール： `opam uninstall satysfi` を実行
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,70 @@
 
 This software is supported by IPA Mitou Project.
 
-## Install
+## Install using OPAM
 
-First, clone this repository.
+### Prerequisites
 
-### Using OPAM
+Here is a list of minimally required softwares.
 
-* To install SATySFi, in the repository
-  1. run `git submodule update -i` to clone submodules.
-  2. run `opam pin add satysfi .`.
-  3. run `opam install satysfi`.
+* bzip2
+* cc
+* git
+* m4
+* make
+* unzip
+* wget
+* [opam](https://opam.ocaml.org/) 1.2 (Installation instructions are [here](https://opam.ocaml.org/doc/Install.html).)
+* ocaml 4.05.0 (installed by OPAM)
+
+#### Example (Ubuntu)
+
+```sh
+sudo apt-get update
+sudo apt-get install build-essential git m4 unzip wget
+
+# The following command will ask if OPAM modifies some files.
+# Be sure to read its instructions. Otherwise, some environment variables won't be set.
+wget https://raw.github.com/ocaml/opam/master/shell/opam_installer.sh -O - | sh -s /usr/local/bin
+
+opam switch 4.05.0
+eval `opam config env`
+opam update
+```
+
+#### Example (OS X Mavericks or later)
+
+```sh
+# Before running this scripts, install essential softwares such as GCC and Make. They can be installed from Xcode Command Line Tools.
+# Also, install Homebrew.
+
+brew update
+brew install unzip wget git opam
+
+# The following command will ask if OPAM modifies some files.
+# Be sure to read their instructions. Otherwise, some environment variables won't be set.
+opam init
+
+opam switch 4.05.0
+eval `opam config env`
+opam update
+```
+
+### Build
+
+First, clone this repository and submodules. Then build SATySFi using OPAM.
+
+```sh
+# clone
+git clone https://github.com/gfngfn/SATySFi.git
+cd SATySFi
+git submodule update --init --recursive
+
+# build
+opam pin add satysfi .
+opam install satysfi
+```
+
 * To reinstall, run `opam reinstall satysfi`.
 * To uninstall, run `opam uninstall satysfi`.
 


### PR DESCRIPTION
This PR add more explicit installation instructions into README.

I tested the instructions for Ubuntu on plain ubuntu:16.04 image of Docker.
However, I haven't tested those for macOS because I don't have any Mac.
So before merging, please test it if you can :pray:. Feel free to edit instructions.

Also, this instructions is for OCaml 4.05.0, not 4.06.0.
So after merging #16, this should be edited.