### PR TITLE
Add header to tests/glue1.saty

### DIFF
--- a/tests/glue1.saty
+++ b/tests/glue1.saty
@@ -1,3 +1,5 @@
+@import: head
+
 let-inline ctx \glueneg = inline-glue 0pt 0pt (0pt -' 100pt) in
 document (|
   title = {Glue Test};


### PR DESCRIPTION
Currently, `cd tests && satysfi glue1.saty` fails due to an undefined variable 'document'.

```
$ satysfi glue1.saty
 ---- ---- ---- ----
  target file: 'glue1.pdf'
  dump file: 'glue1.satysfi-aux' (already exists)
  parsing 'glue1.saty' ...
 ---- ---- ---- ----
  reading 'glue1.saty' ...
! [Type Error] at line 2, characters 0-8:
    undefined variable 'document'.
```

This PR adds `@import: head` into `glue1.saty` and makes `satysfi glue1.saty` successful if some fonts are provided.