### PR TITLE
Remove uCoreLib from dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "backend/external/otfm"]
 	path = external/otfm
 	url = https://github.com/gfngfn/otfm.git
-[submodule "external/ucorelib"]
-	path = external/ucorelib
-	url = https://github.com/gfngfn/ucorelib

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OCB_FLAGS = -cflags -unsafe-string -cflag -w -cflag -3 \
 	-use-ocamlfind -use-menhir \
 	-I $(SRCROOT)/ -I $(FRONTEND)/ -I $(BACKEND)/ -I $(CHARDECODER)/ \
 	-I $(EXTERNAL)/otfm/src/ -I $(EXTERNAL)/camlpdf/ \
-	-pkgs "ppx_deriving.show,core_kernel,result,uutf,bitv,batteries, \
+	-pkgs "ppx_deriving.show,core_kernel,result,uutf,batteries, \
 	menhirLib,yojson,camlimages,camlimages.jpeg" \
 	-tag thread -yaccflags "--table --explain" \
 	-lflags "flatestubs.c rijndael-alg-fst.c stubs-aes.c sha2.c stubs-sha2.c"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ OCB_FLAGS = -cflags -unsafe-string -cflag -w -cflag -3 \
 	-use-ocamlfind -use-menhir \
 	-I $(SRCROOT)/ -I $(FRONTEND)/ -I $(BACKEND)/ -I $(CHARDECODER)/ \
 	-I $(EXTERNAL)/otfm/src/ -I $(EXTERNAL)/camlpdf/ \
-	-I $(EXTERNAL)/ucorelib/src/ \
 	-pkgs "ppx_deriving.show,core_kernel,result,uutf,bitv,batteries, \
 	menhirLib,yojson,camlimages,camlimages.jpeg" \
 	-tag thread -yaccflags "--table --explain" \

--- a/opam
+++ b/opam
@@ -26,7 +26,6 @@ depends: [
   "uutf"
   "result"
   "core_kernel" {>= "v0.10.0"}
-  "bitv"
   "batteries"
   "yojson"
   "camlimages"

--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -21,7 +21,7 @@ all:
 #	ocamlc -c external/camlpdf/stubs-sha2.c
 	mv *.c _build/
 	mv *.h _build/
-#	ocamlbuild -use-ocamlfind -use-menhir -tag thread -pkgs "core,ctypes,otfm,ucorelib" -lflags "external/camlpdf/flatestubs.o external/camlpdf/rijndael-alg-fst.o external/camlpdf/stubs-aes.o external/camlpdf/miniz.o external/camlpdf/sha2.o external/camlpdf/stubs-sha2.o" -I external/camlpdf/ pageBreak.native
-#	ocamlbuild -use-ocamlfind -use-menhir -tag thread -pkgs "core,ctypes,otfm,ucorelib" -lflags "flatestubs.o rijndael-alg-fst.o stubs-aes.o miniz.o sha2.o stubs-sha2.o" -no-hygiene -I external/camlpdf/ pageBreak.native
-	ocamlbuild -use-ocamlfind -use-menhir -tag thread -pkgs "core,ctypes,result,uutf,ucorelib" -lflags "flatestubs.c rijndael-alg-fst.c stubs-aes.c sha2.c stubs-sha2.c" -I external/camlpdf/ -I external/otfm/ pageBreak.native
-#	ocamlbuild -use-ocamlfind -use-menhir -tag thread -pkgs "core,ctypes,otfm,ucorelib" -no-hygiene -I external/camlpdf/ pageBreak.native
+#	ocamlbuild -use-ocamlfind -use-menhir -tag thread -pkgs "core,ctypes,otfm" -lflags "external/camlpdf/flatestubs.o external/camlpdf/rijndael-alg-fst.o external/camlpdf/stubs-aes.o external/camlpdf/miniz.o external/camlpdf/sha2.o external/camlpdf/stubs-sha2.o" -I external/camlpdf/ pageBreak.native
+#	ocamlbuild -use-ocamlfind -use-menhir -tag thread -pkgs "core,ctypes,otfm" -lflags "flatestubs.o rijndael-alg-fst.o stubs-aes.o miniz.o sha2.o stubs-sha2.o" -no-hygiene -I external/camlpdf/ pageBreak.native
+	ocamlbuild -use-ocamlfind -use-menhir -tag thread -pkgs "core,ctypes,result,uutf" -lflags "flatestubs.c rijndael-alg-fst.c stubs-aes.c sha2.c stubs-sha2.c" -I external/camlpdf/ -I external/otfm/ pageBreak.native
+#	ocamlbuild -use-ocamlfind -use-menhir -tag thread -pkgs "core,ctypes,otfm" -no-hygiene -I external/camlpdf/ pageBreak.native

--- a/src/backend/internalText.ml
+++ b/src/backend/internalText.ml
@@ -1,52 +1,84 @@
 
-module ChEnc = UCoreLib.CharEncoding
-
-
-type t = UCoreLib.text
+(* We use utf8 as the internal representation *)
+type t = string
 
 exception NotEncodableToUTF16BE of t
 
 
 let of_utf8 (str_utf8 : string) : t =
-  let dcdr_utf8 = ChEnc.create_decoder ChEnc.utf8 in
-  let (_, s) = ChEnc.decode dcdr_utf8 str_utf8 in
-    s
+  let buffer = Buffer.create (String.length str_utf8) in
+  let decoder = Uutf.decoder ~encoding:`UTF_8 (`String str_utf8) in
+  let encoder = Uutf.encoder `UTF_8 (`Buffer buffer) in
+  let rec loop () =
+    match Uutf.decode decoder with
+    | `Await -> assert false (* Manual source! *)
+    | `End -> ignore (Uutf.encode encoder `End)
+    | `Malformed _ ->
+        ignore (Uutf.encode encoder (`Uchar Uchar.rep));
+        loop ()
+    | `Uchar ch ->
+        ignore (Uutf.encode encoder (`Uchar ch));
+        loop ()
+  in
+  loop ();
+  Buffer.contents buffer
 
 
 let to_utf16be_hex (intext : t) =
-  let hexify_byte = Printf.sprintf "%02X" in
-  let rec hexify_string (acc : string) (i : int) (len : int) (str : string) : string =
-    if len <= i then acc else
-      let b = Char.code (String.get str i) in
-      let strhex = hexify_byte b in
-        hexify_string (acc ^ strhex) (i + 1) len str
+  let buffer = Buffer.create (String.length intext * 4) in
+  let decoder = Uutf.decoder ~encoding:`UTF_8 (`String intext) in
+  let rec loop () =
+    match Uutf.decode decoder with
+    | `Await -> assert false (* Manual source! *)
+    | `End -> ()
+    | `Malformed _ -> assert false (* Valid utf-8! *)
+    | `Uchar ch ->
+        let cp = Uchar.to_int ch in
+        if cp < 0x10000 then
+          Printf.bprintf buffer "%04X" cp
+        else
+          Printf.bprintf buffer "%04X%04X"
+            ((cp - 0x10000) / 0x0400 + 0xD800)
+            ((cp - 0x10000) mod 0x0400 + 0xDC00);
+        loop ()
   in
-  let encdr_utf16be = ChEnc.create_encoder ChEnc.utf16be in
-    match ChEnc.encode encdr_utf16be intext with
-    | `Error                   -> raise (NotEncodableToUTF16BE(intext))
-    | `Success(_, str_utf16be) -> hexify_string "" 0 (String.length str_utf16be) str_utf16be
+  loop ();
+  Buffer.contents buffer
 
 
 let to_uchar_list (intext : t) : Uchar.t list =
-  let len = UCoreLib.Text.length intext in
-  let rec aux acc i =
-    if len <= i then List.rev acc else
-      match UCoreLib.Text.get intext i with
-      | None            -> aux acc (i + 1)  (* needs reconsideration; maybe should emit an error *)
-      | Some(uch_ucore) -> aux (uch_ucore :: acc) (i + 1)
+  let rev_chars = ref [] in
+  let decoder = Uutf.decoder ~encoding:`UTF_8 (`String intext) in
+  let rec loop () =
+    match Uutf.decode decoder with
+    | `Await -> assert false (* Manual source! *)
+    | `End -> ()
+    | `Malformed _ -> assert false (* Valid utf-8! *)
+    | `Uchar ch ->
+        rev_chars := ch :: !rev_chars;
+        loop ()
   in
-  let lst = aux [] 0 in
-    List.map (fun uch_ucore -> Uchar.of_int (UCoreLib.UChar.code uch_ucore)) lst
+  loop ();
+  List.rev !rev_chars
 
 
-let to_utf8 (intext : t) : string = UCoreLib.Text.string_of intext
-  
+
+let to_utf8 (intext : t) : string = intext
+
 
 let of_uchar (uch : Uchar.t) : t =
-  match UCoreLib.UChar.of_int (Uchar.to_int uch) with
-  | None            -> UCoreLib.Text.empty  (* needs reconsideration; maybe should emit an error *)
-  | Some(uch_ucore) -> UCoreLib.Text.of_uchar uch_ucore
+  let buffer = Buffer.create 4 in
+  let encoder = Uutf.encoder `UTF_8 (`Buffer buffer) in
+  ignore (Uutf.encode encoder (`Uchar uch));
+  ignore (Uutf.encode encoder `End);
+  Buffer.contents buffer
 
 
 let of_uchar_list (uchlst : Uchar.t list) : t =
-  uchlst |> List.map of_uchar |> List.fold_left UCoreLib.Text.append UCoreLib.Text.empty
+  let buffer = Buffer.create (List.length uchlst * 4) in
+  let encoder = Uutf.encoder `UTF_8 (`Buffer buffer) in
+  List.iter (fun uch ->
+    ignore (Uutf.encode encoder (`Uchar uch))
+  ) uchlst;
+  ignore (Uutf.encode encoder `End);
+  Buffer.contents buffer

--- a/src/chardecoder/charBasis.ml
+++ b/src/chardecoder/charBasis.ml
@@ -143,15 +143,11 @@ let script_equal = (=)
 
 
 let add_to_map cp scr umap =
-  match UCoreLib.UChar.of_int cp with
-  | Some(uch_ucore) -> umap |> UCoreLib.UMap.add uch_ucore scr
-  | None            -> umap  (* needs reconsideration; maybe should cause an error *)
+  umap |> BatIMap.add cp scr
 
 
 let add_range_to_map cp1 cp2 scr umap =
-  match (UCoreLib.UChar.of_int cp1, UCoreLib.UChar.of_int cp2) with
-  | (Some(uch_ucore1), Some(uch_ucore2)) -> umap |> UCoreLib.UMap.add_range uch_ucore1 uch_ucore2 scr
-  | _                                    -> umap  (* needs reconsideration; maybe should canse an error *)
+  umap |> BatIMap.add_range cp1 cp2 scr
 
 
 let map_of_list (type a) (readf : int -> string -> a) (lst : (code_point_kind * string) list) =
@@ -160,7 +156,7 @@ let map_of_list (type a) (readf : int -> string -> a) (lst : (code_point_kind * 
     | (CodePoint(cp), data)            -> accmap |> add_to_map cp (readf cp data)
     | (CodePointRange(cp1, cp2), data) -> accmap |> add_range_to_map cp1 cp2 (readf cp1 data)
         (* -- needs reconsideration: 'readf' receives the first code point of the range -- *)
-  ) (UCoreLib.UMap.empty ~eq:(=))
+  ) (BatIMap.empty ~eq:(=))
 
 
 (* for debug *)

--- a/src/chardecoder/lineBreakDataMap.ml
+++ b/src/chardecoder/lineBreakDataMap.ml
@@ -102,7 +102,7 @@ let line_break_class_overriding_list =
   ]
 
 
-let line_break_map_ref : (line_break_class UCoreLib.UMap.t) ref = ref (UCoreLib.UMap.empty ~eq:(=))
+let line_break_map_ref : (line_break_class BatIMap.t) ref = ref (BatIMap.empty ~eq:(=))
 
 
 let set_from_file filename =
@@ -111,9 +111,7 @@ let set_from_file filename =
   let line_break_map_raw = line_break_list |> CharBasis.map_of_list class_of_string in
   let line_break_map =
     List.fold_left (fun mapacc (cp, lbc) ->
-      match UCoreLib.UChar.of_int cp with
-      | None            -> mapacc  (* needs reconsideration; maybe should warn emptyness *)
-      | Some(uch_ucore) -> mapacc |> UCoreLib.UMap.add uch_ucore lbc
+      mapacc |> BatIMap.add cp lbc
     ) line_break_map_raw line_break_class_overriding_list
   in
   begin
@@ -122,12 +120,8 @@ let set_from_file filename =
 
 
 let find uch =
-  match UCoreLib.UChar.of_int (Uchar.to_int uch) with
-  | None            -> XX  (* temporary *)
-  | Some(uch_ucore) ->
-      match (!line_break_map_ref) |> UCoreLib.UMap.find_opt uch_ucore with
-      | None      -> XX  (* temporary *)
-      | Some(lbc) -> lbc
+  try (!line_break_map_ref) |> BatIMap.find (Uchar.to_int uch)
+  with Not_found -> XX  (* temporary *)
 
 
 (* --


### PR DESCRIPTION
SATySFi does not use much of uCoreLib. This PR replaces the usages of uCoreLib with batteries and uutf, which it already depends on.

Fixes #40.

#35 may also be related.