### PR TITLE
add new math commands

### DIFF
--- a/lib-satysfi/dist/packages/math.satyh
+++ b/lib-satysfi/dist/packages/math.satyh
@@ -45,6 +45,8 @@ module Math : sig
   direct \times : [] math-cmd
   direct \nabla : [] math-cmd
 
+  direct \le     : [] math-cmd
+  direct \ge     : [] math-cmd
   direct \equiv  : [] math-cmd
   direct \neq    : [] math-cmd
   direct \simeq  : [] math-cmd
@@ -269,6 +271,8 @@ end = struct
   let-math \times = math-char MathBin `×`
   let-math \vdash = math-char MathRel `⊢`
   let-math \colon-rel = math-char MathRel `:`
+  let-math \le     = math-char MathRel `≤`
+  let-math \ge     = math-char MathRel `≥`
   let-math \equiv  = math-char MathRel `≡`
   let-math \neq    = math-char MathRel `≠`
   let-math \simeq  = math-char MathRel `≃`

--- a/lib-satysfi/dist/packages/math.satyh
+++ b/lib-satysfi/dist/packages/math.satyh
@@ -63,6 +63,14 @@ module Math : sig
   direct \max : [] math-cmd
   direct \min : [] math-cmd
 
+  direct \wedge : [] math-cmd
+  direct \vee : [] math-cmd
+  direct \rightarrow : [] math-cmd
+  direct \leftarrow : [] math-cmd
+  direct \leftrightarrow : [] math-cmd
+  direct \forall : [] math-cmd
+  direct \exists : [] math-cmd
+
 
   direct \Alpha   : [] math-cmd
   direct \Beta    : [] math-cmd
@@ -300,6 +308,15 @@ end = struct
 
   let-math \sum = math-big-char MathOp `∑`
   let-math \prod = math-big-char MathOp `∏`
+
+  let-math \wedge = math-char MathBin `∧`
+  let-math \vee   = math-char MathBin `∨`
+  let-math \rightarrow = math-char MathRel `⇒`
+  let-math \leftarrow = math-char MathRel `⇐`
+  let-math \leftrightarrow = math-char MathRel `⇔`
+  let-math \forall = math-char MathOrd `∀`
+  let-math \exists = math-char MathOrd `∃`
+
 
 %% -- for Latin Modern Math --
   let-math \int =

--- a/lib-satysfi/dist/packages/math.satyh
+++ b/lib-satysfi/dist/packages/math.satyh
@@ -66,9 +66,9 @@ module Math : sig
 
   direct \wedge : [] math-cmd
   direct \vee : [] math-cmd
-  direct \rightarrow : [] math-cmd
-  direct \leftarrow : [] math-cmd
-  direct \leftrightarrow : [] math-cmd
+  direct \Rightarrow : [] math-cmd
+  direct \Leftarrow : [] math-cmd
+  direct \Leftrightarrow : [] math-cmd
   direct \forall : [] math-cmd
   direct \exists : [] math-cmd
 
@@ -315,9 +315,9 @@ end = struct
 
   let-math \wedge = math-char MathBin `∧`
   let-math \vee   = math-char MathBin `∨`
-  let-math \rightarrow = math-char MathRel `⇒`
-  let-math \leftarrow = math-char MathRel `⇐`
-  let-math \leftrightarrow = math-char MathRel `⇔`
+  let-math \Rightarrow = math-char MathRel `⇒`
+  let-math \Leftarrow = math-char MathRel `⇐`
+  let-math \Leftrightarrow = math-char MathRel `⇔`
   let-math \forall = math-char MathOrd `∀`
   let-math \exists = math-char MathOrd `∃`
 

--- a/lib-satysfi/dist/packages/math.satyh
+++ b/lib-satysfi/dist/packages/math.satyh
@@ -71,6 +71,9 @@ module Math : sig
   direct \forall : [] math-cmd
   direct \exists : [] math-cmd
 
+  direct \because : [] math-cmd
+  direct \therefore : [] math-cmd
+
 
   direct \Alpha   : [] math-cmd
   direct \Beta    : [] math-cmd
@@ -316,6 +319,9 @@ end = struct
   let-math \leftrightarrow = math-char MathRel `⇔`
   let-math \forall = math-char MathOrd `∀`
   let-math \exists = math-char MathOrd `∃`
+
+  let-math \therefore = math-char MathOrd `∴`
+  let-math \because = math-char MathOrd `∵`
 
 
 %% -- for Latin Modern Math --

--- a/lib-satysfi/dist/packages/math.satyh
+++ b/lib-satysfi/dist/packages/math.satyh
@@ -60,6 +60,9 @@ module Math : sig
   direct \propto : [] math-cmd
 
   direct \lim : [] math-cmd
+  direct \max : [] math-cmd
+  direct \min : [] math-cmd
+
 
   direct \Alpha   : [] math-cmd
   direct \Beta    : [] math-cmd
@@ -291,6 +294,9 @@ end = struct
   let-math \ldots = math-char MathPunct `…`
 
   let-math \lim = math-char MathOp `lim`
+  let-math \max = math-char MathOp `max`
+  let-math \min = math-char MathOp `min`
+
 
   let-math \sum = math-big-char MathOp `∑`
   let-math \prod = math-big-char MathOp `∏`

--- a/lib-satysfi/dist/packages/math.satyh
+++ b/lib-satysfi/dist/packages/math.satyh
@@ -50,6 +50,7 @@ module Math : sig
   direct \le     : [] math-cmd
   direct \ge     : [] math-cmd
   direct \in     : [] math-cmd
+  direct \mid : [] math-cmd
 
   direct \equiv  : [] math-cmd
   direct \neq    : [] math-cmd
@@ -271,6 +272,8 @@ end = struct
 
   let-math \infty = math-char MathOrd `∞`
   let-math \to    = math-char MathRel `→`
+  let-math \in    = math-char MathRel `∈`
+  let-math \mid   = math-char MathRel `|`
   let-math \pm    = math-char MathBin `±`
   let-math \times = math-char MathBin `×`
   let-math \vdash = math-char MathRel `⊢`

--- a/lib-satysfi/dist/packages/math.satyh
+++ b/lib-satysfi/dist/packages/math.satyh
@@ -32,6 +32,8 @@ module Math : sig
   direct \app : [math; math] math-cmd
   direct \angle : [math] math-cmd
   direct \brace : [math] math-cmd
+  direct \abs : [math] math-cmd
+  direct \norm : [math] math-cmd
 
   direct \to : [] math-cmd
   direct \pm : [] math-cmd
@@ -699,5 +701,75 @@ let-math \brace =
 
   let-math \overwrite f x v =
     ${#f \sqbracket{#x \mapsto #v}}
+
+
+  let abs-left hgt dpt hgtaxis fontsize color =
+    let halflen = half-length hgt dpt hgtaxis fontsize in
+    let wid = 5.0pt in
+    let path (xpos, ypos) =
+      start-path (xpos +' wid *' 0.5, ypos +' hgtaxis +' halflen)
+        |> line-to (xpos +' wid *' 0.5, ypos +' hgtaxis -' halflen)
+        |> close-with-line
+    in
+    let graphics point = [ stroke 0.5pt color (path point); ] in
+    let kerninfo _ = 0pt in
+      (inline-graphics wid (hgtaxis +' halflen) (halflen -' hgtaxis) graphics, kerninfo)
+
+  let abs-right hgt dpt hgtaxis fontsize color =
+    let halflen = half-length hgt dpt hgtaxis fontsize in
+    let wid = 5.0pt in
+    let path (xpos, ypos) =
+      start-path (xpos +' wid *' 0.5, ypos +' hgtaxis +' halflen)
+        |> line-to (xpos +' wid *' 0.5, ypos +' hgtaxis -' halflen)
+        |> close-with-line
+    in
+    let graphics point = [ stroke 0.5pt color (path point); ] in
+    let kerninfo _ = 0pt in
+      (inline-graphics wid (hgtaxis +' halflen) (halflen -' hgtaxis) graphics, kerninfo)
+
+
+  let-math \abs =
+    math-paren abs-left abs-right
+
+
+  let norm-left hgt dpt hgtaxis fontsize color =
+    let halflen = half-length hgt dpt hgtaxis fontsize in
+    let wid = 7.0pt in
+    let path (xpos, ypos) =
+      unite-path (
+        start-path (xpos +' wid *' 0.5 -' 1.2pt, ypos +' hgtaxis +' halflen)
+          |> line-to (xpos +' wid *' 0.5 -' 1.2pt, ypos +' hgtaxis -' halflen)
+          |> close-with-line
+      ) (
+        start-path (xpos +' wid *' 0.5 +' 1.2pt, ypos +' hgtaxis +' halflen)
+          |> line-to (xpos +' wid *' 0.5 +' 1.2pt, ypos +' hgtaxis -' halflen)
+          |> close-with-line
+      )
+    in
+    let graphics point = [ stroke 0.5pt color (path point); ] in
+    let kerninfo _ = 0pt in
+      (inline-graphics wid (hgtaxis +' halflen) (halflen -' hgtaxis) graphics, kerninfo)
+
+  let norm-right hgt dpt hgtaxis fontsize color =
+    let halflen = half-length hgt dpt hgtaxis fontsize in
+    let wid = 7.0pt in
+    let path (xpos, ypos) =
+      unite-path (
+        start-path (xpos +' wid *' 0.5 -' 1.2pt, ypos +' hgtaxis +' halflen)
+          |> line-to (xpos +' wid *' 0.5 -' 1.2pt, ypos +' hgtaxis -' halflen)
+          |> close-with-line
+      ) (
+        start-path (xpos +' wid *' 0.5 +' 1.2pt, ypos +' hgtaxis +' halflen)
+          |> line-to (xpos +' wid *' 0.5 +' 1.2pt, ypos +' hgtaxis -' halflen)
+          |> close-with-line
+      )
+    in
+    let graphics point = [ stroke 0.5pt color (path point); ] in
+    let kerninfo _ = 0pt in
+      (inline-graphics wid (hgtaxis +' halflen) (halflen -' hgtaxis) graphics, kerninfo)
+
+
+  let-math \norm =
+    math-paren norm-left norm-right
 
 end

--- a/lib-satysfi/dist/packages/math.satyh
+++ b/lib-satysfi/dist/packages/math.satyh
@@ -49,6 +49,8 @@ module Math : sig
 
   direct \le     : [] math-cmd
   direct \ge     : [] math-cmd
+  direct \in     : [] math-cmd
+
   direct \equiv  : [] math-cmd
   direct \neq    : [] math-cmd
   direct \simeq  : [] math-cmd

--- a/lib-satysfi/dist/packages/math.satyh
+++ b/lib-satysfi/dist/packages/math.satyh
@@ -32,6 +32,7 @@ module Math : sig
   direct \app : [math; math] math-cmd
   direct \angle : [math] math-cmd
   direct \brace : [math] math-cmd
+  direct \sqbracket : [math] math-cmd
   direct \abs : [math] math-cmd
   direct \norm : [math] math-cmd
 


### PR DESCRIPTION
I added new math commands needed to write my report.
They are basically implemented by math-char, but \abs and \norm are implemented by math-paren.