### PR TITLE
Add .editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# See editorconfig.org for details
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.{ml,mli,mll,mly}]
+indent_style = space
+indent_size = 2
+
+[*.{saty,satyh}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
This PR adds [EditorConfig](http://editorconfig.org) to ensure conventions such as LF, UTF-8, soft tab, and indent size 2.