### PR TITLE
Remove jbuilder pin as ocaml/dune#567 is resolved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ install:
   - bash -ex .travis-ocaml.sh
   - eval `opam config env`
   - opam update
-# Issue #46: we temporarily pin jbuilder to avoid problems in 1.0+beta18.
-# See https://github.com/ocaml/dune/issues/567 for details.
-  - opam pin add -y jbuilder 1.0+beta17
 # Issue #46: we temporarily pin camlimages to avoid Graphics-related problems.
 # See https://github.com/ocaml/dune/issues/563 for details.
   - opam pin add -y camlimages 4.2.6

--- a/README-ja.md
+++ b/README-ja.md
@@ -76,8 +76,6 @@ git clone https://github.com/gfngfn/SATySFi.git
 cd SATySFi
 git submodule update --init --recursive
 
-# Issue #46: core_kernel を正しくビルドするために 1.0+beta18 を避ける
-opam pin add -y jbuilder 1.0+beta17
 # build
 opam pin add satysfi .
 opam install satysfi

--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ git clone https://github.com/gfngfn/SATySFi.git
 cd SATySFi
 git submodule update --init --recursive
 
-# Issue #46: avoid 1.0+beta18 to build core_kernel correctly.
-opam pin add -y jbuilder 1.0+beta17
 # build
 opam pin add satysfi .
 opam install satysfi


### PR DESCRIPTION
This commit removes part of version pinnings introduced by bd737ab and f8189a8, because jbuilder 1.0+beta18.1 includes a fix of ocaml/dune#567. Part of #46.