### PR TITLE
Change root dirs in Win32.

### DIFF
--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -729,10 +729,25 @@ let arg_spec_list curdir =
 
 
 let setup_root_dirs () =
-  let ds =
-    (match Sys.getenv_opt "HOME" with
-    | None    -> []
-    | Some(s) -> [Filename.concat s ".satysfi"]) @ ["/usr/local/share/satysfi"; "/usr/share/satysfi"] in
+  let runtime_dirs =
+    if Sys.os_type = "Win32" then
+      match Sys.getenv_opt "SATYSFI_RUNTIME" with
+      | None    -> []
+      | Some(s) -> [s]
+    else
+      ["/usr/local/share/satysfi"; "/usr/share/satysfi"]
+  in
+  let user_dirs =
+    if Sys.os_type = "Win32" then
+      match Sys.getenv_opt "userprofile" with
+      | None    -> []
+      | Some(s) -> [Filename.concat s ".satysfi"]
+    else
+      match Sys.getenv_opt "HOME" with
+      | None    -> []
+      | Some(s) -> [Filename.concat s ".satysfi"]
+  in
+  let ds = user_dirs @ runtime_dirs in
   (if List.length ds = 0 then
     raise NoLibraryRootDesignation);
   Config.initialize ds


### PR DESCRIPTION
This patch changes root dirs in Win32, because on Windows,
- `%HOME%` is rarely used. `%userprofile%` is set instead.
- Installation directories are movable.

After this patch, SATySFi [sets the root dirs](https://twitter.com/qnighy/status/974919889013022720) to
- `%userprofile%\.satysfi;%SATYSFI_RUNTIME%` in Win32.
- `$HOME/.satysfi:/usr/local/share/satysfi:/usr/share/satysfi` in other
  platforms.