### PR TITLE
Workaround travis error by pinning versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ install:
   - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-ocaml.sh
   - bash -ex .travis-ocaml.sh
   - eval `opam config env`
+  - opam update
+  - opam pin add -y jbuilder 1.0+beta17
+  - opam pin add -y camlimages 4.2.6
   - opam install -y ppx_deriving
   - opam install -y menhir
   - opam install -y core_kernel.v0.10.0


### PR DESCRIPTION
Recent updates to the packages:

- `jbuilder 1.0+beta17` → `jbuilder 1.0+beta18`
- `camlimages 4.2.6` → `camlimages 5.0.0`

caused CI on master to fail. It temporarily fixes the error by pinning them to the old versions.