### PR TITLE
Remove redundant dependencies for macOS

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -47,7 +47,7 @@ opam update
 # また，Homebrew もインストールしてください。
 
 brew update
-brew install unzip wget git opam
+brew install wget opam
 
 # 以下のコマンドは OPAM が（~/.bash_profile などの）ファイルに環境変数に関する設定を追記してもよいか聞いてきます。
 # 必ず説明を読み，環境変数を適切に設定してください。

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ opam update
 # Also, install Homebrew.
 
 brew update
-brew install unzip wget git opam
+brew install wget opam
 
 # The following command will ask if OPAM modifies some files.
 # Be sure to read their instructions. Otherwise, some environment variables won't be set.


### PR DESCRIPTION
`unzip` is bundled with macOS.
`git` is provided by Xcode Command Line Tools, which is a dependency of
Homebrew.
We don't have to install them via Homebrew, unless we need the latest version of them.