### PR TITLE
add demo/satysfi-logo.jpg to generate demo.pdf

### DIFF
--- a/demo/satysfi-logo.jpg
+++ b/demo/satysfi-logo.jpg
@@ -1,0 +1,1 @@
+../tests/images/satysfi-logo-rgb.jpg


### PR DESCRIPTION
At present `demo/` does not have `satysfi-logo.jpg`, so `make` fails.
In this PR I use symlink to `tests/images/satysfi-logo-rgb.jpg` (possibly there is more preferable one).