### PR TITLE
Implements `break-on-regex` and `string-match` primitives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ OCB_FLAGS = -cflags -unsafe-string -cflag -w -cflag -3 \
 	-I $(SRCROOT)/ -I $(FRONTEND)/ -I $(BACKEND)/ -I $(CHARDECODER)/ \
 	-I $(EXTERNAL)/otfm/src/ -I $(EXTERNAL)/camlpdf/ \
 	-I $(EXTERNAL)/ucorelib/src/ \
-	-pkgs "ppx_deriving.show,core_kernel,result,uutf,bitv,batteries, \
+	-pkgs "str,ppx_deriving.show,core_kernel,result,uutf,bitv,batteries, \
 	menhirLib,yojson,camlimages,camlimages.jpeg" \
 	-tag thread -yaccflags "--table --explain" \
 	-lflags "flatestubs.c rijndael-alg-fst.c stubs-aes.c sha2.c stubs-sha2.c"

--- a/src/frontend/evaluator.ml
+++ b/src/frontend/evaluator.ml
@@ -1348,6 +1348,14 @@ and interpret env ast =
         pairlst |> make_list (fun (i, s) ->
           TupleCons(IntegerConstant(i), TupleCons(StringConstant(s), EndOfTuple)))
 
+  | PrimitiveSplitOnRegex(areg, asts) ->
+      let sep = Str.regexp (interpret_string env areg) in
+      let s = interpret_string env asts in
+      let slst = Str.split sep s in
+      let pairlst = slst |> List.map chop_space_indent in
+        pairlst |> make_list (fun (i, s) ->
+          TupleCons(IntegerConstant(i), TupleCons(StringConstant(s), EndOfTuple)))
+
   | PrimitiveArabic(astnum) ->
       let num = interpret_int env astnum in StringConstant(string_of_int num)
 

--- a/src/frontend/evaluator.ml
+++ b/src/frontend/evaluator.ml
@@ -1341,6 +1341,11 @@ and interpret env ast =
       in
         StringConstant(s)
 
+  | PrimitiveStringMatch(apat, astr) ->
+      let pat = Str.regexp (interpret_string env apat) in
+      let s   = interpret_string env astr in
+      BooleanConstant(Str.string_match pat s 0)
+
   | PrimitiveSplitIntoLines(asts) ->
       let s = interpret_string env asts in
       let slst = String.split_on_char '\n' s in

--- a/src/frontend/primitives.ml
+++ b/src/frontend/primitives.ml
@@ -634,6 +634,7 @@ let make_environments () =
         ( "atan"         , ~% (tFL @-> tFL)            , lambda1 (fun vf -> FloatArcTangent(vf)) );
         ( "atan2"        , ~% (tFL @-> tFL @-> tFL)    , lambda2 (fun vf1 vf2 -> FloatArcTangent2(vf1, vf2)) );
         ("split-into-lines", ~% (tS @-> (tL (tPROD [tI; tS]))), lambda1 (fun vs -> PrimitiveSplitIntoLines(vs)));
+        ("split-on-regex", ~% (tS @-> tS @-> (tL (tPROD [tI; tS]))), lambda2 (fun vpat vs -> PrimitiveSplitOnRegex(vpat, vs)));
 
         ("line-break"            , ~% (tB @-> tB @-> tCTX @-> tIB @-> tBB)                   , lambda4 (fun vb1 vb2 vctx vbr -> BackendLineBreaking(vb1, vb2, vctx, vbr)) );
         ("page-break"            , ~% (tPG @-> tPAGECONTF @-> tPAGEPARTSF @-> tBB @-> tDOC)  , lambda4 (fun vpgsz vpcf vppf vbb -> BackendPageBreaking(vpgsz, vpcf, vppf, vbb)));

--- a/src/frontend/primitives.ml
+++ b/src/frontend/primitives.ml
@@ -635,7 +635,7 @@ let make_environments () =
         ( "atan2"        , ~% (tFL @-> tFL @-> tFL)    , lambda2 (fun vf1 vf2 -> FloatArcTangent2(vf1, vf2)) );
         ("split-into-lines", ~% (tS @-> (tL (tPROD [tI; tS]))), lambda1 (fun vs -> PrimitiveSplitIntoLines(vs)));
         ("split-on-regex", ~% (tS @-> tS @-> (tL (tPROD [tI; tS]))), lambda2 (fun vpat vs -> PrimitiveSplitOnRegex(vpat, vs)));
-        ("string-match", ~% (tS @-> tS @-> (tL (tPROD [tI; tS]))), lambda2 (fun vpat vs -> PrimitiveStringMatch(vpat, vs)));
+        ("string-match", ~% (tS @-> tS @-> tB), lambda2 (fun vpat vs -> PrimitiveStringMatch(vpat, vs)));
 
 
         ("line-break"            , ~% (tB @-> tB @-> tCTX @-> tIB @-> tBB)                   , lambda4 (fun vb1 vb2 vctx vbr -> BackendLineBreaking(vb1, vb2, vctx, vbr)) );

--- a/src/frontend/primitives.ml
+++ b/src/frontend/primitives.ml
@@ -635,6 +635,8 @@ let make_environments () =
         ( "atan2"        , ~% (tFL @-> tFL @-> tFL)    , lambda2 (fun vf1 vf2 -> FloatArcTangent2(vf1, vf2)) );
         ("split-into-lines", ~% (tS @-> (tL (tPROD [tI; tS]))), lambda1 (fun vs -> PrimitiveSplitIntoLines(vs)));
         ("split-on-regex", ~% (tS @-> tS @-> (tL (tPROD [tI; tS]))), lambda2 (fun vpat vs -> PrimitiveSplitOnRegex(vpat, vs)));
+        ("string-match", ~% (tS @-> tS @-> (tL (tPROD [tI; tS]))), lambda2 (fun vpat vs -> PrimitiveStringMatch(vpat, vs)));
+
 
         ("line-break"            , ~% (tB @-> tB @-> tCTX @-> tIB @-> tBB)                   , lambda4 (fun vb1 vb2 vctx vbr -> BackendLineBreaking(vb1, vb2, vctx, vbr)) );
         ("page-break"            , ~% (tPG @-> tPAGECONTF @-> tPAGEPARTSF @-> tBB @-> tDOC)  , lambda4 (fun vpgsz vpcf vppf vbb -> BackendPageBreaking(vpgsz, vpcf, vppf, vbb)));

--- a/src/frontend/types.ml
+++ b/src/frontend/types.ml
@@ -592,6 +592,7 @@ and abstract_tree =
   | PrimitiveStringLength of abstract_tree
   | PrimitiveStringUnexplode of abstract_tree
   | PrimitiveSplitIntoLines  of abstract_tree
+  | PrimitiveSplitOnRegex    of abstract_tree * abstract_tree
   | PrimitiveArabic       of abstract_tree
   | PrimitiveFloat        of abstract_tree
   | PrimitiveRound        of abstract_tree

--- a/src/frontend/types.ml
+++ b/src/frontend/types.ml
@@ -588,6 +588,7 @@ and abstract_tree =
   | LogicalOr             of abstract_tree * abstract_tree
   | LogicalNot            of abstract_tree
   | PrimitiveSame         of abstract_tree * abstract_tree
+  | PrimitiveStringMatch  of abstract_tree * abstract_tree
   | PrimitiveStringSub    of abstract_tree * abstract_tree * abstract_tree
   | PrimitiveStringLength of abstract_tree
   | PrimitiveStringUnexplode of abstract_tree


### PR DESCRIPTION
This pull-request implements `break-on-regex` and `string-match` primitives, which build on top of `Str` package.
These are useful to implement a lightweight syntax highlighting.