### PR TITLE
Faster Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,13 @@ services:
 matrix:
   include:
     - os: osx
-      env: OCAML_VERSION="4.06.1"
+      env: OCAML_VERSION="4.06.0"
     - os: linux
       env: DISTRO="alpine" OCAML_VERSION="4.05.0"
     - os: linux
       env: DISTRO="alpine" OCAML_VERSION="4.06.0"
     - os: linux
-      env: DISTRO="alpine" OCAML_VERSION="4.06.1"
-    - os: linux
-      env: DISTRO="ubuntu-16.04" OCAML_VERSION="4.06.1"
+      env: DISTRO="ubuntu-16.04" OCAML_VERSION="4.06.0"
 env:
   global:
     - PACKAGE="satysfi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,15 @@ services:
 matrix:
   include:
     - os: osx
-      env: OCAML_VERSION="4.06.0"
+      env: OCAML_VERSION="4.06.1"
     - os: linux
       env: DISTRO="alpine" OCAML_VERSION="4.05.0"
     - os: linux
       env: DISTRO="alpine" OCAML_VERSION="4.06.0"
     - os: linux
-      env: DISTRO="ubuntu-16.04" OCAML_VERSION="4.06.0"
+      env: DISTRO="alpine" OCAML_VERSION="4.06.1"
+    - os: linux
+      env: DISTRO="ubuntu-16.04" OCAML_VERSION="4.06.1"
 env:
   global:
     - PACKAGE="satysfi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,36 @@
 language: c
-os:
-  - linux
-  - osx
-env:
-  - OCAML_VERSION=4.06
 sudo: required
-install:
-  - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-ocaml.sh
-  - bash -ex .travis-ocaml.sh
-  - eval `opam config env`
-  - opam install -y ppx_deriving
-  - opam install -y menhir
-  - opam install -y core_kernel.v0.10.0
-  - opam install -y ctypes
-  - opam install -y uutf
-  - opam install -y result
-  - opam install -y bitv
-  - opam install -y batteries
-  - opam install -y yojson
-  - opam install -y camlimages
-  - eval `opam config env`
-  - git submodule update -i
-script:
-  - make all
+services:
+  - docker
+matrix:
+  include:
+    - os: osx
+      env: OCAML_VERSION="4.06.0"
+    - os: linux
+      env: DISTRO="alpine" OCAML_VERSION="4.05.0"
+    - os: linux
+      env: DISTRO="alpine" OCAML_VERSION="4.06.0"
+    - os: linux
+      env: DISTRO="ubuntu-16.04" OCAML_VERSION="4.06.0"
+env:
+  global:
+    - PACKAGE="satysfi"
+    - OPAMBUILDTEST="false"
+    # For osx
+    - OPAMYES="true"
+    - OPAMJOBS=2
+before_script: |
+  if [[ "${TRAVIS_OS_NAME}" == "linux" ]] ; then
+    bash -ex ./travis/linux-before-script.sh ;
+  elif [[ "${TRAVIS_OS_NAME}" == "osx" ]] ; then
+    bash -ex ./travis/osx-before-script.sh ;
+  else
+    echo "Unkown OS name: ${TRAVIS_OS_NAME}" ;
+    false ;
+  fi
+script: |
+  if [[ "${TRAVIS_OS_NAME}" == "linux" ]] ; then
+    docker run satysfi/satysfi:travis ;
+  else
+    opam install "${PACKAGE}.dev" ;
+  fi

--- a/opam
+++ b/opam
@@ -18,17 +18,17 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "depext"
-  "ocamlfind"
-  "ocamlbuild" {build}
-  "menhir"
-  "ppx_deriving"
-  "uutf"
-  "result"
-  "core_kernel" {>= "v0.10.0"}
-  "bitv"
   "batteries"
-  "yojson"
+  "bitv"
   "camlimages"
+  "core_kernel" {>= "v0.10.0"}
+  "depext"
+  "menhir"
+  "ocamlbuild" {build}
+  "ocamlfind"
+  "ppx_deriving"
+  "result"
+  "uutf"
+  "yojson"
 ]
 available: [ ocaml-version >= "4.06.0" ]

--- a/opam
+++ b/opam
@@ -21,6 +21,7 @@ depends: [
   "batteries"
   "bitv"
   "camlimages"
+  "conf-wget" {build}
   "core_kernel" {>= "v0.10.0"}
   "depext"
   "menhir"
@@ -31,4 +32,4 @@ depends: [
   "uutf"
   "yojson"
 ]
-available: [ ocaml-version >= "4.06.0" ]
+available: [ ocaml-version >= "4.05.0" ]

--- a/travis/Dockerfile.template
+++ b/travis/Dockerfile.template
@@ -3,7 +3,7 @@
 FROM ocaml/opam:%distro%_ocaml-%ocaml_version%
 
 WORKDIR /home/opam/build
-ADD . .
+COPY . .
 # Enable --yes option for opam commands (see `opam --help`)
 ENV OPAMYES "true"
 # Enable/disable tests (see `opam install --help`)

--- a/travis/Dockerfile.template
+++ b/travis/Dockerfile.template
@@ -1,0 +1,21 @@
+# This Dockerfile is automatically generated from a simple template file.
+
+FROM ocaml/opam:%distro%_ocaml-%ocaml_version%
+
+WORKDIR /home/opam/build
+ADD . .
+# Enable --yes option for opam commands (see `opam --help`)
+ENV OPAMYES "true"
+# Enable/disable tests (see `opam install --help`)
+ENV OPAMBUILDTEST %opambuildtest%
+# install
+# Note: We should manually update the local opam-repository
+#       because ocaml/opam uses it instead of the online one.
+RUN cd /home/opam/opam-repository \
+ && git pull --quiet origin master \
+ && cd /home/opam/build \
+ && opam update \
+ && opam pin add --no-action %package%.dev . \
+ && opam depext --update %package%.dev \
+ && opam install --deps-only %package%.dev
+CMD opam install %package%.dev

--- a/travis/Dockerfile.template
+++ b/travis/Dockerfile.template
@@ -11,7 +11,8 @@ ENV OPAMBUILDTEST %opambuildtest%
 # install
 # Note: We should manually update the local opam-repository
 #       because ocaml/opam uses it instead of the online one.
-RUN cd /home/opam/opam-repository \
+RUN set -ex \
+ && cd /home/opam/opam-repository \
  && git pull --quiet origin master \
  && cd /home/opam/build \
  && opam update \

--- a/travis/linux-before-script.sh
+++ b/travis/linux-before-script.sh
@@ -1,0 +1,8 @@
+DOCKERFILE="./travis/Dockerfile.template"
+
+sed -i "s/%distro%/${DISTRO}/g"               "${DOCKERFILE}"
+sed -i "s/%ocaml_version%/${OCAML_VERSION}/g" "${DOCKERFILE}"
+sed -i "s/%opambuildtest%/${OPAMBUILDTEST}/g" "${DOCKERFILE}"
+sed -i "s/%package%/${PACKAGE}/g"             "${DOCKERFILE}"
+cat "${DOCKERFILE}"
+docker build --file "${DOCKERFILE}" --tag satysfi/satysfi:travis .

--- a/travis/osx-before-script.sh
+++ b/travis/osx-before-script.sh
@@ -1,0 +1,13 @@
+# Download and install OPAM
+brew update > /dev/null
+brew install aspcud
+wget -O /usr/local/bin/opam https://github.com/ocaml/opam/releases/download/1.2.2/opam-1.2.2-x86_64-Darwin
+chmod +x /usr/local/bin/opam
+opam init --compiler="${OCAML_VERSION}"
+eval `opam config env`
+opam install depext
+
+# Install dependency
+opam pin add --no-action "${PACKAGE}.dev" .
+opam depext "${PACKAGE}.dev"
+opam install --deps-only "${PACKAGE}.dev"


### PR DESCRIPTION
This PR makes CI faster:

|   | linux | osx | 
|:--|--:|--:|
| current `master` | 12--14 min | 13--15 min |
| this PR | 7--8 min | 13--15 min |

See [this result](https://travis-ci.org/nekketsuuu/SATySFi/builds/342762484) to confirm. Also, https://github.com/nekketsuuu/ocaml_travis_ci may be informative.

### Details

* For `linux`, I use a Docker image `ocaml/opam` in order to avoid compiling OCaml in each job.
* For `osx`, I directly download OPAM from the official repo, and then compile OCaml and SATySFi.

### Notes

* This PR (and also current `master`) doesn't run tests because currently we can't run tests for `batteries` with OCaml 4.06.0 (see ocaml-batteries-team/batteries-included#835).
* This PR also enables to build SATySFi with OCaml 4.05.0.