### PR TITLE
use Junicode fonts in stdja.satyh

### DIFF
--- a/lib-satysfi/dist/packages/stdja.satyh
+++ b/lib-satysfi/dist/packages/stdja.satyh
@@ -72,8 +72,8 @@ end = struct
   let font-ratio-latin = 1.
   let font-ratio-cjk = 0.88
 
-  let font-latin-roman  = (`ArnoPro`   , font-ratio-latin, 0.)
-  let font-latin-italic = (`lmroman-it`, font-ratio-latin, 0.)
+  let font-latin-roman  = (`Junicode`   , font-ratio-latin, 0.)
+  let font-latin-italic = (`Junicode-it`, font-ratio-latin, 0.)
   let font-latin-sans   = (`lmsans`    , font-ratio-latin, 0.)
   let font-cjk-mincho   = (`ipaexm`    , font-ratio-cjk  , 0.)
   let font-cjk-gothic   = (`ipaexg`    , font-ratio-cjk  , 0.)


### PR DESCRIPTION
Even though 042a8aa replaced ArnoPro with Junicode in `stdjabook.satyh`, `stdja.satyh` still uses ArnoPro as its roman font.
This makes several files (such as ones in `doc` directory) uncompilable without ArnoPro.
This commit fixes the issue by applying the same kind of patch as 042a8aa to `satja.satyh`.