### PR TITLE
simplify `opam install` invocation in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,7 @@ install:
   - eval `opam config env`
   - opam repository add satysfi-external https://github.com/gfngfn/satysfi-external-repo.git
   - opam update
-  - opam install -y ppx_deriving
-  - opam install -y menhir
-  - opam install -y core_kernel.v0.10.0
-  - opam install -y ctypes
-  - opam install -y uutf
-  - opam install -y result
-  - opam install -y bitv
-  - opam install -y batteries
-  - opam install -y yojson
-  - opam install -y camlimages
-  - opam install -y camlpdf.2.2.1+satysfi
-  - opam install -y otfm.0.3.0+satysfi
-  - eval `opam config env`
+  - opam pin add -y --no-action satysfi .
+  - opam install -y --deps-only satysfi
 script:
   - make all


### PR DESCRIPTION
All dependencies are already listed in the `opam` file. There should be no need to repeat them in `.travis.yml`.