### PR TITLE
Implements `string-compare`

### DIFF
--- a/src/frontend/evaluator.ml
+++ b/src/frontend/evaluator.ml
@@ -1319,6 +1319,10 @@ and interpret env ast =
       let str2 = interpret_string env ast2 in
         BooleanConstant(String.equal str1 str2)
 
+  | PrimitiveStringCompare(ast1, ast2) ->
+      let str1 = interpret_string env ast1 in
+      let str2 = interpret_string env ast2 in
+        IntegerConstant(String.compare str1 str2)
 
   | PrimitiveStringSub(aststr, astpos, astwid) ->
       let str = interpret_string env aststr in

--- a/src/frontend/primitives.ml
+++ b/src/frontend/primitives.ml
@@ -624,6 +624,7 @@ let make_environments () =
         ( "|>" , ptyappinv               , lambda2 (fun vx vf -> Apply(vf, vx)));
 
         ( "string-same"  , ~% (tS @-> tS @-> tB)       , lambda2 (fun v1 v2 -> PrimitiveSame(v1, v2)) );
+        ( "string-compare"  , ~% (tS @-> tS @-> tI)    , lambda2 (fun v1 v2 -> PrimitiveStringCompare(v1, v2)) );
         ( "string-sub"   , ~% (tS @-> tI @-> tI @-> tS), lambda3 (fun vstr vpos vwid -> PrimitiveStringSub(vstr, vpos, vwid)) );
         ( "string-length", ~% (tS @-> tI)              , lambda1 (fun vstr -> PrimitiveStringLength(vstr)) );
         ( "arabic"       , ~% (tI @-> tS)              , lambda1 (fun vnum -> PrimitiveArabic(vnum)) );

--- a/src/frontend/typeenv.ml
+++ b/src/frontend/typeenv.ml
@@ -214,15 +214,15 @@ module MapList
     val to_list : ('a, 'b) t -> ('a * 'b) list
   end
 = struct
-    type ('a, 'b) t = (('a * 'b) list) ref
+    type ('a, 'b) t = (('a * 'b) Alist.t) ref
 
-    let create () = ref []
+    let create () = ref Alist.empty
 
-    let add mapl k v = begin mapl := (k, v) :: !mapl; end
+    let add mapl k v = begin mapl := Alist.extend !mapl (k, v); end
 
-    let find_opt mapl k = List.assoc_opt k (!mapl)
+    let find_opt mapl k = List.assoc_opt k (Alist.to_list (!mapl))
 
-    let to_list = ( ! )
+    let to_list mapl = Alist.to_list (!mapl)
 
   end
 

--- a/src/frontend/types.ml
+++ b/src/frontend/types.ml
@@ -592,6 +592,7 @@ and abstract_tree =
   | LogicalOr             of abstract_tree * abstract_tree
   | LogicalNot            of abstract_tree
   | PrimitiveSame         of abstract_tree * abstract_tree
+  | PrimitiveStringCompare of abstract_tree * abstract_tree
   | PrimitiveStringMatch  of abstract_tree * abstract_tree
   | PrimitiveStringSub    of abstract_tree * abstract_tree * abstract_tree
   | PrimitiveStringLength of abstract_tree


### PR DESCRIPTION
Implemented `string-compare` primitive, which corresponds to the OCaml's `String.compare` function:
 `string-compare l r` returns `0` if they are equal, negative value if `l` is strictly smaller
 (w.r.t. lex-ordering) than `r`, positive if greater.

I once considered to add a special type dedicated for comparison result, e.g. Haskell's `Ordered`-type,
but I didn't take that way because it introduces additional type for less used things.