### PR TITLE
Support multiple configuration directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PREFIX=/usr/local
-LIBDIR=~/.satysfi
+LIBDIR=$(PREFIX)/share/satysfi
 SRCROOT=src
 BACKEND=src/backend
 FRONTEND=src/frontend

--- a/src/backend/loadFont.mli
+++ b/src/backend/loadFont.mli
@@ -11,4 +11,4 @@ exception UnexpectedYOJSONKey             of file_path * font_abbrev * string
 exception UnexpectedYOJSONValue           of file_path * font_abbrev * string * string
 exception MissingRequiredYOJSONKey        of file_path * font_abbrev * string
 
-val main : dir_path -> file_path -> (font_abbrev * file_path) list
+val main : file_path -> (font_abbrev * file_path) list

--- a/src/backend/loadHyph.ml
+++ b/src/backend/loadHyph.ml
@@ -1,5 +1,6 @@
 
 open MyUtil
+open Config
 
 
 type dir_path = string
@@ -157,8 +158,8 @@ let read_assoc (srcpath : file_path) (assoc : (string * Yojson.Safe.json) list) 
     (excpmap, hyphpatlst)
 
 
-let main (satysfi_root_dir : dir_path) (filename : file_path) : t =
-  let srcpath = Filename.concat satysfi_root_dir (Filename.concat "dist/hyph" filename) in
+let main (filename : file_path) : t =
+  let srcpath = resolve_dist_path (Filename.concat "dist/hyph" filename) in
     try
       let json = Yojson.Safe.from_file srcpath in
           (* -- may raise 'Sys_error', or 'Yojson.Json_error' -- *)

--- a/src/backend/loadHyph.mli
+++ b/src/backend/loadHyph.mli
@@ -19,6 +19,6 @@ type answer =
 
 val empty : t
 
-val main : dir_path -> file_path -> t
+val main : file_path -> t
 
 val lookup : t -> Uchar.t list -> answer

--- a/src/backend/setDefaultFont.ml
+++ b/src/backend/setDefaultFont.ml
@@ -1,6 +1,7 @@
 
 open MyUtil
 open CharBasis
+open Config
 
 type dir_path    = string
 type file_path   = string
@@ -82,8 +83,8 @@ let read_assoc srcpath assoc =
         end
 
 
-let main (satysfi_root_dir : dir_path) : (font_abbrev * float * float) ScriptSchemeMap.t =
-  let srcpath = Filename.concat satysfi_root_dir "dist/hash/default-font.satysfi-hash" in
+let main () : (font_abbrev * float * float) ScriptSchemeMap.t =
+  let srcpath = resolve_dist_path "dist/hash/default-font.satysfi-hash" in
     try
       let json = Yojson.Safe.from_file srcpath in
           (* -- may raise 'Sys_error', or 'Yojson.Json_error' -- *)

--- a/src/config.ml
+++ b/src/config.ml
@@ -1,0 +1,17 @@
+
+exception DistFileNotFound of string
+
+let satysfi_root_dirs : string list ref = ref []
+
+
+let initialize root_dirs =
+  satysfi_root_dirs := root_dirs
+
+
+let resolve_dist_path filename =
+  let rec go = function
+  | [] -> raise (DistFileNotFound filename)
+  | d :: ds ->
+    let fn = Filename.concat d filename in
+    if Sys.file_exists fn then fn else go ds
+  in go !satysfi_root_dirs

--- a/src/config.mli
+++ b/src/config.mli
@@ -1,0 +1,6 @@
+
+exception DistFileNotFound of string
+
+val initialize : string list -> unit
+
+val resolve_dist_path : string -> string

--- a/src/frontend/fontInfo.ml
+++ b/src/frontend/fontInfo.ml
@@ -3,6 +3,7 @@ open MyUtil
 open LengthInterface
 open HorzBox
 open Types
+open Config
 
 exception InvalidFontAbbrev     of font_abbrev
 exception InvalidMathFontAbbrev of math_font_abbrev
@@ -104,7 +105,8 @@ module FontAbbrevHashTable
           begin
             match store with
             | Unused(srcpath) ->
-      (* -- if this is the first access to the font -- *)
+                let srcpath = resolve_dist_path (Filename.concat "dist/fonts" srcpath) in
+                (* -- if this is the first access to the font -- *)
                 begin
                   match FontFormat.get_decoder_single srcpath with
                   | None ->
@@ -245,6 +247,7 @@ module MathFontAbbrevHashTable
             match !storeref with
             | UnusedMath(srcpath) ->
               (* -- if this is the first access to the math font -- *)
+                let srcpath = resolve_dist_path (Filename.concat "dist/fonts" srcpath) in
                 begin
                   match FontFormat.get_math_decoder srcpath with
                   | None ->
@@ -410,7 +413,7 @@ let get_font_dictionary (pdf : Pdf.t) : Pdf.pdfobject =
     Pdf.Dictionary(keyval)
 
 
-let initialize (satysfi_lib_root : string) =
+let initialize () =
 
   begin
     FontAbbrevHashTable.initialize ();
@@ -418,20 +421,20 @@ let initialize (satysfi_lib_root : string) =
 (*
     PrintForDebug.initfontE "!!ScriptDataMap";
 *)
-    let filename_S   = Filename.concat satysfi_lib_root "dist/unidata/Scripts.txt" in
-    let filename_EAW = Filename.concat satysfi_lib_root "dist/unidata/EastAsianWidth.txt" in
+    let filename_S   = resolve_dist_path "dist/unidata/Scripts.txt" in
+    let filename_EAW = resolve_dist_path "dist/unidata/EastAsianWidth.txt" in
     ScriptDataMap.set_from_file filename_S filename_EAW;
 (*
     PrintForDebug.initfontE "!!LineBreakDataMap";
 *)
-    LineBreakDataMap.set_from_file (Filename.concat satysfi_lib_root "dist/unidata/LineBreak.txt");
+    LineBreakDataMap.set_from_file (resolve_dist_path "dist/unidata/LineBreak.txt");
 (*
     PrintForDebug.initfontE "!!begin initialize";  (* for debug *)
 *)
-    let font_hash = LoadFont.main satysfi_lib_root "fonts.satysfi-hash" in
+    let font_hash = LoadFont.main "fonts.satysfi-hash" in
     List.iter (fun (abbrev, srcpath) -> FontAbbrevHashTable.add abbrev srcpath) font_hash;
 
-    let math_font_hash = LoadFont.main satysfi_lib_root "mathfonts.satysfi-hash" in
+    let math_font_hash = LoadFont.main "mathfonts.satysfi-hash" in
     List.iter (fun (mfabbrev, srcfile) -> MathFontAbbrevHashTable.add mfabbrev srcfile) math_font_hash;
 (*
     PrintForDebug.initfontE "!!end initialize"  (* for debug *)

--- a/src/frontend/fontInfo.mli
+++ b/src/frontend/fontInfo.mli
@@ -10,7 +10,7 @@ exception NotASingleMathFont    of font_abbrev * file_path
 
 type tag = string
 
-val initialize : string -> unit
+val initialize : unit -> unit
 
 val get_metrics_of_word : horz_string_info -> Uchar.t list -> OutputText.t * length * length * length
 

--- a/src/frontend/primitives.ml
+++ b/src/frontend/primitives.ml
@@ -571,7 +571,7 @@ let frame_deco_VM =
 (* -- end: constants just for experimental use -- *)
 
 
-let make_environments satysfi_root_dir =
+let make_environments () =
   let tyenvinit = add_default_types Typeenv.empty in
   let envinit : environment = (EvalVarIDMap.empty, ref (StoreIDHashTable.create 128)) in
 
@@ -733,7 +733,7 @@ let make_environments satysfi_root_dir =
     ) (tyenvinit, envinit, Alist.empty)
   in
   locacc |> Alist.to_list |> List.iter (fun (loc, deff) -> loc := deff envfinal);
-  default_font_scheme_ref := SetDefaultFont.main satysfi_root_dir;
-  default_hyphen_dictionary := LoadHyph.main satysfi_root_dir "english.satysfi-hyph";
+  default_font_scheme_ref := SetDefaultFont.main ();
+  default_hyphen_dictionary := LoadHyph.main "english.satysfi-hyph";
       (* temporary; should depend on the current language -- *)
     (tyenvfinal, envfinal)

--- a/src/frontend/primitives.mli
+++ b/src/frontend/primitives.mli
@@ -6,6 +6,6 @@ val option_type : mono_type -> mono_type
 
 val get_initial_context : length -> HorzBox.context_main
 
-val make_environments : string -> Typeenv.t * environment
+val make_environments : unit -> Typeenv.t * environment
 
 val default_radical : HorzBox.radical


### PR DESCRIPTION
Satysfi's path resolver is modified as follows:
1. Satysfi first searches `~/.satysfi` for a config/package/font file the input saty program requires,
2. and if the search fails, satysfi then searches `/usr/local/share/satysfi`, and if it fails again, `/usr/share/satysfi` is searched.

Makefile now installs the initial configuration and fonts in the system directory by default. If you want use some extra files (say, Arno Pro fonts) in a satysfi code, you just need to make a directory `~/.satysfi/dist/fonts/` and put the font files there. (You don't even have to create empty directory trees under ~/.satysfi if you don't use them).