### PR TITLE
fix CI error on MacOS (fix #24)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ sudo: required
 install:
   - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-ocaml.sh
   - bash -ex .travis-ocaml.sh
+  - eval `opam config env`
   - opam install -y ppx_deriving
   - opam install -y menhir
   - opam install -y core.v0.9.1


### PR DESCRIPTION
fix #24 (CI will succeed after merging #16)  (cf. https://github.com/sunaemon/SATySFi/commit/766a82c2b20ec3e60af4f632695939411a2d3653)
CI on MacOS fails due to invalid PATH.
The test success by putting ``eval `opam config env` `` before  `opam install`.
