### PR TITLE
Say crossref resolved only when no `?`.

### DIFF
--- a/src/backend/crossRef.ml
+++ b/src/backend/crossRef.ml
@@ -114,6 +114,12 @@ let register (key : string) (value : string) =
         end
 
 
+let probe (key : string) =
+  match CrossRefHashTable.find_opt main_hash_table key with
+  | Some(value) -> Some(value)
+  | None -> None
+
+
 let get (key : string) =
   match CrossRefHashTable.find_opt main_hash_table key with
   | Some(value) -> Some(value)

--- a/src/backend/crossRef.ml
+++ b/src/backend/crossRef.ml
@@ -14,6 +14,7 @@ module CrossRefHashTable = Hashtbl.Make
   end)
 
 
+let unresolved_crossrefs = ref []
 let changed = ref false
 
 let count = ref 0
@@ -71,7 +72,7 @@ let initialize (srcpath : file_path) : bool =
 
 type answer =
   | NeedsAnotherTrial
-  | CanTerminate
+  | CanTerminate of string list
   | CountMax
 
 
@@ -84,6 +85,7 @@ let needs_another_trial (outpath : file_path) : answer =
       end
     else
       begin
+        unresolved_crossrefs := [];
         changed := false;
         incr count;
         NeedsAnotherTrial
@@ -91,7 +93,7 @@ let needs_another_trial (outpath : file_path) : answer =
   else
     begin
       write_dump_file outpath;
-      CanTerminate
+      CanTerminate (List.sort_uniq String.compare !unresolved_crossrefs)
     end
 
 
@@ -113,4 +115,8 @@ let register (key : string) (value : string) =
 
 
 let get (key : string) =
-  CrossRefHashTable.find_opt main_hash_table key
+  match CrossRefHashTable.find_opt main_hash_table key with
+  | Some(value) -> Some(value)
+  | None ->
+      unresolved_crossrefs := key :: !unresolved_crossrefs;
+      None

--- a/src/backend/crossRef.mli
+++ b/src/backend/crossRef.mli
@@ -9,7 +9,7 @@ val initialize : file_path -> bool
 
 type answer =
   | NeedsAnotherTrial
-  | CanTerminate
+  | CanTerminate of string list
   | CountMax
 
 val needs_another_trial : file_path -> answer

--- a/src/backend/crossRef.mli
+++ b/src/backend/crossRef.mli
@@ -16,4 +16,6 @@ val needs_another_trial : file_path -> answer
 
 val register : string -> string -> unit
 
+val probe : string -> string option
+
 val get : string -> string option

--- a/src/frontend/evaluator.ml
+++ b/src/frontend/evaluator.ml
@@ -1117,6 +1117,14 @@ and interpret env ast =
         UnitConstant
       end
 
+  | BackendProbeCrossReference(astk) ->
+      let k = interpret_string env astk in
+      begin
+        match CrossRef.probe k with
+        | None    -> Constructor("None", UnitConstant)
+        | Some(v) -> Constructor("Some", StringConstant(v))
+      end
+
   | BackendGetCrossReference(astk) ->
       let k = interpret_string env astk in
       begin

--- a/src/frontend/logging.ml
+++ b/src/frontend/logging.ml
@@ -74,7 +74,7 @@ let achieve_fixpoint unresolved_crossrefs =
   if unresolved_crossrefs = [] then
     print_endline ("  all cross references were solved.")
   else
-    print_endline ("  some cross references were not solved.")
+    print_endline ("  some cross references were not solved: " ^ String.concat " " unresolved_crossrefs ^ ".")
 
 
 let end_output file_name_out =

--- a/src/frontend/logging.ml
+++ b/src/frontend/logging.ml
@@ -67,11 +67,14 @@ let needs_another_trial () =
 
 
 let achieve_count_max () =
-  print_endline ("  some cross references were not solved.")
+  print_endline ("  could not reach to fixpoint when resolving cross references.")
 
 
-let achieve_fixpoint () =
-  print_endline ("  all cross references were solved.")
+let achieve_fixpoint unresolved_crossrefs =
+  if unresolved_crossrefs = [] then
+    print_endline ("  all cross references were solved.")
+  else
+    print_endline ("  some cross references were not solved.")
 
 
 let end_output file_name_out =

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -242,9 +242,9 @@ let eval_document_file (tyenv : Typeenv.t) (env : environment) (file_path_in : f
                           Logging.end_output file_path_out;
                         end
 
-                    | CrossRef.CanTerminate ->
+                    | CrossRef.CanTerminate unresolved_crossrefs ->
                         begin
-                          Logging.achieve_fixpoint ();
+                          Logging.achieve_fixpoint unresolved_crossrefs;
                           output_pdf pdf;
                           Logging.end_output file_path_out;
                         end

--- a/src/frontend/primitives.ml
+++ b/src/frontend/primitives.ml
@@ -736,6 +736,7 @@ let make_environments () =
         ("script-guard"            , ~% (tSCR @-> tIB @-> tIB)                       , lambda2 (fun vscr vh -> BackendScriptGuard(vscr, vh)));
         ("discretionary"           , ~% (tI @-> tIB @-> tIB @-> tIB @-> tIB)         , lambda4 (fun vpb vib0 vib1 vib2 -> BackendDiscretionary(vpb, vib0, vib1, vib2)));
         ("register-cross-reference", ~% (tS @-> tS @-> tU)                           , lambda2 (fun vk vv -> BackendRegisterCrossReference(vk, vv)));
+        ("probe-cross-reference"     , ~% (tS @-> (tOPT tS))                         , lambda1 (fun vk -> BackendProbeCrossReference(vk)));
         ("get-cross-reference"     , ~% (tS @-> (tOPT tS))                           , lambda1 (fun vk -> BackendGetCrossReference(vk)));
         ("hook-page-break"         , ~% ((tPBINFO @-> tPT @-> tU) @-> tIB)           , lambda1 (fun vhook -> BackendHookPageBreak(vhook)));
       ]

--- a/src/frontend/types.ml
+++ b/src/frontend/types.ml
@@ -695,6 +695,7 @@ and abstract_tree =
   | BackendScriptGuard          of abstract_tree * abstract_tree
   | BackendDiscretionary        of abstract_tree * abstract_tree * abstract_tree * abstract_tree
   | BackendRegisterCrossReference of abstract_tree * abstract_tree
+  | BackendProbeCrossReference    of abstract_tree
   | BackendGetCrossReference      of abstract_tree
 
 and pattern_branch =


### PR DESCRIPTION
Fixes #68.

@gfngfn could you review this?