### PR TITLE
add bytecode compiler and vm

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -30,6 +30,7 @@ $ brew install --HEAD nyuichi/satysfi/satysfi
 * make
 * unzip
 * wget or curl
+* ruby
 * [opam](https://opam.ocaml.org/) 1.2 （インストール手順は[こちら](https://opam.ocaml.org/doc/Install.html)。）
 * ocaml 4.06.0 （OPAM からインストールします）
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Here is a list of minimally required softwares.
 * make
 * unzip
 * wget or curl
+* ruby
 * [opam](https://opam.ocaml.org/) 1.2 (Installation instructions are [here](https://opam.ocaml.org/doc/Install.html).)
 * ocaml 4.06.0 (installed by OPAM)
 

--- a/gen_code.rb
+++ b/gen_code.rb
@@ -1,0 +1,168 @@
+require 'yaml'
+require 'pathname'
+require 'optparse'
+
+STACK       = "stack"
+ENVIRONMENT = "env"
+CODE        = "code"
+DUMP        = "dump"
+VMEXEC      = "exec"
+FUNCPREFIX  = "get_"
+TRANSPRIM = "transform_primitive"
+
+DESTRUCTURING_RULES = {
+  "int" => lambda {|v| "IntegerConstant(#{v})"},
+  "bool" => lambda {|v| "BooleanConstant(#{v})"},
+  "context" => lambda {|v| "Context(#{v})"},
+  "float" => lambda {|v| "FloatConstant(#{v})"},
+  "horz" => lambda {|v| "Horz(#{v})"},
+  "vert" => lambda {|v| "Vert(#{v})"},
+  "length" => lambda {|v| "LengthConstant(#{v})"},
+  "math" => lambda {|v| "MathValue(#{v})"},
+  "path_value" => lambda {|v| "PathValue(#{v})"},
+  "prepath" => lambda {|v| "PrePathValue(#{v})"},
+  "regexp" => lambda {|v| "RegExpConstant(#{v})"},
+}
+
+def default_false b
+  if b == nil then false else b end
+end
+
+def gen_vminstrs
+  YAML.load_documents(ARGF.read) do |inst|
+    tmpn = 0
+    destruct = []
+    funcapp = []
+
+    inst["params"].each do |param|
+      if param.is_a?(String) then
+        destruct.push param
+      elsif param.is_a?(Hash) then
+        pat = param.keys[0]
+        type = param.values[0]
+        rule = DESTRUCTURING_RULES[type]
+        if rule then
+          destruct.push (rule.call pat)
+        else
+          destruct.push "_tmp#{tmpn}"
+          funcapp.push [pat, type, "_tmp#{tmpn}"]
+          tmpn = tmpn + 1
+        end
+      end
+    end if inst["params"]
+
+    if inst["fields"] != nil then
+      fieldnames = inst["fields"].collect{|e| e.keys[0]}
+      puts "  | Op#{inst["inst"]}(#{fieldnames.join ', '}) ->"
+    else
+      puts "  | Op#{inst["inst"]} ->"
+    end
+    puts "      begin"
+    puts "        match #{STACK} with" if inst["params"]
+
+    puts "        | #{destruct.reverse.join(" :: ")} :: #{STACK} ->" if destruct.length > 0
+
+    funcapp.each do |app|
+      dest, func, src = app
+      puts "            let #{dest} = #{FUNCPREFIX}#{func} #{src} in"
+    end
+
+    puts "          #{VMEXEC} ((" if inst["is-primitive"]
+    puts "            begin"
+    puts "         #{inst["code"]}"
+    puts "            end"
+    puts "          )::#{STACK}) #{ENVIRONMENT} #{CODE} #{DUMP}" if inst["is-primitive"]
+    puts "        | _ -> report_bug_vm \"invalid primitive argument #{inst["inst"]}\"" if inst["params"]
+    puts "      end"
+    puts ""
+  end
+end
+
+def gen_insttype
+  puts "and instruction ="
+  YAML.load_documents(ARGF.read) do |inst|
+    if inst["fields"] != nil then
+      fieldtypes = inst["fields"].collect{|e| e.values[0]}
+      puts "  | Op#{inst["inst"]} of #{fieldtypes.join ' * '}"
+    else
+      puts "  | Op#{inst["inst"]}"
+    end
+
+    puts "      [@printer (fun fmt _ -> Format.fprintf fmt \"Op#{inst["inst"]}(...)\")]" if inst["suppress-pp"]
+    puts "      [@printer (#{inst["custom-pp"]})]" if inst["custom-pp"]
+  end
+  puts "  [@@deriving show]"
+end
+
+def gen_attype
+  YAML.load_documents(ARGF.read) do |inst|
+    if inst["is-primitive"] && !default_false(inst["no-ircode"]) then
+      if inst["params"] != nil then
+        puts "  | #{inst["inst"]} of #{(["abstract_tree"] * inst["params"].length).join ' * '}"
+      else
+        puts "  | #{inst["inst"]}"
+      end
+    end
+  end
+end
+
+def gen_ircases
+  YAML.load_documents(ARGF.read) do |inst|
+    if inst["is-primitive"] && !default_false(inst["no-ircode"]) then
+      params = [*1..inst["params"].length].collect{|n| "p"+n.to_s}
+
+      puts "  | #{inst["inst"]}(#{params.join ', '}) ->"
+      puts "      #{TRANSPRIM} env [#{params.join '; '}] Op#{inst["inst"]}"
+    end
+  end
+end
+
+def pp_include
+  srcpath = Pathname.new(ARGV[0])
+
+  puts "(***********************************************************)"
+  puts "(*                                                         *)"
+  puts "(*                                                         *)"
+  puts "(*                                                         *)"
+  puts "(*                   AUTO-GENERATED FILE                   *)"
+  puts "(*                      DO NOT MODIFY                      *)"
+  puts "(*                                                         *)"
+  puts "(*                                                         *)"
+  puts "(*                                                         *)"
+  puts "(***********************************************************)"
+
+  ARGF.each_line do |line|
+    match = line.match(/\(\*\*\*\*.*include *: *(.*) *\*\*\*\*\)/)
+    if match then
+       inspath = Pathname.new(match[1].strip)
+       if inspath.absolute? then
+         openpath = inspath
+       else
+         openpath = srcpath.dirname.join(inspath.basename)
+       end
+
+       File.open(openpath) do |file|
+         file.each_line do |line|
+           puts line
+         end
+       end
+    else
+      puts line
+    end
+  end
+end
+
+
+opt = OptionParser.new
+
+func = nil
+
+opt.on('--gen-vm') {|v| func = method(:gen_vminstrs) }
+opt.on('--gen-ir') {|v| func = method(:gen_ircases) }
+opt.on('--gen-insttype') {|v| func = method(:gen_insttype) }
+opt.on('--gen-attype') {|v| func = method(:gen_attype) }
+opt.on('--pp-include') {|v| func = method(:pp_include) }
+
+opt.parse!(ARGV)
+
+func.call

--- a/src/frontend/assoc.ml
+++ b/src/frontend/assoc.ml
@@ -34,6 +34,8 @@ let map_value f amap =
 let iter_value f amap =
   AssocMap.iter (fun _ v -> f v) amap
 
+let iter f amap =
+  AssocMap.iter (fun k v -> f k v) amap
 
 let fold_value f init amap =
   AssocMap.fold (fun _ v acc -> f acc v) amap init
@@ -79,3 +81,7 @@ let combine_value amap1 amap2 =
 
 let union amap1 amap2 =
   AssocMap.union (fun k v1 v2 -> Some(v2)) amap1 amap2
+
+let cardinal amap =
+  AssocMap.cardinal amap
+

--- a/src/frontend/assoc.mli
+++ b/src/frontend/assoc.mli
@@ -17,6 +17,8 @@ val map_value : ('v -> 'w) -> 'v t -> 'w t
 
 val iter_value : ('v -> unit) -> 'v t -> unit
 
+val iter : (key -> 'v -> unit) -> 'v t -> unit
+
 val fold_value : ('a -> 'v -> 'a) -> 'a -> 'v t -> 'a
 
 val to_value_list : 'v t -> 'v list
@@ -36,3 +38,6 @@ val combine_value : 'v t -> 'w t -> ('v * 'w) list
 val intersection : 'v t -> 'v t -> ('v * 'v) list
 
 val union : 'v t -> 'v t -> 'v t
+
+val cardinal : 'v t -> int
+

--- a/src/frontend/bytecomp/bytecomp.ml
+++ b/src/frontend/bytecomp/bytecomp.ml
@@ -1,0 +1,32 @@
+module Types = Types_
+module Ir = Ir_
+module Vm = Vm_
+
+open MyUtil
+open LengthInterface
+open Types
+
+
+let compile_and_exec env ast =
+  let (ir, env) = Ir.transform_ast env ast in
+  let code = Compiler.compile ir [] in
+  (*
+  Format.printf "IR:\n%s\n" (show_ir ir);  (* for debug *)
+  List.iter (fun inst -> Format.printf "%s\n" (show_instruction inst)) code;  (* for debug *)
+  *)
+    Vm.exec [] (env, []) code []
+
+let compile_environment env =
+  let (binds, _) = env in
+    binds |> EvalVarIDMap.iter (fun evid loc -> 
+        match !loc with
+        | PrimitiveWithEnvironment(parbrs, env1, arity, astf) ->
+          begin
+            match compile_and_exec env (Function(parbrs)) with
+            | CompiledFuncWithEnvironment(_, _, framesize, body, env1) ->
+              loc := CompiledPrimitiveWithEnvironment(arity, [], framesize, body, env1, astf)
+            | _ -> ()
+          end
+        | _ -> ()
+      )
+

--- a/src/frontend/bytecomp/compiler.ml
+++ b/src/frontend/bytecomp/compiler.ml
@@ -1,0 +1,315 @@
+
+module Types = Types_
+open MyUtil
+open LengthInterface
+open Types
+
+let report_bug_compiler msg =
+  Format.printf "[Bug]@ %s:" msg;
+  failwith ("bug: " ^ msg)
+
+let report_bug_compiler_ast msg ast =
+  Format.printf "[Bug]@ %s:" msg;
+  Format.printf "%a" pp_abstract_tree ast;
+  failwith ("bug: " ^ msg)
+
+let rec compile_list irlist cont =
+  let rec iter irlist cont =
+    match irlist with
+    | [] -> cont
+    | ir :: tail ->
+      iter tail (compile ir cont)
+  in
+    (* -- left-to-right evaluation -- *)
+    iter (List.rev irlist) cont
+
+and emit_appop arglist cont inc_ctx =
+  let arity = List.length arglist + (if inc_ctx then 1 else 0) in
+  let appop = (if cont=[] then OpApplyT(arity) else OpApply(arity)) in
+    if arity = 0 then
+      cont
+    else
+      (appop::cont)
+
+and compile_input_horz_content (ihlst : ir_input_horz_element list) =
+  let imihlist = ihlst |> List.map (function
+      | IRInputHorzText(s) ->
+        CompiledImInputHorzText(s)
+
+      | IRInputHorzEmbedded(ircmd, irarglist) ->
+        let appcode = emit_appop irarglist [] true in
+        let cmdcode = compile ircmd appcode in
+        let compiled = compile_list irarglist cmdcode in
+          CompiledImInputHorzEmbedded(compiled)
+
+      | IRInputHorzEmbeddedMath(irmath) ->
+        CompiledImInputHorzEmbeddedMath(compile irmath [])
+
+      | IRInputHorzContent(ir) ->
+        CompiledImInputHorzContent(compile ir [])
+    )
+  in
+    CompiledInputHorzIntermediate(imihlist)
+
+and compile_input_vert_content (ivlst : ir_input_vert_element list) =
+  let imivlist =  ivlst |> List.map (function
+      | IRInputVertEmbedded(ircmd, irarglist) ->
+        let appcode = emit_appop irarglist [] true in
+        let cmdcode = compile ircmd appcode in
+        let compiled = compile_list irarglist cmdcode in
+          CompiledImInputVertEmbedded(compiled)
+
+      | IRInputVertContent(ir) ->
+        CompiledImInputVertContent(compile ir [])
+    )
+  in
+    CompiledInputVertIntermediate(imivlist)
+
+and compile_path pathcomplst (cycleopt : unit ir_path_component option) =
+  let c_pathcomplst =
+    pathcomplst |> List.map (function
+        | IRPathLineTo(irpt) ->
+          CompiledPathLineTo(compile irpt [])
+
+        | IRPathCubicBezierTo(irpt1, irpt2, irpt) ->
+          let pt1 = compile irpt1 [] in
+          let pt2 = compile irpt2 [] in
+          let pt = compile irpt [] in
+            CompiledPathCubicBezierTo(pt1, pt2, pt)
+      )
+  in
+  let c_cycleopt =
+    match cycleopt with
+    | None -> None
+
+    | Some(IRPathLineTo(())) -> Some(CompiledPathLineTo(()))
+
+    | Some(IRPathCubicBezierTo(irpt1, irpt2, ())) ->
+      let pt1 = compile irpt1 [] in
+      let pt2 = compile irpt2 [] in
+        Some(CompiledPathCubicBezierTo(pt1, pt2, ()))
+  in
+    (c_pathcomplst, c_cycleopt)
+
+
+and compile (ir : ir) (cont : instruction list) =
+  match ir with
+  (* ---- basic value ---- *)
+
+  | IRConstant(v) -> OpPush(v) :: cont
+
+  | IRTerminal -> OpPushEnv :: cont
+
+  | IRInputHorz(ihlst) ->
+    OpClosureInputHorz(compile_input_horz_content ihlst) :: cont
+  (* -- lazy evaluation; evaluates embedded variables only -- *)
+
+  | IRInputVert(ivlst) ->
+    OpClosureInputVert(compile_input_vert_content ivlst) :: cont
+  (* -- lazy evaluation; evaluates embedded variables only -- *)
+
+  (* -- fundamentals -- *)
+
+  | IRContentOf(var) ->
+    begin
+      match var with
+      | GlobalVar(loc, evid, refs) ->
+        if !loc = Nil then
+          OpLoadGlobal(loc, evid, !refs) :: cont
+        else
+          OpPush(!loc) :: cont
+
+      | LocalVar(lv, off, evid, refs) -> OpLoadLocal(lv, off, evid, !refs) :: cont
+    end
+
+  | IRLetRecIn(recbinds, ast2) ->
+    let binds = recbinds |> List.map (fun bind ->
+        let (var, ir) = bind in
+          (var, compile ir [])
+      )
+    in
+      OpBindClosuresRec(binds) :: (compile ast2 cont)
+
+  | IRLetNonRecIn(ir1, irpat, ir2) ->
+    compile ir1 @@ compile_patsel (Range.dummy "LetNonRecIn") [IRPatternBranch(irpat, ir2)] cont
+
+  | IRFunction(framesize, irpatlst, irbody) ->
+    let body = compile irbody [] in
+    let patlst = compile_patlist irpatlst body in
+    let (optcode, n) = optimize_func_prologue patlst in
+      if framesize - n = 0 then
+        OpClosure(List.length irpatlst, 0, optcode) :: cont
+      else
+        OpClosure(List.length irpatlst, framesize, optcode) :: cont
+
+  | IRApply(arity, ircallee, irargs) ->
+    compile_list irargs @@ (compile ircallee @@ emit_appop irargs cont false)
+
+  | IRApplyPrimitive(op, arity, irargs) ->
+    compile_list irargs (op::cont)
+
+  | IRTuple(len, iritems) ->
+    compile_list iritems (OpMakeTuple(len)::cont)
+
+  | IRIfThenElse(irb, ir1, ir2) ->
+    let tpart = compile ir1 cont in
+    let fpart = compile ir2 cont in
+      compile irb [OpSel(tpart, fpart)]
+
+  (* ---- record ---- *)
+
+  | IRRecord(keylst, irlst) ->
+    compile_list irlst (OpMakeRecord(keylst) :: cont)
+
+  | IRAccessField(ir1, fldnm) ->
+    compile ir1 (OpAccessField(fldnm) :: cont)
+
+  (* ---- imperatives ---- *)
+
+  | IRLetMutableIn(var, irini, iraft) ->
+    let bindop =
+      match var with
+      | GlobalVar(loc, evid, refs) -> OpBindLocationGlobal(loc, evid)
+      | LocalVar(lv, off, evid, refs) -> OpBindLocationLocal(lv, off, evid)
+    in
+      compile irini (bindop :: (compile iraft cont))
+
+  | IRSequential(ir1, ir2) ->
+    compile ir1 (OpPop :: compile ir2 cont)
+
+  | IROverwrite(var, irnew) ->
+    begin
+      match var with
+      | GlobalVar(loc, evid, refs) -> compile irnew (OpUpdateGlobal(loc, evid) :: cont)
+      | LocalVar(lv, off, evid, refs) -> compile irnew (OpUpdateLocal(lv, off, evid) :: cont)
+    end
+
+  | IRWhileDo(irb, irc) ->
+    let cond = compile irb [OpBranchIfNot(OpPush(UnitConstant) :: cont)] in
+    let body = compile irc cond in
+      cond @ body
+
+  (* ---- others ---- *)
+
+  | IRPatternMatch(rng, irobj, patbrs) ->
+    compile irobj @@ compile_patsel rng patbrs cont
+
+  | IRNonValueConstructor(constrnm, ircont) ->
+    compile ircont (OpMakeConstructor(constrnm) :: cont)
+
+  | IRModule(irmdl, iraft) ->
+    compile irmdl @@ compile iraft cont
+
+  | IRPath(irpt0, pathcomplst, cycleopt) ->
+    let (pathelemlst, closingopt) = compile_path pathcomplst cycleopt in
+      compile irpt0 (OpPath(pathelemlst, closingopt)::cont)
+
+
+and compile_patsel (rng : Range.t) (patbrs : ir_pattern_branch list) cont =
+  let consif cond a b = 
+    if cond then (a::b) else b
+  in
+  let rec iter patbrs next n = 
+    begin
+      match patbrs with
+      | [] -> next
+      | IRPatternBranch(pat, irto) :: tail ->
+        let rest = compile irto cont in
+        let body = consif (n<>0) OpPop rest in
+        let patchk = compile_patcheck pat next body in
+          iter tail (consif (n<>0) OpDup patchk) (n+1)
+
+      | IRPatternBranchWhen(pat, ircond, irto) :: tail ->
+        let rest = compile irto cont in
+        let body = consif (n<>0) OpPop rest in
+        let cond = compile ircond (OpBranchIfNot(next) :: body) in
+        let patchk = compile_patcheck pat next cond in
+          iter tail (consif (n<>0) OpDup patchk) (n+1)
+    end
+  in
+    iter (List.rev patbrs) [OpError("no matches (" ^ (Range.to_string rng) ^ ")")] 0
+
+and compile_patlist patlist cont =
+  let next = [OpError("no matches")] in
+  let rec iter patlist cont =
+    match patlist with
+    | [] -> cont
+    | pat :: pattail ->
+      iter pattail (compile_patcheck pat next cont)
+  in
+    (* -- right-to-left binding -- *)
+    iter patlist cont
+
+
+and compile_patcheck (pat : ir_pattern_tree) next cont =
+  let return inst = inst::cont in
+    match pat with
+    | IRPIntegerConstant(pnc) -> return (OpCheckStackTopInt(pnc, next))
+    | IRPBooleanConstant(pbc) -> return (OpCheckStackTopBool(pbc, next))
+
+    | IRPStringConstant(str) -> 
+      return (OpCheckStackTopStr(str, next))
+
+    | IRPUnitConstant -> return OpPop
+    | IRPWildCard     -> return OpPop
+
+    | IRPVariable(var) ->
+      begin
+        match var with
+        | GlobalVar(loc, evid, refs) -> return (OpBindGlobal(loc, evid, !refs))
+        | LocalVar(lv, off, evid, refs) -> return (OpBindLocal(lv, off, evid, !refs))
+      end
+
+    | IRPAsVariable(var, psub) ->
+      let bindop =
+        match var with
+        | GlobalVar(loc, evid, refs) -> OpBindGlobal(loc, evid, !refs)
+        | LocalVar(lv, off, evid, refs) -> OpBindLocal(lv, off, evid, !refs)
+      in
+      let code = compile_patcheck psub next cont in
+        OpDup :: bindop :: code
+
+    | IRPEndOfList -> return (OpCheckStackTopEndOfList(next))
+
+    | IRPListCons(phd, ptl) ->
+      let ctl = compile_patcheck ptl next cont in
+      let chd = compile_patcheck phd (OpPop::next) ctl in
+        OpCheckStackTopListCons(next) :: chd
+
+    | IRPEndOfTuple -> return OpPop
+
+    | IRPTupleCons(phd, ptl) ->
+      let ctl = compile_patcheck ptl next cont in
+      let chd = compile_patcheck phd (OpPop::next) ctl in
+        OpCheckStackTopTupleCons(next) :: chd
+
+    | IRPConstructor(cnm1, psub) ->
+      let code = compile_patcheck psub next cont in
+        OpCheckStackTopCtor(cnm1, next) :: code
+
+and optimize_func_prologue code =
+  let rec collect_bind code acc =
+    match code with
+    | (OpBindLocal(_, _, _, _) as hd)::rest -> collect_bind rest (hd::acc)
+    | _ -> (acc, code)
+
+  and collect_load code acc =
+    match code with
+    | (OpLoadLocal(_, _, _, _) as hd)::rest -> collect_load rest (hd::acc)
+    | _ -> (List.rev acc, code)
+
+  and consume bindops loadops n =
+    match (bindops, loadops) with
+    | (OpBindLocal(_, _, bid, 1)::bs, OpLoadLocal(_, _, lid, 1)::ls)
+      when EvalVarID.equal bid lid ->
+      (*Format.printf "omitted\n";*) consume bs ls (n+1)
+    | _ -> ((List.rev bindops) @ loadops, n)
+
+  in
+  let (bindops, rest) = collect_bind code [] in
+  let (loadops, rest) = collect_load rest [] in
+  (*Format.printf "bind/load = %d/%d\n" (List.length bindops) (List.length loadops);*)
+  let (aftcode, n) = consume bindops loadops 0 in
+    (aftcode @ rest, n)
+
+

--- a/src/frontend/bytecomp/ir.ml
+++ b/src/frontend/bytecomp/ir.ml
@@ -1,0 +1,431 @@
+
+module Types = Types_
+open MyUtil
+open LengthInterface
+open Types
+
+type frame = {
+  global : environment;
+  vars : varloc EvalVarIDMap.t;
+  level : int;
+  size : int;
+}
+
+let report_bug_ir msg =
+  Format.printf "[Bug]@ %s:" msg;
+  failwith ("bug: " ^ msg)
+
+let report_bug_ir_ast msg ast =
+  Format.printf "[Bug]@ %s:" msg;
+  Format.printf "%a" pp_abstract_tree ast;
+  failwith ("bug: " ^ msg)
+
+let map_with_env f env lst =
+  let rec iter env lst acc =
+    match lst with
+    | [] -> (List.rev acc, env)
+    | x :: xs ->
+      let (r, envnew) = f env x in
+        iter envnew xs (r :: acc)
+  in
+    iter env lst []
+
+let rec transform_input_horz_content env (ihlst : input_horz_element list) =
+  ihlst @|> env @|> map_with_env (fun env elem ->
+      match elem with
+      | InputHorzText(s) ->
+        (IRInputHorzText(s), env)
+
+      | InputHorzEmbedded(astcmd, astarglst) ->
+        let (ircmd, env) = transform env astcmd in
+        let (irarglst, env) = transform_list env astarglst in
+          (IRInputHorzEmbedded(ircmd, irarglst), env)
+
+      | InputHorzEmbeddedMath(astmath) ->
+        let (irmath, env) = transform env astmath in
+          (IRInputHorzEmbeddedMath(irmath), env)
+
+      | InputHorzContent(ast) ->
+        let (ir, env) = transform env ast in
+          (IRInputHorzContent(ir), env)
+    )
+
+and transform_input_vert_content env (ivlst : input_vert_element list) =
+  ivlst @|> env @|> map_with_env (fun env elem ->
+      match elem with
+      | InputVertEmbedded(astcmd, astarglst) ->
+        let (ircmd, env) = transform env astcmd in
+        let (irarglst, env) = transform_list env astarglst in
+          (IRInputVertEmbedded(ircmd, irarglst), env)
+
+      | InputVertContent(ast) ->
+        let (ir, env) = transform env ast in
+          (IRInputVertContent(ir), env)
+    )
+
+and transform_path env pathcomplst cycleopt =
+  let (irpathcomplst, env) =
+    pathcomplst @|> env @|> map_with_env (fun env path ->
+        match path with
+        | PathLineTo(astpt) ->
+          let (pt, env) = transform env astpt in
+            (IRPathLineTo(pt), env)
+
+        | PathCubicBezierTo(astpt1, astpt2, astpt) ->
+          let (pt1, env) = transform env astpt1 in
+          let (pt2, env) = transform env astpt2 in
+          let (pt, env) = transform env astpt in
+            (IRPathCubicBezierTo(pt1, pt2, pt), env)
+      )
+  in
+  let (ircycleopt, env) =
+    match cycleopt with
+    | None -> (None, env)
+
+    | Some(PathLineTo(())) -> (Some(IRPathLineTo(())), env)
+
+    | Some(PathCubicBezierTo(astpt1, astpt2, ())) ->
+      let (pt1, env) = transform env astpt1 in
+      let (pt2, env) = transform env astpt2 in
+        (Some(IRPathCubicBezierTo(pt1, pt2, ())), env)
+  in
+    (irpathcomplst, ircycleopt, env)
+
+and transform_ast (env : environment) ast =
+  let (genv, _) = env in
+  let initvars = EvalVarIDMap.fold (fun k v acc ->
+      EvalVarIDMap.add k (GlobalVar(v, k, ref 0)) acc 
+    ) genv EvalVarIDMap.empty 
+  in
+  let initframe = {global = env; vars = initvars; level = 0; size = 0; } in
+  let (ir, frame) = transform initframe ast in
+    (ir, frame.global)
+
+and transform_list env astlst =
+  map_with_env transform env astlst
+
+and transform_primitive env astlst op =
+  let (irargs, env) = transform_list env astlst in
+    (IRApplyPrimitive(op, List.length astlst, irargs), env)
+
+and transform_patsel env (patbrs : pattern_branch list) =
+  let before_size = env.size in
+  let max_size = ref before_size in
+  let (irpatsel, envnew) =
+    patbrs @|> env @|> map_with_env (fun env patbr ->
+        match patbr with
+        | PatternBranch(pat, astto) ->
+          let env = { env with size = before_size; } in
+          let (irpat, env) = transform_pattern env pat in
+          let (irto, env) = transform env astto in
+            max_size := max !max_size env.size;
+            (IRPatternBranch(irpat, irto), env)
+
+        | PatternBranchWhen(pat, astcond, astto) ->
+          let env = { env with size = before_size; } in
+          let (irpat, env) = transform_pattern env pat in
+          let (ircond, env) = transform env astcond in
+          let (irto, env) = transform env astto in
+            max_size := max !max_size env.size;
+            (IRPatternBranchWhen(irpat, ircond, irto), env)
+      )
+  in
+    (irpatsel, { envnew with size = !max_size; })
+
+
+and transform_pattern_list env patlst =
+  map_with_env transform_pattern env patlst
+
+and transform_pattern env (pat : pattern_tree) =
+  let return b = (b, env) in
+    match pat with
+    | PIntegerConstant(pnc) -> return (IRPIntegerConstant(pnc))
+    | PBooleanConstant(pbc) -> return (IRPBooleanConstant(pbc))
+
+    | PStringConstant(ast1) ->
+      let str1 = 
+        begin
+          match ast1 with
+          | Value(StringEmpty)       -> ""
+          | Value(StringConstant(s)) -> s
+          | _                 -> report_bug_ir "get_string"
+        end
+      in
+        return (IRPStringConstant(str1))
+
+    | PUnitConstant -> return IRPUnitConstant
+    | PWildCard     -> return IRPWildCard
+
+    | PVariable(evid) ->
+      let (env, var) = add_to_environment env evid  in
+        (IRPVariable(var), env)
+
+    | PAsVariable(evid, psub) ->
+      let (env, var) = add_to_environment env evid  in
+      let (bsub, env) = transform_pattern env psub in
+        (IRPAsVariable(var, bsub), env)
+
+    | PEndOfList -> return IRPEndOfList
+
+    | PListCons(phd, ptl) ->
+      let (bhd, envhd) = transform_pattern env phd in
+      let (btl, envtl) = transform_pattern envhd ptl in
+        (IRPListCons(bhd, btl), envtl)
+
+    | PEndOfTuple -> return IRPEndOfTuple
+
+    | PTupleCons(phd, ptl) ->
+      let (bhd, envhd) = transform_pattern env phd in
+      let (btl, envtl) = transform_pattern envhd ptl in
+        (IRPTupleCons(bhd, btl), envtl)
+
+    | PConstructor(cnm1, psub) -> 
+      let (bsub, env) = transform_pattern env psub in
+        (IRPConstructor(cnm1, bsub), env)
+
+and newlevel (env : frame) =
+  { env with level = env.level+1; size = 0; }
+
+and add_to_environment (env : frame) evid =
+  let (var, newglobal) =
+    if env.level = 0 then
+      let loc = (ref Nil) in
+        (GlobalVar(loc, evid, ref 0), Types.add_to_environment env.global evid loc)
+    else
+      (LocalVar(env.level, env.size, evid, ref 0), env.global)
+  in
+  let locvar =
+    match var with
+    | LocalVar(lv, off, id, refs) -> LocalVar(env.level - lv, off, id, refs)
+    | GlobalVar(loc, id, refs) -> var
+  in
+  let newvars = EvalVarIDMap.add evid var env.vars in
+    ({env with global = newglobal; vars = newvars; size = env.size+1}, locvar)
+
+and find_in_environment (env : frame) (evid : EvalVarID.t) : varloc option =
+  match (env.vars |> EvalVarIDMap.find_opt evid) with
+  | Some(LocalVar(lv, off, id, refs)) -> incr refs; Some(LocalVar(env.level - lv, off, id, refs))
+  | Some(GlobalVar(_, _, refs)) as v -> incr refs; v
+  | None -> None
+
+and add_letrec_bindings_to_environment env (recbinds : letrec_binding list) =
+  recbinds @|> env @|> map_with_env (fun env recbind ->
+      let LetRecBinding(evid, patbrs) = recbind in
+      let (env, var) = add_to_environment env evid in
+        ((var, patbrs), env)
+    )
+
+and flatten_function astfun =
+  let rec iter ast acc = 
+    match ast with
+    | Function([PatternBranch(pat, body)]) -> iter body (pat::acc) 
+    | _ -> (ast, List.rev acc)
+  in
+    iter astfun []
+
+and flatten_application apast =
+  let rec iter ast acc = 
+    match ast with
+    | Apply(ast1, ast2) -> iter ast1 (ast2 :: acc)
+    | _ -> (ast, acc)
+  in
+    iter apast []
+
+and flatten_tuple asttup =
+  let rec iter ast acc = 
+    match ast with
+    | PrimitiveTupleCons(hd, Value(EndOfTuple)) -> List.rev (hd::acc)
+    | PrimitiveTupleCons(hd, tl) -> iter tl (hd :: acc)
+    | _ -> report_bug_ir_ast "malformed tuple!" asttup
+  in
+    iter asttup []
+
+and transform_tuple env ast =
+  let items = flatten_tuple ast in
+  let (iritems, envnew) = map_with_env transform env items in
+  let len = List.length items in
+    (IRTuple(len, iritems), envnew)
+
+and check_primitive env ast =
+  match ast with
+  | ContentOf(_, evid) ->
+    begin
+      match Types.find_in_environment env.global evid with
+      | Some(rfvalue) -> 
+        begin
+          let value = !rfvalue in
+            match value with
+            | CompiledPrimitiveWithEnvironment(arity, _, _, _, _, astf) -> Some((arity, astf))
+            | _ -> None
+        end
+      | None -> None
+    end
+  | _ -> None
+
+and transform (env : frame) ast : (ir * frame) =
+  let return ir = (ir, env) in
+    match ast with
+    | Value(v) -> return (IRConstant(v))
+
+    | FinishHeaderFile -> return IRTerminal
+
+    | FinishStruct -> return IRTerminal
+
+    | InputHorz(ihlst) ->
+      let (imihlst, env) = transform_input_horz_content env ihlst in
+        (IRInputHorz(imihlst), env)
+    (* -- lazy evaluation; evaluates embedded variables only -- *)
+
+    | InputVert(ivlst) ->
+      let (imivlst, env) = transform_input_vert_content env ivlst in
+        (IRInputVert(imivlst), env)
+    (* -- lazy evaluation; evaluates embedded variables only -- *)
+
+    | LengthDescription(flt, unitnm) ->
+      let len =
+        match unitnm with  (* temporary; ad-hoc handling of unit names *)
+        | "pt"   -> Length.of_pdf_point flt
+        | "cm"   -> Length.of_centimeter flt
+        | "mm"   -> Length.of_millimeter flt
+        | "inch" -> Length.of_inch flt
+        | _      -> report_bug_ir_ast "LengthDescription; unknown unit name" ast
+      in
+        return (IRConstant(LengthConstant(len)))
+
+    | BackendMathList(astmlst) ->
+      transform_primitive env astmlst (OpBackendMathList(List.length astmlst))
+
+    | Path(astpt0, pathcomplst, cycleopt) ->
+      let (irpt0, env) = transform env astpt0 in
+      let (pathelemlst, closingopt, env) = transform_path env pathcomplst cycleopt in
+        (IRPath(irpt0, pathelemlst, closingopt), env)
+
+    | LambdaVert(evid, astdef) ->
+      transform env (Function [(PatternBranch ((PVariable evid), astdef))])
+
+    | LambdaHorz(evid, astdef) ->
+      transform env (Function [(PatternBranch ((PVariable evid), astdef))])
+
+    | PrimitiveTupleCons(asthd, asttl) ->
+      transform_tuple env ast
+
+    (* -- fundamentals -- *)
+
+    | ContentOf(rng, evid) ->
+      begin
+        match find_in_environment env evid with
+        | Some(var) ->
+          return (IRContentOf(var))
+
+        | None ->
+          report_bug_ir_ast ("ContentOf: variable '" ^ (EvalVarID.show_direct evid) ^ "' (at " ^ (Range.to_string rng) ^ ") not found") ast
+      end
+
+    | LetRecIn(recbinds, ast2) ->
+      let (pairs, env) = add_letrec_bindings_to_environment env recbinds in
+      let varir_lst = 
+        pairs |> List.map (fun pair ->
+            let (var, patbrs) = pair in
+            let (ir, _) = transform env (Function(patbrs)) in
+              (var, ir)
+          )
+      in
+      let (ir2, env) = transform env ast2 in
+        (IRLetRecIn(varir_lst, ir2), env)
+
+    | LetNonRecIn(pat, ast1, ast2) ->
+      let (ir1, env) = transform env ast1 in
+      let (irpat, env) = transform_pattern env pat in
+      let (ir2, env) = transform env ast2 in
+        (IRLetNonRecIn(ir1, irpat, ir2), env)
+
+    | Function(patbrs) ->
+      let (body, args) = flatten_function ast in
+      let funenv = newlevel env in
+      let (irargs, funenv) = transform_pattern_list funenv args in
+      let (irbody, funenv) = transform funenv body in
+        (IRFunction(funenv.size, irargs, irbody), env)
+
+    | Apply(ast1, ast2) ->
+      let (callee, args) = flatten_application ast in
+        begin
+          match check_primitive env callee with
+          | Some((arity, astf)) when arity = List.length args ->
+            transform env (astf args)
+
+          | _ ->
+            let (ircallee, env) = transform env callee in
+            let (irargs, env) = transform_list env args in
+              (IRApply(List.length irargs, ircallee, irargs), env)
+        end
+
+    | IfThenElse(astb, ast1, ast2) ->
+      let (irb, env) = transform env astb in
+      let before_size = env.size in
+      let (ir1, env) = transform env ast1 in
+      let ast1_size = env.size in
+      let (ir2, env) = transform { env with size = before_size } ast2 in
+      let ast2_size = env.size in
+        (IRIfThenElse(irb, ir1, ir2), { env with size = max ast1_size ast2_size })
+
+    (* ---- record ---- *)
+
+    | Record(asc) ->
+      let iter acc key ast = 
+        let (keylst, irlst, env) = acc in
+        let (ir, env) = transform env ast in
+          (key::keylst, ir::irlst, env)
+      in
+      let (keylst, irlst, env) = Assoc.fold iter ([], [], env) asc in
+        (IRRecord(List.rev keylst, List.rev irlst), env)
+
+    | AccessField(ast1, fldnm) ->
+      let (ir1, env) = transform env ast1 in
+        (IRAccessField(ir1, fldnm), env)
+
+    (* ---- imperatives ---- *)
+
+    | LetMutableIn(evid, astini, astaft) ->
+      let (irini, env) = transform env astini in
+      let (env, var) = add_to_environment env evid in
+      let (iraft, env) = transform env astaft in
+        (IRLetMutableIn(var, irini, iraft), env)
+
+    | Sequential(ast1, ast2) ->
+      let (ir1, env) = transform env ast1 in
+      let (ir2, env) = transform env ast2 in
+        (IRSequential(ir1, ir2), env)
+
+    | Overwrite(evid, astnew) ->
+      begin
+        match find_in_environment env evid with
+        | Some(var) ->
+          let (irnew, env) = transform env astnew in
+            (IROverwrite(var, irnew), env)
+
+        | None ->
+          report_bug_ir_ast ("Overwrite: mutable value '" ^ (EvalVarID.show_direct evid) ^ "' not found") ast
+      end
+
+    | WhileDo(astb, astc) ->
+      let (irb, env) = transform env astb in
+      let (irc, env) = transform env astc in
+        (IRWhileDo(irb, irc), env)
+
+    (* ---- others ---- *)
+
+    | PatternMatch(rng, astobj, patbrs) ->
+      let (irobj, env) = transform env astobj in
+      let (irpatsel, env) = transform_patsel env patbrs in
+        (IRPatternMatch(rng, irobj, irpatsel), env)
+
+    | NonValueConstructor(constrnm, astcont) ->
+      let (ircont, env) = transform env astcont in
+        (IRNonValueConstructor(constrnm, ircont), env)
+
+    | Module(astmdl, astaft) ->
+      let (irmdl, env) = transform env astmdl in
+      let (iraft, env) = transform env astaft in
+        (IRModule(irmdl, iraft), env)
+
+(**** include: __ir.ml ****) 

--- a/src/frontend/bytecomp/vm.ml
+++ b/src/frontend/bytecomp/vm.ml
@@ -1,0 +1,683 @@
+
+module Types = Types_
+open MyUtil
+open LengthInterface
+open Types
+
+exception ExecError of string
+
+type compiled_nom_input_horz_element =
+  | CompiledNomInputHorzText     of string
+  | CompiledNomInputHorzEmbedded of instruction list
+  | CompiledNomInputHorzContent  of compiled_nom_input_horz_element list * vmenv
+
+
+let report_bug_vm msg =
+  Format.printf "[Bug]@ %s:" msg;
+  failwith ("bug: " ^ msg)
+
+
+let local_get_value env lv off =
+  let (_, frames) = env in
+    if lv = 0 then
+      (List.hd frames).(off)
+    else
+      (List.nth frames lv).(off)
+
+let local_set_value env lv off value =
+  let (_, frames) = env in
+    if lv = 0 then
+      (List.hd frames).(off) <- value
+    else
+      (List.nth frames lv).(off) <- value
+
+let vmenv_global env =
+  let (global, _) = env in
+    global
+
+let newframe env size =
+  let (global, local) = env in
+    (global, (Array.make size Nil) :: local)
+
+let newframe_recycle env preenv size =
+  let (global, local) = env in
+    match preenv with
+    | (_, prefrm::_) ->
+      if size > Array.length prefrm then
+        (global, (Array.make size Nil) :: local)
+      else
+        (global, prefrm::local)
+    | _ ->
+      (global, (Array.make size Nil) :: local)
+
+
+let chop_space_indent s =
+  let imax = String.length s in
+  let rec aux i s =
+    if i >= imax then
+      (i, "")
+    else
+      match String.get s i with
+      | ' ' -> aux (i + 1) s
+      | _   -> (i, String.sub s i (imax - i))
+  in
+    try
+      aux 0 s
+    with
+    | Invalid_argument(_) -> assert false
+
+let get_string (value : syntactic_value) : string =
+  match value with
+  | StringEmpty       -> ""
+  | StringConstant(s) -> s
+  | _                 -> report_bug_vm "get_string"
+
+let graphics_of_list value : (HorzBox.intermediate_horz_box list) Graphics.t =
+  let rec aux gracc value =
+    match value with
+    | EndOfList                             -> gracc
+    | ListCons(GraphicsValue(grelem), tail) -> aux (Graphics.extend gracc grelem) tail
+    | _                                     -> report_bug_vm "make_frame_deco"
+  in
+    aux Graphics.empty value
+
+
+
+let get_paddings (value : syntactic_value) =
+  match value with
+  | TupleCons(LengthConstant(lenL),
+              TupleCons(LengthConstant(lenR),
+                        TupleCons(LengthConstant(lenT),
+                                  TupleCons(LengthConstant(lenB), EndOfTuple)))) ->
+    {
+      HorzBox.paddingL = lenL;
+      HorzBox.paddingR = lenR;
+      HorzBox.paddingT = lenT;
+      HorzBox.paddingB = lenB;
+    }
+
+  | _ -> report_bug_vm "interpret_paddings"
+
+
+let get_cell (value : syntactic_value) =
+  match value with
+  | Constructor("NormalCell", TupleCons(valuepads,
+                                        TupleCons(Horz(hblst), EndOfTuple))) ->
+    let pads = get_paddings valuepads in
+      HorzBox.NormalCell(pads, hblst)
+
+  | Constructor("EmptyCell", UnitConstant) -> HorzBox.EmptyCell
+
+  | Constructor("MultiCell", TupleCons(IntegerConstant(nr),
+                                       TupleCons(IntegerConstant(nc),
+                                                 TupleCons(valuepads,
+                                                           TupleCons(Horz(hblst), EndOfTuple))))) ->
+    let pads = get_paddings valuepads in
+      HorzBox.MultiCell(nr, nc, pads, hblst)
+
+  | _ -> report_bug_vm "get_cell"
+
+
+let get_color (value : syntactic_value) : GraphicData.color =
+  let open GraphicData in
+    match value with
+    | Constructor("Gray", FloatConstant(gray)) -> DeviceGray(gray)
+
+    | Constructor("RGB", TupleCons(FloatConstant(fltR),
+                                   TupleCons(FloatConstant(fltG),
+                                             TupleCons(FloatConstant(fltB), EndOfTuple)))) ->
+      DeviceRGB(fltR, fltG, fltB)
+
+    | Constructor("CMYK", TupleCons(FloatConstant(fltC),
+                                    TupleCons(FloatConstant(fltM),
+                                              TupleCons(FloatConstant(fltY),
+                                                        TupleCons(FloatConstant(fltK), EndOfTuple))))) ->
+      DeviceCMYK(fltC, fltM, fltY, fltK)
+
+    | _ -> report_bug_vm "interpret_color"
+
+
+
+
+let get_decoset (value : syntactic_value) =
+  match value with
+  | TupleCons(valuedecoS,
+              TupleCons(valuedecoH,
+                        TupleCons(valuedecoM,
+                                  TupleCons(valuedecoT, EndOfTuple)))) ->
+    (valuedecoS, valuedecoH, valuedecoM, valuedecoT)
+
+  | _ -> report_bug_vm "interpret_decoset"
+
+
+let get_font (value : syntactic_value) : HorzBox.font_with_ratio =
+  match value with
+  | TupleCons(valueabbrev,
+              TupleCons(FloatConstant(sizer),
+                        TupleCons(FloatConstant(risingr), EndOfTuple))) ->
+    let abbrev = get_string valueabbrev in
+      (abbrev, sizer, risingr)
+
+  | _ -> report_bug_vm "interpret_font"
+
+
+let get_input_horz_content env (value : syntactic_value) =
+  match value with
+  | CompiledInputHorzIntermediate(imihlist) ->
+    CompiledInputHorzWithEnvironment(imihlist, env)
+  | _ -> report_bug_vm "bad stack top item"
+
+
+let get_input_vert_content env (value : syntactic_value) =
+  match value with
+  | CompiledInputVertIntermediate(imivlist) ->
+    CompiledInputVertWithEnvironment(imivlist, env)
+  | _ -> report_bug_vm "bad stack top item"
+
+
+let get_language_system (value : syntactic_value) =
+  match value with
+  | Constructor("Japanese"        , UnitConstant) -> CharBasis.Japanese
+  | Constructor("English"         , UnitConstant) -> CharBasis.English
+  | Constructor("NoLanguageSystem", UnitConstant) -> CharBasis.NoLanguageSystem
+  | _ ->
+    report_bug_vm "interpret_language_system"
+
+
+let get_list getf (value : syntactic_value) =
+  let rec aux acc value =
+    match value with
+    | ListCons(vhead, vtail) -> aux (Alist.extend acc (getf vhead)) vtail
+    | EndOfList              -> Alist.to_list acc
+    | _                      -> report_bug_vm "get_list"
+  in
+    aux Alist.empty value
+
+let get_math_char_class (value : syntactic_value) =
+  match value with
+  | Constructor("MathItalic"      , UnitConstant) -> HorzBox.MathItalic
+  | Constructor("MathBoldItalic"  , UnitConstant) -> HorzBox.MathBoldItalic
+  | Constructor("MathRoman"       , UnitConstant) -> HorzBox.MathRoman
+  | Constructor("MathBoldRoman"   , UnitConstant) -> HorzBox.MathBoldRoman
+  | Constructor("MathScript"      , UnitConstant) -> HorzBox.MathScript
+  | Constructor("MathBoldScript"  , UnitConstant) -> HorzBox.MathBoldScript
+  | Constructor("MathFraktur"     , UnitConstant) -> HorzBox.MathFraktur
+  | Constructor("MathBoldFraktur" , UnitConstant) -> HorzBox.MathBoldFraktur
+  | Constructor("MathDoubleStruck", UnitConstant) -> HorzBox.MathDoubleStruck
+  | _ ->
+    report_bug_vm "interpret_math_char_class"
+
+
+let get_math_class (value : syntactic_value) =
+  match value with
+  | Constructor("MathOrd"   , UnitConstant) -> HorzBox.MathOrdinary
+  | Constructor("MathBin"   , UnitConstant) -> HorzBox.MathBinary
+  | Constructor("MathRel"   , UnitConstant) -> HorzBox.MathRelation
+  | Constructor("MathOp"    , UnitConstant) -> HorzBox.MathOperator
+  | Constructor("MathPunct" , UnitConstant) -> HorzBox.MathPunct
+  | Constructor("MathOpen"  , UnitConstant) -> HorzBox.MathOpen
+  | Constructor("MathClose" , UnitConstant) -> HorzBox.MathClose
+  | Constructor("MathPrefix", UnitConstant) -> HorzBox.MathPrefix
+  | _ ->
+    report_bug_vm "interpret_math_class"
+
+
+let get_option getf (value : syntactic_value) =
+  match value with
+  | Constructor("None", UnitConstant) -> None
+  | Constructor("Some", valuesub)     -> Some(getf valuesub)
+  | _                                 -> report_bug_vm "interpret_option"
+
+let get_page_size (value : syntactic_value) : HorzBox.page_size =
+  match value with
+  | Constructor("A0Paper" , UnitConstant) -> HorzBox.A0Paper
+  | Constructor("A1Paper" , UnitConstant) -> HorzBox.A1Paper
+  | Constructor("A2Paper" , UnitConstant) -> HorzBox.A2Paper
+  | Constructor("A3Paper" , UnitConstant) -> HorzBox.A3Paper
+  | Constructor("A4Paper" , UnitConstant) -> HorzBox.A4Paper
+  | Constructor("A5Paper" , UnitConstant) -> HorzBox.A5Paper
+  | Constructor("USLetter", UnitConstant) -> HorzBox.USLetter
+  | Constructor("USLegal" , UnitConstant) -> HorzBox.USLegal
+
+  | Constructor("UserDefinedPaper",
+                TupleCons(LengthConstant(pgwid), TupleCons(LengthConstant(pghgt), EndOfTuple))) ->
+    HorzBox.UserDefinedPaper(pgwid, pghgt)
+
+  | _ -> report_bug_vm "interpret_page"
+
+
+let get_point (value : syntactic_value) =
+  match value with
+  | TupleCons(LengthConstant(lenx),
+              TupleCons(LengthConstant(leny), EndOfTuple)) -> (lenx, leny)
+
+  | _ -> report_bug_vm "get_point"
+
+
+let get_script (value : syntactic_value) =
+  match value with
+  | Constructor("HanIdeographic", UnitConstant) -> CharBasis.HanIdeographic
+  | Constructor("Kana"          , UnitConstant) -> CharBasis.HiraganaOrKatakana
+  | Constructor("Latin"         , UnitConstant) -> CharBasis.Latin
+  | Constructor("Other"         , UnitConstant) -> CharBasis.OtherScript
+  | _ ->
+    report_bug_vm "interpret_script: not a script value"
+
+
+let get_uchar_list (value : syntactic_value) =
+  match value with
+  | StringEmpty       -> []
+  | StringConstant(s) -> InternalText.to_uchar_list (InternalText.of_utf8 s)
+  | _                 -> report_bug_vm "get_uchar_list"
+
+
+let make_page_break_info pbinfo =
+  let asc =
+    Assoc.of_list [
+      ("page-number", IntegerConstant(pbinfo.HorzBox.current_page_number));
+    ]
+  in
+    RecordValue(asc)
+
+let make_page_content_info pcinfo =
+  make_page_break_info pcinfo  (* temporary *)
+
+
+let make_length_list lenlst =
+  List.fold_right (fun l acc ->
+      ListCons(LengthConstant(l), acc)
+    ) lenlst EndOfList
+
+
+let lex_horz_text (ctx : HorzBox.context_main) (s_utf8 : string) : HorzBox.horz_box list =
+  let uchlst = InternalText.to_uchar_list (InternalText.of_utf8 s_utf8) in
+    HorzBox.([HorzPure(PHCInnerString(ctx, uchlst))])
+
+
+let make_font_value (abbrev, sizer, risingr) =
+  TupleCons(StringConstant(abbrev),
+            TupleCons(FloatConstant(sizer),
+                      TupleCons(FloatConstant(risingr), EndOfTuple)))
+
+
+let adjust_to_first_line (imvblst : HorzBox.intermediate_vert_box list) =
+  let open HorzBox in
+  let rec aux optinit totalhgtinit imvblst =
+    imvblst |> List.fold_left (fun (opt, totalhgt) imvb ->
+        match (imvb, opt) with
+        | (ImVertLine(hgt, dpt, _), None)  -> (Some(totalhgt +% hgt), totalhgt +% hgt +% (Length.negate dpt))
+        | (ImVertLine(hgt, dpt, _), _)     -> (opt, totalhgt +% hgt +% (Length.negate dpt))
+        | (ImVertFixedEmpty(vskip), _)     -> (opt, totalhgt +% vskip)
+
+        | (ImVertFrame(pads, _, _, imvblstsub), _) ->
+          let totalhgtbefore = totalhgt +% pads.paddingT in
+          let (optsub, totalhgtsub) = aux opt totalhgtbefore imvblstsub in
+          let totalhgtafter = totalhgtsub +% pads.paddingB in
+            (optsub, totalhgtafter)
+
+      ) (optinit, totalhgtinit)
+  in
+    match aux None Length.zero imvblst with
+    | (Some(hgt), totalhgt) -> (hgt, Length.negate (totalhgt -% hgt))
+    | (None, totalhgt)      -> (Length.zero, Length.negate totalhgt)
+
+
+let adjust_to_last_line (imvblst : HorzBox.intermediate_vert_box list) =
+  let open HorzBox in
+  let rec aux optinit totalhgtinit evvblst =
+    let evvblstrev = List.rev evvblst in
+      evvblstrev |> List.fold_left (fun (opt, totalhgt) imvblast ->
+          match (imvblast, opt) with
+          | (ImVertLine(hgt, dpt, _), None)  -> (Some((Length.negate totalhgt) +% dpt), totalhgt +% (Length.negate dpt) +% hgt)
+          | (ImVertLine(hgt, dpt, _), _)     -> (opt, totalhgt +% (Length.negate dpt) +% hgt)
+          | (ImVertFixedEmpty(vskip), _)     -> (opt, totalhgt +% vskip)
+
+          | (ImVertFrame(pads, _, _, evvblstsub), _) ->
+            let totalhgtbefore = totalhgt +% pads.paddingB in
+            let (optsub, totalhgtsub) = aux opt totalhgtbefore evvblstsub in
+            let totalhgtafter = totalhgtsub +% pads.paddingT in
+              (optsub, totalhgtafter)
+
+        ) (optinit, totalhgtinit)
+  in
+    match aux None Length.zero imvblst with
+    | (Some(dpt), totalhgt) -> (totalhgt +% dpt, dpt)
+    | (None, totalhgt)      -> (totalhgt, Length.zero)
+
+
+let make_list (type a) (makef : a -> syntactic_value) (lst : a list) : syntactic_value =
+  List.fold_right (fun x ast -> ListCons(makef x, ast)) lst EndOfList
+
+
+let make_line_stack (hblstlst : (HorzBox.horz_box list) list) =
+  let open HorzBox in
+  let wid =
+    hblstlst |> List.fold_left (fun widacc hblst ->
+        let (wid, _, _) = LineBreak.get_natural_metrics hblst in
+          Length.max wid widacc
+      ) Length.zero
+  in
+  let trilst = hblstlst |> List.map (fun hblst -> LineBreak.fit hblst wid) in
+  let imvblst =
+    trilst |> List.fold_left (fun imvbacc (imhblst, hgt, dpt) ->
+        Alist.extend imvbacc (VertLine(hgt, dpt, imhblst))
+      ) Alist.empty |> Alist.to_list
+  in
+    (wid, imvblst)
+
+
+let make_script_value script =
+  let label =
+    match script with
+    | CharBasis.HanIdeographic     -> "HanIdeographic"
+    | CharBasis.HiraganaOrKatakana -> "Kana"
+    | CharBasis.Latin              -> "Latin"
+    | CharBasis.OtherScript        -> "OtherScript"
+    | _                            -> report_bug_vm "make_script_value"
+  in
+    Constructor(label, UnitConstant)
+
+
+let make_language_system_value langsys =
+  let label =
+    match langsys with
+    | CharBasis.Japanese         -> "Japanese"
+    | CharBasis.English          -> "English"
+    | CharBasis.NoLanguageSystem -> "NoLanguageSystem"
+  in
+    Constructor(label, UnitConstant)
+
+
+let make_color_value color =
+  let open GraphicData in
+    match color with
+    | DeviceGray(gray) ->
+      Constructor("Gray", FloatConstant(gray))
+
+    | DeviceRGB(r, g, b) ->
+      Constructor("RGB", TupleCons(FloatConstant(r),
+                                   TupleCons(FloatConstant(g),
+                                             TupleCons(FloatConstant(b), EndOfTuple))))
+
+    | DeviceCMYK(c, m, y, k) ->
+      Constructor("CMYK", TupleCons(FloatConstant(c),
+                                    TupleCons(FloatConstant(m),
+                                              TupleCons(FloatConstant(y),
+                                                        TupleCons(FloatConstant(k), EndOfTuple)))))
+
+let get_tuple3 getf value =
+  match value with
+  | TupleCons(v1, TupleCons(v2, TupleCons(v3, EndOfTuple))) ->
+    let c1 = getf v1 in
+    let c2 = getf v2 in
+    let c3 = getf v3 in
+      (c1, c2, c3)
+  | _ -> report_bug_vm "interpret_tuple3"
+
+let popn stack n =
+  let rec iter st n acc =
+    if n = 0 then
+      (acc, st)
+    else
+      match st with
+      | x :: xs -> iter xs (n-1) (x::acc)
+      | [] -> report_bug_vm "stack underflow!"
+  in
+    iter stack n []
+
+let rec make_hook env (valuehook : syntactic_value) : (HorzBox.page_break_info -> point -> unit) =
+  (fun pbinfo (xpos, yposbaseline) ->
+     let valuept = TupleCons(LengthConstant(xpos), TupleCons(LengthConstant(yposbaseline), EndOfTuple)) in
+     let valuepbinfo = make_page_break_info pbinfo in
+     let valueret = exec [valuehook; valuept; valuepbinfo] env [OpApplyT(2)] [] in
+       match valueret with
+       | UnitConstant -> ()
+       | _            -> report_bug_vm "make_hook"
+  )
+
+
+and get_path env c_pathcomplst c_cycleopt =
+  let pathelemlst =
+    c_pathcomplst |> List.map (function
+        | CompiledPathLineTo(ptcode) ->
+          let pt = get_point @@ exec [] env ptcode [] in
+            GraphicData.LineTo(pt)
+
+        | CompiledPathCubicBezierTo(pt1code, pt2code, ptcode) ->
+          let pt1 = get_point @@ exec [] env pt1code [] in
+          let pt2 = get_point @@ exec [] env pt2code [] in
+          let pt = get_point @@ exec [] env ptcode [] in
+            GraphicData.CubicBezierTo(pt1, pt2, pt)
+      )
+  in
+  let closingopt =
+    match c_cycleopt with
+    | None -> None
+
+    | Some(CompiledPathLineTo(())) -> Some(GraphicData.LineTo(()))
+
+    | Some(CompiledPathCubicBezierTo(pt1code, pt2code, ())) ->
+      let pt1 = get_point @@ exec [] env pt1code [] in
+      let pt2 = get_point @@ exec [] env pt2code [] in
+        Some(GraphicData.CubicBezierTo(pt1, pt2, ()))
+  in
+    (pathelemlst, closingopt)
+
+
+and make_page_content_scheme_func env valuef : HorzBox.page_content_scheme_func =
+  (fun pbinfo ->
+     let valuepbinfo = make_page_break_info pbinfo in
+     let valueret = exec [valuef; valuepbinfo] env [OpApplyT(1)] [] in
+       match valueret with
+       | RecordValue(asc) ->
+         begin
+           match
+             (Assoc.find_opt asc "text-origin",
+              Assoc.find_opt asc "text-height")
+           with
+           | (Some(vTO), Some(LengthConstant(vTHlen))) ->
+             HorzBox.({
+                 page_content_origin = get_point(vTO);
+                 page_content_height = vTHlen;
+               })
+
+           | _ -> report_bug_vm "make_page_scheme_func"
+         end
+
+       | _ -> report_bug_vm "make_page_scheme_func"
+  )
+
+
+and make_page_parts_scheme_func env valuef : HorzBox.page_parts_scheme_func =
+  (fun pcinfo ->
+     let valuepcinfo = make_page_content_info pcinfo in
+     let valueret = exec [valuef; valuepcinfo] env [OpApplyT(1)] [] in
+       match valueret with
+       | RecordValue(asc) ->
+         begin
+           match
+             (Assoc.find_opt asc "header-origin",
+              Assoc.find_opt asc "header-content",
+              Assoc.find_opt asc "footer-origin",
+              Assoc.find_opt asc "footer-content")
+           with
+           | (Some(vHO), Some(Vert(vHCvert)), Some(vFO), Some(Vert(vFCvert))) ->
+             HorzBox.({
+                 header_origin  = get_point vHO;
+                 header_content = PageBreak.solidify vHCvert;
+                 footer_origin  = get_point vFO;
+                 footer_content = PageBreak.solidify vFCvert;
+               })
+
+           | _ -> report_bug_vm "make_page_parts_scheme_func"
+         end
+
+       | _ -> report_bug_vm "make_page_parts_scheme_func"
+  )
+
+
+and make_frame_deco env valuedeco =
+  (fun (xpos, ypos) wid hgt dpt ->
+     let valuepos = TupleCons(LengthConstant(xpos), TupleCons(LengthConstant(ypos), EndOfTuple)) in
+     let valuewid = LengthConstant(wid) in
+     let valuehgt = LengthConstant(hgt) in
+     let valuedpt = LengthConstant(Length.negate dpt) in
+     (* -- depth values for users are nonnegative -- *)
+     let valueret = exec [valuedeco; valuedpt; valuehgt; valuewid; valuepos] env [OpApplyT(4)] [] in
+       graphics_of_list valueret
+  )
+
+
+and make_paren env valueparenf : HorzBox.paren =
+  (fun hgt dpt hgtaxis fontsize color ->
+     let valuehgt      = LengthConstant(hgt) in
+     let valuedpt      = LengthConstant(Length.negate dpt) in
+     (* -- depth values for users are nonnegative -- *)
+     let valuehgtaxis  = LengthConstant(hgtaxis) in
+     let valuefontsize = LengthConstant(fontsize) in
+     let valuecolor    = make_color_value color in
+     let valueret = exec [valueparenf; valuecolor; valuefontsize; valuehgtaxis; valuedpt; valuehgt] env [OpApplyT(5)] [] in
+       match valueret with
+       | TupleCons(Horz(hblst), TupleCons(valuekernf, EndOfTuple)) ->
+         let kernf = make_math_kern_func env valuekernf in
+           (hblst, kernf)
+
+       | _ ->
+         report_bug_vm "make_paren"
+  )
+
+
+and make_math_kern_func env valuekernf : HorzBox.math_kern_func =
+  (fun corrhgt ->
+    let astcorrhgt = LengthConstant(corrhgt) in
+       match exec [valuekernf; astcorrhgt] env [OpApplyT(1)] [] with
+       | LengthConstant(valueret) -> valueret
+       | _ -> report_bug_vm "bad return value"
+  )
+
+
+and make_math_char_kern_func env valuekernf : HorzBox.math_char_kern_func =
+  (fun fontsize ypos ->
+     let valuefontsize = LengthConstant(fontsize) in
+     let valueypos     = LengthConstant(ypos) in
+       match exec [valuekernf; valueypos; valuefontsize] env [OpApplyT(2)] [] with
+       | LengthConstant(valueret) -> valueret
+       | _ -> report_bug_vm "bad return value"
+  )
+
+and make_inline_graphics env valueg =
+  (fun (xpos, ypos) ->
+     let valuepos = TupleCons(LengthConstant(xpos), TupleCons(LengthConstant(ypos), EndOfTuple)) in
+     let valueret = exec [valueg; valuepos] env [OpApplyT(1)] [] in
+       graphics_of_list valueret
+  )
+
+and exec_intermediate_input_vert (env : vmenv) (valuectx : syntactic_value) (imivlst : compiled_intermediate_input_vert_element list) : syntactic_value =
+  let rec interpret_commands env imivlst =
+    imivlst |> List.map (fun imiv ->
+        match imiv with
+        | CompiledImInputVertEmbedded(code) ->
+          begin
+            match exec [valuectx] env (code) [] with
+            | Vert(valueret) -> valueret
+            | _ -> report_bug_vm "bad return value"
+          end
+
+        | CompiledImInputVertContent(ctcode) ->
+          let value = exec [] env ctcode [] in
+            begin
+              match value with
+              | CompiledInputVertWithEnvironment(imivlst, envsub) ->
+                interpret_commands envsub imivlst
+
+              | _ -> report_bug_vm "interpret_input_vert_content"
+            end
+
+      ) |> List.concat
+  in
+  let imvblst = interpret_commands env imivlst in
+    Vert(imvblst)
+
+
+and exec_intermediate_input_horz (env : vmenv) (valuectx : syntactic_value) (imihlst : compiled_intermediate_input_horz_element list) : syntactic_value =
+  match valuectx with
+  | Context((ctx, valuemcmd)) ->
+    begin
+      let rec normalize imihlst =
+        imihlst |> List.fold_left (fun acc imih ->
+            match imih with
+            | CompiledImInputHorzEmbedded(code) ->
+              let nmih = CompiledNomInputHorzEmbedded(code) in
+                Alist.extend acc nmih
+
+            | CompiledImInputHorzText(s2) ->
+              begin
+                match Alist.chop_last acc with
+                | Some(accrest, CompiledNomInputHorzText(s1)) -> (Alist.extend accrest (CompiledNomInputHorzText(s1 ^ s2)))
+                | _                                   -> (Alist.extend acc (CompiledNomInputHorzText(s2)))
+              end
+
+            | CompiledImInputHorzEmbeddedMath(mathcode) ->
+              let nmih = CompiledNomInputHorzEmbedded(mathcode @ [OpPush(valuemcmd); OpApplyT(2)]) in
+                Alist.extend acc nmih
+
+            | CompiledImInputHorzContent(ctcode) ->
+              let value = exec [] env ctcode [] in
+                begin
+                  match value with
+                  | CompiledInputHorzWithEnvironment(imihlst, envsub) ->
+                    let nmihlstsub = normalize imihlst in
+                    let nmih = CompiledNomInputHorzContent(nmihlstsub, envsub) in
+                      Alist.extend acc nmih
+
+                  | _ -> report_bug_vm "interpret_input_horz_content"
+                end
+
+          ) Alist.empty |> Alist.to_list
+      in
+
+      let rec interpret_commands env (nmihlst : compiled_nom_input_horz_element list) : HorzBox.horz_box list =
+        nmihlst |> List.map (fun nmih ->
+            match nmih with
+            | CompiledNomInputHorzEmbedded(code) ->
+              begin
+                match exec [valuectx] env code [] with
+                | Horz(valueret) -> valueret
+                | _ -> report_bug_vm "bad return value"
+              end
+
+            | CompiledNomInputHorzText(s) ->
+              lex_horz_text ctx s
+
+            | CompiledNomInputHorzContent(nmihlstsub, envsub) ->
+              interpret_commands envsub nmihlstsub
+
+          ) |> List.concat
+      in
+
+      let nmihlst = normalize imihlst in
+      let hblst = interpret_commands env nmihlst in
+        Horz(hblst)
+    end
+  | _ ->
+    report_bug_vm "Context expected"
+
+and exec (stack : syntactic_value list) (env : vmenv) (code : instruction list) dump = 
+  match code with
+  | [] ->
+    begin
+      match dump with
+      | (pe, pc) :: rest ->
+        exec stack pe pc rest
+
+      | [] ->
+        begin match stack with
+          | v :: _ -> v
+          | [] -> report_bug_vm "stack underflow!"
+        end
+    end
+
+  | c :: code ->
+    (*Format.printf "\nexec ---> %a\n" pp_instruction c;*)
+    match c with
+    (**** include: __vm.ml ****)

--- a/src/frontend/bytecomp/vminstdef.yaml
+++ b/src/frontend/bytecomp/vminstdef.yaml
@@ -1,0 +1,1963 @@
+# ---------------------------------------------------
+#   SATySFi virtual machine instruction definitions
+# ---------------------------------------------------
+#
+# This is formatted according to the YAML.
+#
+# This file is read by gen_code.rb.
+# gen_code.rb generates OCaml source code and 
+# type declarations for types.ml, ir.ml and vm.ml.
+# Final source codes that gen_code.rb generates are
+# types_.ml, ir_.ml and vm_.ml.
+#
+# To add a new primitive,
+#   1. Add a new instruction definition to this file.
+#      (is-primitive should be yes.)
+#   2. Add a new entry to primitives.ml.
+#
+#
+# inst:          Instruction name (essential)
+# is-primitive:  Primitive or pure vm instruction (default: no)
+# suppress-pp:   Use a simple pritty printer (default: no)
+# custom-pp:     Specify custom pritty printer
+# no-ircode:     Suppress code generation for ir.ml (default: no)
+# fields:        Field list (for 'abstract_tree' type)
+# params:        Paramater list
+# code:          Instruction code
+#   (note: If is-primitive is yes, code that pushes to stack and
+#          go to next instruction will be automatically inserted.
+#          (see gen_code.rb))
+#
+---
+inst: AccessField
+fields:
+- field_nm : field_name
+params:
+- value1
+code: |
+  match value1 with
+  | RecordValue(asc1) ->
+    begin
+      match Assoc.find_opt asc1 field_nm with
+      | Some(v) -> exec (v::stack) env code dump
+      | None    -> report_bug_vm ("AccessField field " ^ field_nm ^ " not found")
+    end
+
+  | _ -> report_bug_vm "not a Record"
+
+---
+inst: Apply
+fields:
+- n : int
+params:
+- f
+code: |
+  match f with
+  | CompiledFuncWithEnvironment(arity, pargs, framesize, body, env1) ->
+    if arity = n then 
+      begin
+       if pargs = [] then
+          exec stack (newframe env1 framesize) body ((env, code)::dump)
+        else
+          let (args, stack) = popn stack n in
+          let allargs = List.rev (pargs @ args) in
+            exec (allargs @ stack) (newframe env1 framesize) body ((env, code)::dump)
+      end
+ 
+    else if arity > n then
+      let (args, stack) = popn stack n in
+      let applied = CompiledFuncWithEnvironment(arity - n, pargs @ args, framesize, body, env1) in
+        exec (applied::stack) env code dump
+ 
+    else
+      let (surplus, stack) = popn stack (n-arity) in
+      let (args, stack) = popn stack arity in
+      let allargs = List.rev (pargs @ args) in
+        exec (allargs @ stack) (newframe env1 framesize) body ((env, OpInsertArgs(surplus)::OpApply(n-arity)::code)::dump)
+ 
+   | CompiledPrimitiveWithEnvironment(arity, [], framesize, body, env1, astf) ->
+     if arity = n then
+       exec stack (newframe env1 framesize) body ((env, code)::dump)
+
+     else if arity > n then
+       let (args, stack) = popn stack n in
+        let applied = CompiledFuncWithEnvironment(arity - n, args, framesize, body, env1) in
+          exec (applied::stack) env code dump
+ 
+     else
+       let (surplus, stack) = popn stack (n-arity) in
+         exec stack (newframe env1 framesize) body ((env, OpInsertArgs(surplus)::OpApply(n-arity)::code)::dump)
+ 
+   | _ -> report_bug_vm "Apply: not a function"
+
+---
+inst: ApplyT
+fields:
+- n : int
+params:
+- f
+code: |
+  match f with
+  | CompiledFuncWithEnvironment(arity, pargs, framesize, body, env1) ->
+    if arity = n then 
+      begin
+       if pargs = [] then
+          exec stack (newframe env1 framesize) body dump
+        else
+          let (args, stack) = popn stack n in
+          let allargs = List.rev (pargs @ args) in
+            exec (allargs @ stack) (newframe env1 framesize) body dump
+      end
+ 
+    else if arity > n then
+      let (args, stack) = popn stack n in
+      let applied = CompiledFuncWithEnvironment(arity - n, pargs @ args, framesize, body, env1) in
+        exec (applied::stack) env code dump
+ 
+    else
+      let (surplus, stack) = popn stack (n-arity) in
+      let (args, stack) = popn stack arity in
+      let allargs = List.rev (pargs @ args) in
+        exec (allargs @ stack) (newframe env1 framesize) body ((env, OpInsertArgs(surplus)::OpApplyT(n-arity)::code)::dump)
+ 
+   | CompiledPrimitiveWithEnvironment(arity, [], framesize, body, env1, astf) ->
+     if arity = n then
+       exec stack (newframe env1 framesize) body dump
+
+     else if arity > n then
+       let (args, stack) = popn stack n in
+        let applied = CompiledFuncWithEnvironment(arity - n, args, framesize, body, env1) in
+          exec (applied::stack) env code dump
+ 
+     else
+       let (surplus, stack) = popn stack (n-arity) in
+         exec stack (newframe env1 framesize) body ((env, OpInsertArgs(surplus)::OpApplyT(n-arity)::code)::dump)
+ 
+   | _ -> report_bug_vm "ApplyT: not a function"
+
+---
+inst: BindGlobal
+fields:
+- loc : syntactic_value ref
+- evid : EvalVarID.t
+- refs : int
+params:
+- v
+code: |
+  loc := v;
+  exec stack env code dump
+
+---
+inst: BindLocal
+fields:
+- lv : int
+- offset : int
+- evid : EvalVarID.t
+- refs : int
+params:
+- v
+code: |
+  local_set_value env lv offset v;
+  exec stack env code dump
+
+---
+inst: BindClosuresRec
+fields:
+- binds : (varloc * instruction list) list
+code: |
+  binds |> List.iter (fun (var, code) ->
+    let recfunc = exec [] env code [] in
+      match var with
+      | GlobalVar(loc, evid, refs) -> loc := recfunc
+      | LocalVar(lv, offset, evid, refs) -> local_set_value env lv offset recfunc
+  );
+  exec stack env code dump
+
+---
+inst: Branch
+suppress-pp : yes
+fields:
+- body : instruction list
+code: |
+  exec stack env body dump
+
+---
+inst: BranchIf
+suppress-pp : yes
+fields:
+- body : instruction list
+params:
+- b : bool
+code: |
+  if b then
+    exec stack env body dump
+  else
+    exec stack env code dump
+
+---
+inst: BranchIfNot
+suppress-pp : yes
+fields:
+- body : instruction list
+params:
+- b : bool
+code: |
+  if b then
+    exec stack env code dump
+  else
+    exec stack env body dump
+
+---
+inst: LoadGlobal
+custom-pp:
+  (fun fmt (r, evid, refs) -> Format.fprintf fmt "OpLoadGlobal(%s)" (EvalVarID.show_direct evid))
+fields:
+- loc : syntactic_value ref
+- evid : EvalVarID.t
+- refs : int
+code: |
+  exec ((!loc)::stack) env code dump
+
+---
+inst: LoadLocal
+fields:
+- lv : int
+- offset : int
+- evid : EvalVarID.t
+- refs : int
+code: |
+  exec ((local_get_value env lv offset)::stack) env code dump
+
+---
+inst: Dereference
+is-primitive: yes
+params:
+- valuecont
+code: |
+  match valuecont with
+  | Location(stid) ->
+     begin
+       match find_location_value (vmenv_global env) stid with
+       | Some(value) -> value
+       | None        -> report_bug_vm "Dereference"
+     end
+ 
+  | _ ->
+    report_bug_vm "Dereference" 
+
+---
+inst: Dup
+code: | 
+  exec ((List.hd stack)::stack) env code dump
+
+---
+inst: Error
+fields:
+- msg : string
+code: | 
+  raise (ExecError msg)
+
+---
+inst: MakeConstructor
+fields:
+- ctor_nm : constructor_name
+params:
+- valuecont
+code: |
+  exec (Constructor(ctor_nm, valuecont)::stack) env code dump
+
+---
+inst: MakeRecord
+suppress-pp : yes
+fields:
+- keylst : Assoc.key list
+code: |
+  let rec collect keys asc st =
+    match keys with
+    | [] -> (asc, st)
+    | k::rest ->
+        begin
+          match st with
+          | v::stnew -> collect rest (Assoc.add asc k v) stnew
+          | _-> report_bug_vm "MakeRecord"
+        end
+    in
+    let (asc, stack) = collect (List.rev keylst) Assoc.empty stack in
+      exec ((RecordValue(asc))::stack) env code dump
+
+---
+inst: MakeTuple
+fields:
+- len : int
+code: |
+  let rec iter n last st =
+    if n = 0 then
+      (last, st)
+    else
+      begin match st with
+      | value :: stnew ->
+        iter (n-1) (TupleCons(value, last)) stnew
+      | [] -> report_bug_vm "stack underflow"
+      end
+  in
+  let (tuple, stack) = iter len EndOfTuple stack in
+    exec (tuple::stack) env code dump
+  
+---
+inst: Pop
+code: | 
+  exec (List.tl stack) env code dump
+
+---
+inst: Push
+fields:
+- v : syntactic_value
+code: | 
+  exec (v::stack) env code dump
+
+---
+inst: PushEnv
+code: | 
+  exec ((EvaluatedEnvironment(vmenv_global env))::stack) env code dump
+
+---
+inst: CheckStackTopBool
+suppress-pp : yes
+fields:
+- b : bool
+- next : instruction list
+params:
+- v
+code: |
+  match v with
+  | BooleanConstant(b0) when b=b0 ->
+    exec stack env code dump
+  | _ -> 
+    exec stack env next dump
+
+---
+inst: CheckStackTopCtor
+suppress-pp : yes
+fields:
+- ctor_nm : constructor_name
+- next : instruction list
+params:
+- v
+code: |
+  match v with
+  | Constructor(nm, sub) when nm=ctor_nm ->
+    exec (sub::stack) env code dump
+  | _ -> 
+    exec stack env next dump
+
+---
+inst: CheckStackTopEndOfList
+suppress-pp : yes
+fields:
+- next : instruction list
+params:
+- v
+code: |
+  match v with
+  | EndOfList ->
+    exec stack env code dump
+  | _ -> 
+    exec stack env next dump
+
+---
+inst: CheckStackTopInt
+suppress-pp : yes
+fields:
+- i : int
+- next : instruction list
+params:
+- v
+code: |
+  match v with
+  | IntegerConstant(i0) when i=i0 ->
+    exec stack env code dump
+  | _ -> 
+    exec stack env next dump
+
+---
+inst: CheckStackTopListCons
+suppress-pp : yes
+fields:
+- next : instruction list
+params:
+- v
+code: |
+  match v with
+  | ListCons(car, cdr) ->
+    exec (car::cdr::stack) env code dump
+  | _ -> 
+    exec stack env next dump
+
+---
+inst: CheckStackTopStr
+suppress-pp : yes
+fields:
+- str : string
+- next : instruction list
+params:
+- v
+code: |
+  match v with
+  | StringConstant(s0) when s0=str ->
+    exec stack env code dump
+  | _ -> 
+    exec stack env next dump
+
+---
+inst: CheckStackTopTupleCons
+suppress-pp : yes
+fields:
+- next : instruction list
+params:
+- v 
+code: |
+  match v with
+  | TupleCons(car, cdr) ->
+    exec (car::cdr::stack) env code dump
+  | _ -> 
+    exec stack env next dump
+
+---
+inst: Closure
+fields:
+- arity : int
+- framesize : int
+- body : instruction list
+code: |
+  exec (CompiledFuncWithEnvironment(arity, [], framesize, body, env)::stack) env code dump
+
+---
+inst: ClosureInputHorz
+fields:
+- body : syntactic_value
+code: |
+  let imihclos = get_input_horz_content env body in
+    exec (imihclos::stack) env code dump
+
+---
+inst: ClosureInputVert
+fields:
+- body : syntactic_value
+code: |
+  let imivclos = get_input_vert_content env body in
+    exec (imivclos::stack) env code dump
+
+---
+inst: BindLocationGlobal
+fields:
+- loc : syntactic_value ref
+- evid : EvalVarID.t
+params:
+- valueini
+code: |
+  let stid = register_location (vmenv_global env) valueini in
+    loc := Location(stid);
+    exec stack env code dump
+
+---
+inst: BindLocationLocal
+fields:
+- lv : int
+- offset : int
+- evid : EvalVarID.t
+params:
+- valueini
+code: |
+  let stid = register_location (vmenv_global env) valueini in
+    local_set_value env lv offset (Location(stid));
+    exec stack env code dump
+
+---
+inst: UpdateGlobal
+suppress-pp : yes
+fields:
+- loc : syntactic_value ref
+- evid : EvalVarID.t
+params:
+- valuenew
+code: |
+   match !loc with
+   | Location(stid) ->
+      begin
+        update_location (vmenv_global env) stid valuenew;
+        exec (UnitConstant::stack) env code dump
+      end
+
+   | _ -> report_bug_vm "UpdateGlobal"
+
+---
+inst: UpdateLocal
+suppress-pp : yes
+fields:
+- lv : int
+- offset : int
+- evid : EvalVarID.t
+params:
+- valuenew
+code: |
+  match local_get_value env lv offset with
+  | Location(stid) ->
+     begin
+       update_location (vmenv_global env) stid valuenew;
+       exec (UnitConstant::stack) env code dump
+     end
+
+  | _ -> report_bug_vm "UpdateLocal"
+
+---
+inst: Sel
+fields:
+- tpart : instruction list
+- fpart : instruction list
+suppress-pp: yes
+params:
+- b : bool
+code: |
+  if b then
+    exec stack env tpart dump
+  else
+    exec stack env fpart dump
+
+---
+inst: Concat 
+is-primitive: yes 
+params:
+- value1
+- value2
+code: |
+  match (value1, value2) with
+  | (StringEmpty, _)   -> value2
+  | (_, StringEmpty)   -> value1
+  | (StringConstant(s1), StringConstant(s2)) -> StringConstant(s1 ^ s2)
+  | _  -> report_bug_vm "Concat"
+  
+---
+inst: PrimitiveSetMathVariantToChar 
+is-primitive: yes 
+params:
+- s : string
+- mccls : math_char_class
+- mathcls : math_class
+- uchlst : uchar_list
+- (ctx, v) : context
+code: | 
+  let mvvalue = (mathcls, HorzBox.MathVariantToChar(false, uchlst)) in
+  let mcclsmap = ctx.HorzBox.math_variant_char_map in
+    Context(HorzBox.({ ctx with math_variant_char_map = mcclsmap |> MathVariantCharMap.add (s, mccls) mvvalue }), v)
+  
+---
+inst: PrimitiveSetMathCommand 
+is-primitive: yes 
+params:
+- valuecmd
+- (ctx, _) : context
+code: |
+  Context(ctx, valuecmd)
+  
+---
+inst: BackendMathVariantCharDirect 
+is-primitive: yes 
+params:
+- mathcls : math_class
+- valuercd
+code: |
+  let is_big = false in  (* temporary *)
+  let rcd =
+    match valuercd with
+    | RecordValue(rcd) -> rcd
+    | _  -> report_bug_vm "BackendMathVariantCharDirect not a record"
+  in
+  begin
+    match
+      ( Assoc.find_opt rcd "italic",
+        Assoc.find_opt rcd "bold-italic",
+        Assoc.find_opt rcd "roman",
+        Assoc.find_opt rcd "bold-roman",
+        Assoc.find_opt rcd "script",
+        Assoc.find_opt rcd "bold-script",
+        Assoc.find_opt rcd "fraktur",
+        Assoc.find_opt rcd "bold-fraktur",
+        Assoc.find_opt rcd "double-struck" )
+    with
+    | ( Some(vcpI),
+        Some(vcpBI),
+        Some(vcpR),
+        Some(vcpBR),
+        Some(vcpS),
+        Some(vcpBS),
+        Some(vcpF),
+        Some(vcpBF),
+        Some(vcpDS) ) ->
+          let uchlstI  = get_uchar_list vcpI  in
+          let uchlstBI = get_uchar_list vcpBI in
+          let uchlstR  = get_uchar_list vcpR  in
+          let uchlstBR = get_uchar_list vcpBR in
+          let uchlstS  = get_uchar_list vcpS  in
+          let uchlstBS = get_uchar_list vcpBS in
+          let uchlstF  = get_uchar_list vcpF  in
+          let uchlstBF = get_uchar_list vcpBF in
+          let uchlstDS = get_uchar_list vcpDS in
+          let mvsty =
+            HorzBox.({
+              math_italic  = uchlstI ;
+              math_bold_italic   = uchlstBI;
+              math_roman   = uchlstR ;
+              math_bold_roman    = uchlstBR;
+              math_script  = uchlstS ;
+              math_bold_script   = uchlstBS;
+              math_fraktur       = uchlstF ;
+              math_bold_fraktur  = uchlstBF;
+              math_double_struck = uchlstDS;
+     })
+      in
+        MathValue(HorzBox.([MathPure(MathVariantCharDirect(mathcls, is_big, mvsty))]))
+  
+    | _ -> report_bug_vm "BackendMathVariantCharDirect missing some field"
+    end
+ 
+---
+inst: BackendMathConcat 
+is-primitive: yes 
+params:
+- mlst1 : math
+- mlst2 : math
+code: |
+  MathValue(List.append mlst1 mlst2)
+  
+---
+inst: BackendMathGroup 
+is-primitive: yes 
+params:
+- mathcls1 : math_class
+- mathcls2 : math_class
+- mlst : math
+code: |
+  MathValue([MathGroup(mathcls1, mathcls2, mlst)])
+  
+---
+inst: BackendMathSuperscript 
+is-primitive: yes 
+params:
+- mlst1 : math
+- mlst2 : math
+code: |
+  MathValue([MathSuperscript(mlst1, mlst2)])
+  
+---
+inst: BackendMathSubscript 
+is-primitive: yes 
+params:
+- mlst1 : math
+- mlst2 : math
+code: |
+  MathValue([MathSubscript(mlst1, mlst2)])
+  
+---
+inst: BackendMathFraction 
+is-primitive: yes 
+params:
+- mlst1 : math
+- mlst2 : math
+code: |
+  MathValue([MathFraction(mlst1, mlst2)])
+  
+---
+inst: BackendMathRadical 
+is-primitive: yes 
+params:
+- mlst1opt
+- mlst2 : math
+code: |
+  let mlst1opt = get_option (fun v -> match v with
+                                      | MathValue(mlst) -> mlst
+                                      | _ -> report_bug_vm "MathValue expected"
+  ) mlst1opt in
+  let radical = Primitives.default_radical in  (* temporary; should be variable *)
+    match mlst1opt with
+    | None  -> MathValue([MathRadical(radical, mlst2)])
+    | Some(mlst1) -> MathValue([MathRadicalWithDegree(mlst1, mlst2)])
+ 
+---
+inst: BackendMathParen 
+is-primitive: yes 
+params:
+- valueparenL
+- valueparenR
+- mlst1 : math
+code: |
+  let parenL = make_paren env valueparenL in
+  let parenR = make_paren env valueparenR in
+    MathValue([MathParen(parenL, parenR, mlst1)])
+  
+---
+inst: BackendMathUpperLimit 
+is-primitive: yes 
+params:
+- mlst1 : math
+- mlst2 : math
+code: |
+  MathValue([MathUpperLimit(mlst1, mlst2)])
+  
+---
+inst: BackendMathLowerLimit 
+is-primitive: yes 
+params:
+- mlst1 : math
+- mlst2 : math
+code: |
+  MathValue([MathLowerLimit(mlst1, mlst2)])
+  
+---
+inst: BackendMathChar 
+is-primitive: yes 
+params:
+- mathcls : math_class
+- s : string
+code: |
+  let uchlst = (InternalText.to_uchar_list (InternalText.of_utf8 s)) in
+  let mlst = [HorzBox.(MathPure(MathElement(mathcls, MathChar(false, uchlst))))] in
+    MathValue(mlst)
+
+---
+inst: BackendMathBigChar 
+is-primitive: yes 
+params:
+- mathcls : math_class
+- s : string
+code: |
+  let uchlst = (InternalText.to_uchar_list (InternalText.of_utf8 s)) in
+  let mlst = [HorzBox.(MathPure(MathElement(mathcls, MathChar(true, uchlst))))] in
+    MathValue(mlst)
+
+---
+inst: BackendMathCharWithKern 
+is-primitive: yes 
+params:
+- mathcls : math_class
+- s : string
+- valuekernfL
+- valuekernfR
+code: |
+  let uchlst = (InternalText.to_uchar_list (InternalText.of_utf8 s)) in
+  let kernfL = make_math_char_kern_func env valuekernfL in
+  let kernfR = make_math_char_kern_func env valuekernfR in
+  let mlst = [HorzBox.(MathPure(MathElement(mathcls, MathCharWithKern(false, uchlst, kernfL, kernfR))))] in
+    MathValue(mlst)
+
+---
+inst: BackendMathBigCharWithKern 
+is-primitive: yes 
+params:
+- mathcls : math_class
+- s : string
+- valuekernfL
+- valuekernfR
+code: |
+  let uchlst = (InternalText.to_uchar_list (InternalText.of_utf8 s)) in
+  let kernfL = make_math_char_kern_func env valuekernfL in
+  let kernfR = make_math_char_kern_func env valuekernfR in
+  let mlst = [HorzBox.(MathPure(MathElement(mathcls, MathCharWithKern(true, uchlst, kernfL, kernfR))))] in
+    MathValue(mlst)
+  
+---
+inst: BackendMathText 
+is-primitive: yes 
+params:
+- mathcls : math_class
+- valuef
+code: |
+  let hblstf ictx =
+    match exec [valuef; Context(ictx)] env [OpApplyT(1)] [] with
+    | Horz(h) -> h
+    | _ -> report_bug_vm "Horz expected"
+  in
+    MathValue(HorzBox.([MathPure(MathElement(mathcls, MathEmbeddedText(hblstf)))]))
+  
+---
+inst: BackendMathColor 
+is-primitive: yes 
+params:
+- color : color
+- mlst : math
+code: |
+  MathValue(HorzBox.([MathChangeContext(MathChangeColor(color), mlst)]))
+  
+---
+inst: BackendMathCharClass 
+is-primitive: yes 
+params:
+- mccls : math_char_class
+- mlst : math
+code: |
+  MathValue(HorzBox.([MathChangeContext(MathChangeMathCharClass(mccls), mlst)]))
+
+---
+inst: BackendMathList
+no-ircode: yes
+fields:
+- n : int
+code: |
+  let rec iter n st acc =
+    match n with 
+    | 0 -> (acc, st)
+    | n ->
+      begin
+        match st with
+        | MathValue(m) :: stnew -> iter (n-1) stnew (m::acc)
+        | _ -> report_bug_vm "BackendMathList"
+      end
+  in
+  let (mlst, stack) = iter n stack [] in
+    exec (MathValue(List.concat mlst)::stack) env code dump
+ 
+---
+inst: BackendEmbeddedMath 
+is-primitive: yes 
+params:
+- ictx : context
+- mlst : math
+code: |
+  let mathctx = MathContext.make ictx in
+  let hblst = Math.main mathctx mlst in
+    Horz(hblst)
+  
+---
+inst: BackendTabular 
+is-primitive: yes 
+params:
+- tabular
+- valuerulesf
+code: |
+  let tabular = get_list (get_list get_cell) tabular in
+  let (imtabular, widlst, lenlst, wid, hgt, dpt) = Tabular.main tabular in
+  let rulesf xs ys =
+    let valueret =
+      exec [valuerulesf; make_length_list ys; make_length_list xs] env [OpApplyT(2)] []
+    in
+      graphics_of_list valueret
+  in
+    Horz(HorzBox.([HorzPure(PHGFixedTabular(wid, hgt, dpt, imtabular, widlst, lenlst, rulesf))]))
+  
+---
+inst: BackendRegisterPdfImage 
+is-primitive: yes 
+params:
+- srcpath : string
+- pageno : int
+code: |
+  let imgkey = ImageInfo.add_pdf srcpath pageno in
+    ImageKey(imgkey)
+  
+---
+inst: BackendRegisterOtherImage 
+is-primitive: yes 
+params:
+- srcpath : string
+code: |
+  let imgkey = ImageInfo.add_image srcpath in
+    ImageKey(imgkey)
+  
+---
+inst: BackendUseImageByWidth 
+is-primitive: yes 
+params:
+- valueimg
+- wid : length
+code: | 
+  match valueimg with
+  | ImageKey(imgkey) ->
+     let hgt = ImageInfo.get_height_from_width imgkey wid in
+       Horz(HorzBox.([HorzPure(PHGFixedImage(wid, hgt, imgkey))]))
+  
+  | _ -> report_bug_vm "BackendUseImage"
+  
+---
+inst: BackendHookPageBreak 
+is-primitive: yes 
+params:
+- hookf
+code: |
+  let hookf = make_hook env hookf in
+    Horz(HorzBox.([HorzPure(PHGHookPageBreak(hookf))]))
+  
+---
+inst: Path
+suppress-pp : yes
+is-primitive : yes
+no-ircode : yes
+fields:
+- c_pathcomplst : ((instruction list) compiled_path_component) list
+- c_cycleopt : (unit compiled_path_component) option
+params:
+- pt0 : point
+code: |
+  let (pathelemlst, closingopt) = get_path env c_pathcomplst c_cycleopt in
+    PathValue([GraphicData.GeneralPath(pt0, pathelemlst, closingopt)])
+  
+---
+inst: PathUnite 
+is-primitive: yes 
+params:
+- pathlst1 : path_value
+- pathlst2 : path_value
+code: |
+  PathValue(List.append pathlst1 pathlst2)
+  
+---
+inst: PrePathBeginning 
+is-primitive: yes 
+params:
+- pt0 : point
+code: |
+  PrePathValue(PrePath.start pt0)
+  
+---
+inst: PrePathLineTo 
+is-primitive: yes 
+params:
+- pt1 : point
+- prepath : prepath
+code: |
+  PrePathValue(prepath |> PrePath.line_to pt1)
+  
+---
+inst: PrePathCubicBezierTo 
+is-primitive: yes 
+params:
+- ptS : point
+- ptT : point
+- pt1 : point
+- prepath: prepath
+code: |
+  PrePathValue(prepath |> PrePath.bezier_to ptS ptT pt1)
+  
+---
+inst: PrePathTerminate 
+is-primitive: yes 
+params:
+- prepath : prepath
+code: |
+  PathValue([prepath |> PrePath.terminate])
+  
+---
+inst: PrePathCloseWithLine 
+is-primitive: yes 
+params:
+- prepath : prepath
+code: |
+  PathValue([prepath |> PrePath.close_with_line])
+  
+---
+inst: PrePathCloseWithCubicBezier 
+is-primitive: yes 
+params:
+- ptS : point
+- ptT : point
+- prepath : prepath
+code: |
+  PathValue([prepath |> PrePath.close_with_bezier ptS ptT])
+  
+---
+inst: HorzConcat 
+is-primitive: yes 
+params:
+- hblst1 : horz
+- hblst2 : horz
+code: |
+  Horz(List.append hblst1 hblst2)
+  
+---
+inst: VertConcat 
+is-primitive: yes 
+params:
+- vblst1 : vert
+- vblst2 : vert
+code: |
+  Vert(List.append vblst1 vblst2)
+  
+---
+inst: HorzLex 
+is-primitive: yes 
+params:
+- valuectx
+- value1
+code: |
+  match value1 with
+  | CompiledInputHorzWithEnvironment(imihlst, envi) -> 
+     exec_intermediate_input_horz envi valuectx imihlst
+  (*| InputHorzWithEnvironment(imihlst, envi) -> 
+     Evaluator.interpret_intermediate_input_horz envi valuectx imihlst*)
+  | _         -> report_bug_vm "HorzLex"
+  
+---
+inst: VertLex 
+is-primitive: yes 
+params:
+- valuectx
+- value1
+code: |
+  match value1 with
+  | CompiledInputVertWithEnvironment(imivlst, envi) ->
+     exec_intermediate_input_vert envi valuectx imivlst
+  | _         -> report_bug_vm "VertLex"
+  
+---
+inst: BackendFont 
+is-primitive: yes 
+params:
+- abbrev : string
+- size_ratio : float
+- rising_ratio : float
+code: |
+  make_font_value (abbrev, size_ratio, rising_ratio)
+  
+---
+inst: BackendLineBreaking 
+is-primitive: yes 
+params:
+- is_breakable_top : bool
+- is_breakable_bottom : bool
+- (ctx,  _) : context
+- hblst : horz
+code: | 
+  let imvblst = HorzBox.(LineBreak.main is_breakable_top is_breakable_bottom ctx.paragraph_top ctx.paragraph_bottom ctx hblst) in
+    Vert(imvblst)
+  
+---
+inst: BackendPageBreaking 
+is-primitive: yes 
+params:
+- pagesize : page_size
+- pagecontf
+- pagepartsf
+- vblst : vert
+code: |
+  let pagecontf = make_page_content_scheme_func env pagecontf in
+  let pagepartsf = make_page_parts_scheme_func env pagepartsf in
+    DocumentValue(pagesize, pagecontf, pagepartsf, vblst)
+  
+---
+inst: BackendVertFrame 
+is-primitive: yes 
+params:
+- (ctx, valuecmd) : context
+- pads : paddings
+- (valuedecoS, valuedecoH, valuedecoM, valuedecoT) : decoset
+- valuek
+code: |
+  let valuectxsub =
+    Context(HorzBox.({ ctx with paragraph_width = HorzBox.(ctx.paragraph_width -% pads.paddingL -% pads.paddingR) }), valuecmd)
+  in
+  let vblst = 
+    match exec [valuek; valuectxsub] env [OpApplyT(1)] [] with
+    | Vert(v) -> v
+    | _ -> report_bug_vm "BackendVertFrame"
+  in
+    Vert(HorzBox.([
+      VertTopMargin(true, ctx.paragraph_top);
+      VertFrame(pads,
+                  make_frame_deco env valuedecoS,
+                  make_frame_deco env valuedecoH,
+                  make_frame_deco env valuedecoM,
+                  make_frame_deco env valuedecoT,
+                  ctx.paragraph_width, vblst);
+      VertBottomMargin(true, ctx.paragraph_bottom);
+  ]))
+  
+---
+inst: BackendEmbeddedVertTop 
+is-primitive: yes 
+params:
+- (ctx, valuecmd) : context
+- wid : length
+- valuek
+code: |
+  let valuectxsub =
+    Context(HorzBox.({ ctx with paragraph_width = wid; }), valuecmd)
+  in
+  let vblst = 
+    match exec [valuek; valuectxsub] env [OpApplyT(1)] [] with
+    | Vert(v) -> v
+    | _ -> report_bug_vm "BackendEmbeddedVertTop"
+  in
+  let imvblst = PageBreak.solidify vblst in
+  let (hgt, dpt) = adjust_to_first_line imvblst in
+    Horz(HorzBox.([HorzPure(PHGEmbeddedVert(wid, hgt, dpt, imvblst))]))
+  
+---
+inst: BackendVertSkip 
+is-primitive: yes 
+params:
+- len : length
+code: |
+  Vert(HorzBox.([VertFixedBreakable(len)]))
+  
+---
+inst: BackendEmbeddedVertBottom 
+is-primitive: yes 
+params:
+- (ctx, valuecmd) : context
+- wid : length
+- valuek
+code: |
+  let valuectxsub =
+    Context(HorzBox.({ ctx with paragraph_width = wid; }), valuecmd)
+  in
+  let vblst = 
+    match exec [valuek; valuectxsub] env [OpApplyT(1)] [] with
+    | Vert(v) -> v
+    | _ -> report_bug_vm "BackendEmbeddedVertBottom"
+  in
+  let imvblst = PageBreak.solidify vblst in
+  let (hgt, dpt) = adjust_to_last_line imvblst in
+    Horz(HorzBox.([HorzPure(PHGEmbeddedVert(wid, hgt, dpt, imvblst))]))
+  
+---
+inst: BackendLineStackTop 
+is-primitive: yes 
+params:
+- hblstlst
+code: |
+  let hblstlst = get_list (fun v -> match v with 
+                                    | Horz(h) -> h
+                                    | _ -> report_bug_vm "BackendLineStackTop"
+  ) hblstlst 
+  in
+  let (wid, vblst) = make_line_stack hblstlst in
+  let imvblst = PageBreak.solidify vblst in
+  let (hgt, dpt) = adjust_to_first_line imvblst in
+    Horz(HorzBox.([HorzPure(PHGEmbeddedVert(wid, hgt, dpt, imvblst))]))
+  
+---
+inst: BackendLineStackBottom 
+is-primitive: yes 
+params:
+- hblstlst
+code: |
+  let hblstlst = get_list (fun v -> match v with
+                                    | Horz(h) -> h
+                                    | _ -> report_bug_vm "BackendLineStackBottom"
+  ) hblstlst
+  in
+  let (wid, vblst) = make_line_stack hblstlst in
+  let imvblst = PageBreak.solidify vblst in
+  let (hgt, dpt) = adjust_to_last_line imvblst in
+    Horz(HorzBox.([HorzPure(PHGEmbeddedVert(wid, hgt, dpt, imvblst))]))
+  
+---
+inst: PrimitiveGetInitialContext 
+is-primitive: yes 
+params:
+- txtwid : length
+- valuecmd
+code: |
+  Context(Primitives.get_initial_context txtwid, valuecmd)
+  
+---
+inst: PrimitiveSetSpaceRatio 
+is-primitive: yes 
+params:
+- ratio : float
+- (ctx, valuecmd) : context
+code: |
+  Context(HorzBox.({ ctx with space_natural = ratio; }), valuecmd)
+  
+---
+inst: PrimitiveSetParagraphMargin 
+is-primitive: yes 
+params:
+- lentop : length
+- lenbottom : length
+- (ctx, valuecmd) : context 
+code: | 
+  Context(HorzBox.({ ctx with
+    paragraph_top    = lentop;
+    paragraph_bottom = lenbottom;
+  }), valuecmd)
+  
+---
+inst: PrimitiveSetFontSize 
+is-primitive: yes 
+params:
+- size : length
+- (ctx, valuecmd) : context
+code: |
+  Context(HorzBox.({ ctx with font_size = size; }), valuecmd)
+  
+---
+inst: PrimitiveGetFontSize 
+is-primitive: yes 
+params:
+- (ctx, _) : context
+code: |
+  LengthConstant(ctx.HorzBox.font_size)
+  
+---
+inst: PrimitiveSetFont 
+is-primitive: yes 
+params:
+- script : script
+- font_info : font
+- (ctx, valuecmd) : context
+code: |
+  let font_scheme_new = HorzBox.(ctx.font_scheme |> CharBasis.ScriptSchemeMap.add script font_info) in
+    Context(HorzBox.({ ctx with font_scheme = font_scheme_new; }), valuecmd)
+  
+---
+inst: PrimitiveGetFont 
+is-primitive: yes 
+params:
+- script : script
+- (ctx, _) : context
+code: |
+  let fontwr = HorzBox.get_font_with_ratio ctx script in
+    make_font_value fontwr
+  
+---
+inst: PrimitiveSetMathFont 
+is-primitive: yes 
+params:
+- mfabbrev : string
+- (ctx, valuecmd) : context
+code: |
+  Context(HorzBox.({ ctx with math_font = mfabbrev; }), valuecmd)
+  
+---
+inst: PrimitiveSetDominantWideScript 
+is-primitive: yes 
+params:
+- script: script
+- (ctx, valuecmd) : context
+code: |
+  Context(HorzBox.({ ctx with dominant_wide_script = script; }), valuecmd)
+  
+---
+inst: PrimitiveGetDominantWideScript 
+is-primitive: yes 
+params:
+- (ctx, _) : context
+code: |
+  make_script_value ctx.HorzBox.dominant_wide_script
+  
+---
+inst: PrimitiveSetDominantNarrowScript 
+is-primitive: yes 
+params:
+- script : script
+- (ctx, valuecmd) : context
+code: |
+  Context(HorzBox.({ ctx with dominant_narrow_script = script; }), valuecmd)
+  
+---
+inst: PrimitiveGetDominantNarrowScript 
+is-primitive: yes 
+params:
+- (ctx, _) : context
+code: |
+  make_script_value ctx.HorzBox.dominant_narrow_script
+  
+---
+inst: PrimitiveSetLangSys 
+is-primitive: yes 
+params:
+- script : script
+- langsys : language_system
+- (ctx, valuecmd) : context
+code: |
+  Context(HorzBox.({ ctx with langsys_scheme = ctx.langsys_scheme |> CharBasis.ScriptSchemeMap.add script langsys}), valuecmd)
+  
+---
+inst: PrimitiveGetLangSys 
+is-primitive: yes 
+params:
+- script : script
+- (ctx, _) : context
+code: |
+  let langsys = HorzBox.get_language_system ctx script in
+    make_language_system_value langsys
+  
+---
+inst: PrimitiveSetTextColor 
+is-primitive: yes 
+params:
+- color : color
+- (ctx, valuecmd) : context
+code: |
+  Context(HorzBox.({ ctx with text_color = color; }), valuecmd)
+  
+---
+inst: PrimitiveGetTextColor 
+is-primitive: yes 
+params:
+- (ctx, _) : context
+code: |
+  let color = ctx.HorzBox.text_color in
+    make_color_value color
+  
+---
+inst: PrimitiveSetLeading 
+is-primitive: yes 
+params:
+- len : length
+- (ctx, valuecmd) : context
+code: |
+  Context(HorzBox.({ ctx with leading = len; }), valuecmd)
+  
+---
+inst: PrimitiveGetTextWidth 
+is-primitive: yes 
+params:
+- (ctx, _) : context
+code: |
+  LengthConstant(ctx.HorzBox.paragraph_width)
+  
+---
+inst: PrimitiveSetManualRising 
+is-primitive: yes 
+params:
+- rising : length
+- (ctx, valuecmd) : context
+code: |
+  Context(HorzBox.({ ctx with manual_rising = rising; }), valuecmd)
+  
+---
+inst: PrimitiveSetHyphenPenalty 
+is-primitive: yes 
+params:
+- pnlty : int
+- (ctx, valuecmd) : context
+code: |
+  Context(HorzBox.({ ctx with hyphen_badness = pnlty; }), valuecmd)
+  
+---
+inst: PrimitiveEmbed 
+is-primitive: yes 
+params:
+- str : string
+code: |
+  CompiledInputHorzWithEnvironment([CompiledImInputHorzText(str)], env)
+  
+---
+inst: PrimitiveGetAxisHeight 
+is-primitive: yes 
+params:
+- (ctx, _) : context
+code: |
+  let fontsize = ctx.HorzBox.font_size in
+  let mfabbrev = ctx.HorzBox.math_font in
+  let hgt = FontInfo.get_axis_height mfabbrev fontsize in
+    LengthConstant(hgt)
+  
+---
+inst: BackendFixedEmpty 
+is-primitive: yes 
+params:
+- wid : length
+code: |
+  Horz([HorzBox.HorzPure(HorzBox.PHSFixedEmpty(wid))])
+  
+---
+inst: BackendOuterEmpty 
+is-primitive: yes 
+params:
+- widnat : length
+- widshrink : length
+- widstretch : length
+code: |
+  Horz([HorzBox.HorzPure(HorzBox.PHSOuterEmpty(widnat, widshrink, widstretch))])
+  
+---
+inst: BackendOuterFrame 
+is-primitive: yes 
+params:
+- pads : paddings
+- valuedeco
+- hblst : horz
+code: |
+  Horz([HorzBox.HorzPure(HorzBox.PHGOuterFrame(
+    pads,
+    make_frame_deco env valuedeco,
+    hblst))])
+  
+---
+inst: BackendInnerFrame 
+is-primitive: yes 
+params:
+- pads : paddings
+- valuedeco
+- hblst : horz
+code: |
+  Horz([HorzBox.HorzPure(HorzBox.PHGInnerFrame(
+    pads,
+    make_frame_deco env valuedeco,
+    hblst))])
+  
+---
+inst: BackendFixedFrame 
+is-primitive: yes 
+params:
+- wid : length
+- pads : paddings
+- hblst : horz
+- valuedeco
+code: | 
+  Horz([HorzBox.HorzPure(HorzBox.PHGFixedFrame(
+    pads, wid,
+    make_frame_deco env valuedeco,
+    hblst))])
+  
+---
+inst: BackendOuterFrameBreakable 
+is-primitive: yes 
+params:
+- pads : paddings
+- (valuedecoS, valuedecoH, valuedecoM, valuedecoT) : decoset
+- hblst : horz
+code: | 
+  Horz([HorzBox.HorzFrameBreakable(
+    pads, Length.zero, Length.zero,
+    make_frame_deco env valuedecoS,
+    make_frame_deco env valuedecoH,
+    make_frame_deco env valuedecoM,
+    make_frame_deco env valuedecoT,
+    hblst
+  )])
+  
+---
+inst: BackendInlineGraphics 
+is-primitive: yes 
+params:
+- wid : length
+- hgt : length
+- dpt : length
+- valueg
+code: | 
+  let graphics = make_inline_graphics env valueg in
+    Horz(HorzBox.([HorzPure(PHGFixedGraphics(wid, hgt, Length.negate dpt, graphics))]))
+  
+---
+inst: BackendScriptGuard 
+is-primitive: yes 
+params:
+- script : script
+- hblst : horz
+code: |
+  Horz(HorzBox.([HorzScriptGuard(script, hblst)]))
+  
+---
+inst: BackendDiscretionary 
+is-primitive: yes 
+params:
+- pb : int
+- hblst0 : horz
+- hblst1 : horz
+- hblst2 : horz
+code: |
+  Horz(HorzBox.([HorzDiscretionary(pb, hblst0, hblst1, hblst2)]))
+  
+---
+inst: BackendRegisterCrossReference 
+is-primitive: yes 
+params:
+- k : string
+- v : string
+code: |
+  CrossRef.register k v;
+  UnitConstant
+  
+---
+inst: BackendGetCrossReference 
+is-primitive: yes 
+params:
+- k : string
+code: |
+  match CrossRef.get k with
+  | None    -> Constructor("None", UnitConstant)
+  | Some(v) -> Constructor("Some", StringConstant(v))
+
+---
+inst: PrimitiveGetNaturalWidth 
+is-primitive: yes 
+params:
+- hblst : horz
+code: |
+  let (wid, _, _) = LineBreak.get_natural_metrics hblst in
+    LengthConstant(wid)
+  
+---
+inst: PrimitiveGetNaturalLength 
+is-primitive: yes 
+params:
+- vblst : vert
+code: |
+  let imvblst = PageBreak.solidify vblst in
+  let (hgt, dpt) = adjust_to_first_line imvblst in
+    LengthConstant(hgt +% (Length.negate dpt))
+  
+---
+inst: PrimitiveDisplayMessage 
+is-primitive: yes 
+params:
+- str : string
+code: |
+  print_endline str;
+  UnitConstant
+  
+---
+inst: PrimitiveListCons 
+is-primitive: yes 
+params:
+- valuehd
+- valuetl
+code: |
+  ListCons(valuehd, valuetl)
+  
+---
+inst: PrimitiveSame 
+is-primitive: yes 
+params:
+- str1 : string
+- str2 : string
+code: |
+  BooleanConstant(String.equal str1 str2)
+ 
+---
+inst: PrimitiveStringSub 
+is-primitive: yes 
+params:
+- str : string
+- pos : int
+- wid : int
+code: |
+  let resstr =
+  try String.sub str pos wid with
+  | Invalid_argument(s) -> raise (ExecError("illegal index for string-sub"))
+  in
+    StringConstant(resstr)
+
+---
+inst: PrimitiveStringLength 
+is-primitive: yes
+params:
+- str : string
+code: |
+  IntegerConstant(String.length str)
+  
+---
+inst: PrimitiveStringUnexplode 
+is-primitive: yes 
+params:
+- ilst
+code: |
+  let ilst = get_list (fun v -> match v with
+                                | IntegerConstant(i) -> i
+                                | _ -> report_bug_vm "PrimitiveStringUnexplode"
+  ) ilst
+  in
+  let s = (List.map Uchar.of_int ilst) |> InternalText.of_uchar_list |> InternalText.to_utf8 in
+    StringConstant(s)
+  
+---
+inst: PrimitiveRegExpOfString 
+is-primitive: yes 
+params:
+- str : string
+code: |
+  let regexp =
+    try Str.regexp str with
+    | Failure(msg) -> raise (ExecError("regexp-of-string" ^ msg))
+  in
+    RegExpConstant(regexp)
+  
+---
+inst: PrimitiveStringMatch 
+is-primitive: yes 
+params:
+- pat : regexp
+- s : string
+code: |
+  BooleanConstant(Str.string_match pat s 0)
+  
+---
+inst: PrimitiveSplitIntoLines 
+is-primitive: yes 
+params:
+- s : string
+code: |
+  let slst = String.split_on_char '\n' s in
+  let pairlst = slst |> List.map chop_space_indent in
+    (pairlst |> make_list (fun (i, s) ->
+      TupleCons(IntegerConstant(i), TupleCons(StringConstant(s), EndOfTuple))))
+  
+  
+---
+inst: PrimitiveSplitOnRegExp 
+is-primitive: yes 
+params:
+- sep : regexp
+- str : string
+code: |
+  let slst = Str.split sep str in
+  let pairlst = slst |> List.map chop_space_indent in
+    (pairlst |> make_list (fun (i, s) ->
+      TupleCons(IntegerConstant(i), TupleCons(StringConstant(s), EndOfTuple))))
+  
+  
+---
+inst: PrimitiveArabic 
+is-primitive: yes 
+params:
+- num : int
+code: |
+  StringConstant(string_of_int num)
+  
+---
+inst: PrimitiveFloat 
+is-primitive: yes 
+params:
+- ic1 : int
+code: | 
+  FloatConstant(float_of_int ic1)
+  
+---
+inst: PrimitiveRound 
+is-primitive: yes 
+params:
+- fc1 : float
+code: |
+  IntegerConstant(int_of_float fc1)
+  
+---
+inst: PrimitiveDrawText 
+is-primitive: yes 
+params:
+- pt : point
+- hblst : horz
+code: |
+  let (imhblst, _, _) = LineBreak.natural hblst in
+  let grelem = Graphics.make_text pt imhblst in
+    GraphicsValue(grelem)
+  
+---
+inst: PrimitiveDrawStroke 
+is-primitive: yes 
+params:
+- wid : length
+- color : color
+- pathlst : path_value
+code: |
+  let grelem = Graphics.make_stroke wid color pathlst in
+    GraphicsValue(grelem)
+  
+---
+inst: PrimitiveDrawFill 
+is-primitive: yes 
+params:
+- color : color
+- pathlst : path_value
+code: |
+  let grelem = Graphics.make_fill color pathlst in
+    GraphicsValue(grelem)
+  
+---
+inst: PrimitiveDrawDashedStroke
+is-primitive: yes 
+params:
+- wid : length
+- tup3
+- color : color
+- pathlst : path_value
+code: | 
+  let (len1, len2, len3) = get_tuple3 (fun value ->
+    match value with
+    | LengthConstant(len) -> len
+    | _ -> report_bug_vm "PrimitiveDrawDashedStroke"
+  ) tup3
+  in
+  let grelem = Graphics.make_dashed_stroke wid (len1, len2, len3) color pathlst in
+    GraphicsValue(grelem)
+  
+---
+inst: Times 
+is-primitive: yes 
+params:
+- numl : int
+- numr : int
+code: |
+  IntegerConstant(numl * numr)
+  
+---
+inst: Divides 
+is-primitive: yes 
+params:
+- numl : int
+- numr : int
+code: |
+  try IntegerConstant(numl / numr) with
+  | Division_by_zero -> raise (ExecError("division by zero"))
+
+---
+inst: Mod 
+is-primitive: yes 
+params:
+- numl : int
+- numr : int
+code: |
+  try IntegerConstant(numl mod numr) with
+  | Division_by_zero -> raise (ExecError("division by zero"))
+  
+---
+inst: Plus 
+is-primitive: yes 
+params:
+- numl : int
+- numr : int
+code: |
+  IntegerConstant(numl + numr)
+  
+---
+inst: Minus 
+is-primitive: yes 
+params:
+- numl : int
+- numr : int
+code: |
+  IntegerConstant(numl - numr)
+  
+---
+inst: EqualTo 
+is-primitive: yes 
+params:
+- numl : int
+- numr : int
+code: |
+  BooleanConstant(numl = numr)
+
+---
+inst: GreaterThan 
+is-primitive: yes 
+params:
+- numl : int
+- numr : int
+code: |
+  BooleanConstant(numl > numr)
+  
+---
+inst: LessThan 
+is-primitive: yes 
+params:
+- numl : int
+- numr : int
+code: |
+  BooleanConstant(numl < numr)
+  
+---
+inst: LogicalAnd 
+is-primitive: yes 
+params:
+- binl : bool
+- binr : bool
+code: |
+  BooleanConstant(binl && binr)
+  
+---
+inst: LogicalOr 
+is-primitive: yes 
+params:
+- binl : bool
+- binr : bool
+code: |
+  BooleanConstant(binl || binr)
+  
+---
+inst: LogicalNot 
+is-primitive: yes 
+params:
+- binl : bool
+code: |
+  BooleanConstant(not binl)
+  
+---
+inst: FloatPlus 
+is-primitive: yes 
+params:
+- flt1 : float
+- flt2 : float
+code: |
+  FloatConstant(flt1 +. flt2)
+  
+---
+inst: FloatMinus 
+is-primitive: yes 
+params:
+- flt1 : float
+- flt2 : float
+code: |
+  FloatConstant(flt1 -. flt2)
+  
+---
+inst: FloatTimes 
+is-primitive: yes 
+params:
+- flt1 : float
+- flt2 : float
+code: |
+  FloatConstant(flt1 *. flt2)
+  
+---
+inst: FloatDivides 
+is-primitive: yes 
+params:
+- flt1 : float
+- flt2 : float
+code: |
+  FloatConstant(flt1 /. flt2)
+  
+---
+inst: FloatSine 
+is-primitive: yes 
+params:
+- flt1 : float
+code: |
+  FloatConstant(sin flt1)
+  
+---
+inst: FloatArcSine 
+is-primitive: yes 
+params:
+- flt1 : float
+code: |
+  FloatConstant(asin flt1)
+  
+---
+inst: FloatCosine 
+is-primitive: yes 
+params:
+- flt1 : float
+code: |
+  FloatConstant(cos flt1)
+  
+---
+inst: FloatArcCosine 
+is-primitive: yes 
+params:
+- flt1 : float
+code: |
+  FloatConstant(acos flt1)
+  
+---
+inst: FloatTangent 
+is-primitive: yes 
+params:
+- flt1 : float
+code: |
+  FloatConstant(tan flt1)
+  
+---
+inst: FloatArcTangent 
+is-primitive: yes 
+params:
+- flt1 : float
+code: |
+  FloatConstant(atan flt1)
+  
+---
+inst: FloatArcTangent2 
+is-primitive: yes 
+params:
+- flt1 : float
+- flt2 : float
+code: |
+  FloatConstant(atan2 flt1 flt2)
+  
+---
+inst: LengthPlus 
+is-primitive: yes 
+params:
+- len1 : length
+- len2 : length
+code: |
+  LengthConstant(HorzBox.(len1 +% len2))
+
+---
+inst: LengthMinus 
+is-primitive: yes 
+params:
+- len1 : length
+- len2 : length
+code: |
+  LengthConstant(HorzBox.(len1 -% len2))
+  
+---
+inst: LengthTimes 
+is-primitive: yes 
+params:
+- len1 : length
+- flt2 : float
+code: |
+  LengthConstant(HorzBox.(len1 *% flt2))
+  
+---
+inst: LengthDivides 
+is-primitive: yes 
+params:
+- len1 : length
+- len2 : length
+code: |
+  FloatConstant(HorzBox.(len1 /% len2))
+   
+---
+inst: LengthLessThan 
+is-primitive: yes 
+params:
+- len1 : length
+- len2 : length
+code: |
+  BooleanConstant(HorzBox.(len1 <% len2))
+  
+---
+inst: LengthGreaterThan 
+is-primitive: yes 
+params:
+- len1 : length
+- len2 : length
+code: |
+  BooleanConstant(HorzBox.(len2 <% len1))
+
+---
+inst: InsertArgs
+fields:
+- lst : syntactic_value list
+params:
+- func
+code : |
+  exec (func::(List.rev lst) @ stack) env code dump
+
+---
+inst: PrimitiveSetEveryWordBreak
+is-primitive : yes
+params:
+- hblst1 : horz
+- hblst2 : horz
+- (ctx, valuecmd) : context
+code: |
+  Context(HorzBox.({ ctx with
+    before_word_break = hblst1;
+    after_word_break = hblst2;
+  }), valuecmd)
+
+---
+inst: BackendProbeCrossReference
+is-primitive : yes
+params:
+- k : string
+code: |
+  match CrossRef.probe k with
+  | None    -> Constructor("None", UnitConstant)
+  | Some(v) -> Constructor("Some", StringConstant(v))
+

--- a/src/frontend/display.ml
+++ b/src/frontend/display.ml
@@ -1,3 +1,4 @@
+module Types = Types_
 open Types
 
 

--- a/src/frontend/display.mli
+++ b/src/frontend/display.mli
@@ -1,3 +1,4 @@
+module Types = Types_
 open Types
 
 val string_of_utast : untyped_abstract_tree -> string

--- a/src/frontend/evalVarID.ml
+++ b/src/frontend/evalVarID.ml
@@ -30,3 +30,6 @@ let show_direct (i, varnm) =
 
 let pp fmt evid =
   Format.fprintf fmt "%s" (show_direct evid)
+
+let get_varnm ((_, varnm) : t) = varnm
+

--- a/src/frontend/evalVarID.mli
+++ b/src/frontend/evalVarID.mli
@@ -12,3 +12,5 @@ val compare : t -> t -> int
 val show_direct : t -> string
 
 val pp : Format.formatter -> t -> unit
+
+val get_varnm : t -> string

--- a/src/frontend/evaluator.mli
+++ b/src/frontend/evaluator.mli
@@ -1,5 +1,11 @@
+module Types = Types_
 open Types
 
 exception EvalError of string
 
 val interpret : environment -> abstract_tree -> syntactic_value
+
+val select_pattern : Range.t -> environment -> syntactic_value -> pattern_branch list -> syntactic_value
+
+
+val interpret_intermediate_input_horz : environment -> syntactic_value -> intermediate_input_horz_element list -> syntactic_value

--- a/src/frontend/files.ml
+++ b/src/frontend/files.ml
@@ -1,3 +1,4 @@
+module Types = Types_
 open Types
 
 (* string -> string *)

--- a/src/frontend/fontInfo.ml
+++ b/src/frontend/fontInfo.ml
@@ -1,4 +1,5 @@
 
+module Types = Types_
 open MyUtil
 open LengthInterface
 open HorzBox

--- a/src/frontend/fontInfo.mli
+++ b/src/frontend/fontInfo.mli
@@ -1,4 +1,5 @@
 
+module Types = Types_
 open LengthInterface
 open HorzBox
 open Types

--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -1,4 +1,5 @@
 {
+  module Types = Types_
   open Types
   open Parser
 

--- a/src/frontend/main.mli
+++ b/src/frontend/main.mli
@@ -1,3 +1,4 @@
+module Types = Types_
 open Types
 open Typeenv
 (*

--- a/src/frontend/math.ml
+++ b/src/frontend/math.ml
@@ -1,4 +1,5 @@
 
+module Types = Types_
 open MyUtil
 open LengthInterface
 open GraphicData

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -7,7 +7,7 @@
     failwith msg;
 
 
-  open Types
+  open Types_
 
   type literal_reading_state = Normal | ReadingSpace
   type 'a range_kind =
@@ -385,22 +385,22 @@
 
 %}
 
-%token <Range.t * Types.var_name> VAR
-%token <Range.t * Types.ctrlseq_name> HORZCMD
-%token <Range.t * Types.ctrlseq_name> VERTCMD
-%token <Range.t * Types.ctrlseq_name> MATHCMD
-%token <Range.t * (Types.module_name list) * Types.var_name> VARWITHMOD
-%token <Range.t * (Types.module_name list) * Types.ctrlseq_name> HORZCMDWITHMOD
-%token <Range.t * (Types.module_name list) * Types.ctrlseq_name> VERTCMDWITHMOD
-%token <Range.t * (Types.module_name list) * Types.ctrlseq_name> MATHCMDWITHMOD
-%token <Range.t * (Types.module_name list) * Types.ctrlseq_name> VARINHORZ
-%token <Range.t * (Types.module_name list) * Types.ctrlseq_name> VARINVERT
-%token <Range.t * (Types.module_name list) * Types.var_name> VARINMATH
-%token <Range.t * Types.var_name> TYPEVAR
-%token <Range.t * Types.constructor_name> CONSTRUCTOR
+%token <Range.t * Types_.var_name> VAR
+%token <Range.t * Types_.ctrlseq_name> HORZCMD
+%token <Range.t * Types_.ctrlseq_name> VERTCMD
+%token <Range.t * Types_.ctrlseq_name> MATHCMD
+%token <Range.t * (Types_.module_name list) * Types_.var_name> VARWITHMOD
+%token <Range.t * (Types_.module_name list) * Types_.ctrlseq_name> HORZCMDWITHMOD
+%token <Range.t * (Types_.module_name list) * Types_.ctrlseq_name> VERTCMDWITHMOD
+%token <Range.t * (Types_.module_name list) * Types_.ctrlseq_name> MATHCMDWITHMOD
+%token <Range.t * (Types_.module_name list) * Types_.ctrlseq_name> VARINHORZ
+%token <Range.t * (Types_.module_name list) * Types_.ctrlseq_name> VARINVERT
+%token <Range.t * (Types_.module_name list) * Types_.var_name> VARINMATH
+%token <Range.t * Types_.var_name> TYPEVAR
+%token <Range.t * Types_.constructor_name> CONSTRUCTOR
 %token <Range.t * int> INTCONST
 %token <Range.t * float> FLOATCONST
-%token <Range.t * float * Types.length_unit_name> LENGTHCONST
+%token <Range.t * float * Types_.length_unit_name> LENGTHCONST
 %token <Range.t * string> CHAR
 %token <Range.t * string * bool * bool> LITERAL
 %token <Range.t> SPACE BREAK
@@ -414,8 +414,8 @@
 %token <Range.t> LETHORZ LETVERT LETMATH
 %token <Range.t> DEREF
 %token <Range.t> IF THEN ELSE
-%token <Range.t * Types.var_name> BINOP_TIMES BINOP_DIVIDES BINOP_PLUS BINOP_MINUS
-%token <Range.t * Types.var_name> BINOP_HAT BINOP_AMP BINOP_BAR BINOP_GT BINOP_LT BINOP_EQ
+%token <Range.t * Types_.var_name> BINOP_TIMES BINOP_DIVIDES BINOP_PLUS BINOP_MINUS
+%token <Range.t * Types_.var_name> BINOP_HAT BINOP_AMP BINOP_BAR BINOP_GT BINOP_LT BINOP_EQ
 %token <Range.t> EXACT_MINUS EXACT_TIMES MOD BEFORE LNOT
 %token <Range.t> LPAREN RPAREN
 %token <Range.t> BVERTGRP EVERTGRP
@@ -466,49 +466,49 @@
 *)
 
 %start main
-%type <Types.header_element list * Types.untyped_abstract_tree> main
-%type <Types.untyped_abstract_tree> nxlet
-%type <Types.untyped_abstract_tree> nxletsub
-%type <Types.untyped_letrec_binding list> nxrecdec
-%type <Types.untyped_let_binding> nxnonrecdec
-%type <Types.untyped_abstract_tree> nxbfr
-%type <Types.untyped_abstract_tree> nxwhl
-%type <Types.untyped_abstract_tree> nxif
-%type <Types.untyped_abstract_tree> nxlor
-%type <Types.untyped_abstract_tree> nxland
-%type <Types.untyped_abstract_tree> nxcomp
-%type <Types.untyped_abstract_tree> nxconcat
-%type <Types.untyped_abstract_tree> nxlplus
-%type <Types.untyped_abstract_tree> nxltimes
-%type <Types.untyped_abstract_tree> nxrplus
-%type <Types.untyped_abstract_tree> nxrtimes
-%type <Types.untyped_abstract_tree> nxun
-%type <Types.untyped_abstract_tree> nxapp
-%type <Types.untyped_abstract_tree> nxbot
-%type <Types.untyped_abstract_tree> tuple
-%type <Range.t * Types.untyped_pattern_branch list> pats
-%type <Types.untyped_pattern_tree> patas
-%type <Types.untyped_pattern_tree> patbot
-%type <Types.untyped_abstract_tree> nxlist
-%type <Types.untyped_abstract_tree> sxsep
-%type <Types.untyped_abstract_tree> sxblock
-%type <Types.untyped_abstract_tree> vxblock
-%type <Types.untyped_input_vert_element> vxbot
-%type <Types.var_name * Types.manual_kind> constrnt
-%type <Types.constraints> constrnts
+%type <Types_.header_element list * Types_.untyped_abstract_tree> main
+%type <Types_.untyped_abstract_tree> nxlet
+%type <Types_.untyped_abstract_tree> nxletsub
+%type <Types_.untyped_letrec_binding list> nxrecdec
+%type <Types_.untyped_let_binding> nxnonrecdec
+%type <Types_.untyped_abstract_tree> nxbfr
+%type <Types_.untyped_abstract_tree> nxwhl
+%type <Types_.untyped_abstract_tree> nxif
+%type <Types_.untyped_abstract_tree> nxlor
+%type <Types_.untyped_abstract_tree> nxland
+%type <Types_.untyped_abstract_tree> nxcomp
+%type <Types_.untyped_abstract_tree> nxconcat
+%type <Types_.untyped_abstract_tree> nxlplus
+%type <Types_.untyped_abstract_tree> nxltimes
+%type <Types_.untyped_abstract_tree> nxrplus
+%type <Types_.untyped_abstract_tree> nxrtimes
+%type <Types_.untyped_abstract_tree> nxun
+%type <Types_.untyped_abstract_tree> nxapp
+%type <Types_.untyped_abstract_tree> nxbot
+%type <Types_.untyped_abstract_tree> tuple
+%type <Range.t * Types_.untyped_pattern_branch list> pats
+%type <Types_.untyped_pattern_tree> patas
+%type <Types_.untyped_pattern_tree> patbot
+%type <Types_.untyped_abstract_tree> nxlist
+%type <Types_.untyped_abstract_tree> sxsep
+%type <Types_.untyped_abstract_tree> sxblock
+%type <Types_.untyped_abstract_tree> vxblock
+%type <Types_.untyped_input_vert_element> vxbot
+%type <Types_.var_name * Types_.manual_kind> constrnt
+%type <Types_.constraints> constrnts
 (*
-%type <Types.untyped_abstract_tree> sxclsnm
-%type <Types.untyped_abstract_tree> sxidnm
+%type <Types_.untyped_abstract_tree> sxclsnm
+%type <Types_.untyped_abstract_tree> sxidnm
 *)
-%type <Types.untyped_command_argument> narg
-%type <Types.untyped_command_argument> sarg
-%type <Types.untyped_pattern_tree list> argpats
-%type <Range.t * Types.var_name> binop
-%type <Types.untyped_unkinded_type_argument list> xpltyvars
-%type <Types.manual_type option * untyped_pattern_tree list> recdecargpart
-%type <Types.manual_type option * untyped_argument list> nonrecdecargpart
+%type <Types_.untyped_command_argument> narg
+%type <Types_.untyped_command_argument> sarg
+%type <Types_.untyped_pattern_tree list> argpats
+%type <Range.t * Types_.var_name> binop
+%type <Types_.untyped_unkinded_type_argument list> xpltyvars
+%type <Types_.manual_type option * untyped_pattern_tree list> recdecargpart
+%type <Types_.manual_type option * untyped_argument list> nonrecdecargpart
 %type <Range.t * manual_type list * (module_name list * type_name)> txapp
-%type <Range.t * module_name list * Types.type_name> txbot
+%type <Range.t * module_name list * Types_.type_name> txbot
 
 %%
 
@@ -958,13 +958,13 @@ patas:
   | pattr AS VAR       { make_standard (Ranged $1) (Ranged $3) (UTPAsVariable(extract_name $3, $1)) }
   | pattr              { $1 }
 ;
-pattr: /* -> Types.untyped_pattern_tree */
+pattr: /* -> Types_.untyped_pattern_tree */
   | patbot CONS pattr  { make_standard (Ranged $1) (Ranged $3) (UTPListCons($1, $3)) }
   | CONSTRUCTOR patbot { make_standard (Ranged $1) (Ranged $2) (UTPConstructor(extract_name $1, $2)) }
   | CONSTRUCTOR        { make_standard (Ranged $1) (Ranged $1) (UTPConstructor(extract_name $1, (Range.dummy "constructor-unit-value", UTPUnitConstant))) }
   | patbot             { $1 }
 ;
-patbot: /* -> Types.untyped_pattern_tree */
+patbot: /* -> Types_.untyped_pattern_tree */
   | INTCONST           { make_standard (Ranged $1) (Ranged $1) (UTPIntegerConstant(extract_main $1)) }
   | TRUE               { make_standard (Tok $1) (Tok $1) (UTPBooleanConstant(true)) }
   | FALSE              { make_standard (Tok $1) (Tok $1) (UTPBooleanConstant(false)) }
@@ -1156,7 +1156,7 @@ sargs:
     }
 ;
 
-sarg: /* -> Types.untyped_argument_cons */
+sarg: /* -> Types_.untyped_argument_cons */
   | opn=BVERTGRP; utast=vxblock; cls=EVERTGRP { UTMandatoryArgument(make_standard (Tok opn) (Tok cls) (extract_main utast)) }
   | opn=BHORZGRP; utast=sxsep; cls=EHORZGRP   { UTMandatoryArgument(make_standard (Tok opn) (Tok cls) (extract_main utast)) }
 ;

--- a/src/frontend/primitives.mli
+++ b/src/frontend/primitives.mli
@@ -1,4 +1,5 @@
 
+module Types = Types_
 open Types
 open LengthInterface
 

--- a/src/frontend/toplevel.ml
+++ b/src/frontend/toplevel.ml
@@ -1,7 +1,7 @@
 #load "assoc.cmo";;
 #load "stacklist.cmo";;
 #load "range.cmo";;
-#load "types.cmo";;
+#load "types_.cmo";;
 #load "hashTree.cmo";;
 #load "directedGraph.cmo";;
 #load "typeenv.cmo";;

--- a/src/frontend/typechecker.ml
+++ b/src/frontend/typechecker.ml
@@ -1,4 +1,5 @@
 
+module Types = Types_
 open MyUtil
 open Types
 open Display

--- a/src/frontend/typechecker.mli
+++ b/src/frontend/typechecker.mli
@@ -1,3 +1,5 @@
+
+module Types = Types_
 open Types
 open Typeenv
 

--- a/src/frontend/typeenv.ml
+++ b/src/frontend/typeenv.ml
@@ -1,4 +1,5 @@
 
+module Types = Types_
 open MyUtil
 open Types
 

--- a/src/frontend/typeenv.mli
+++ b/src/frontend/typeenv.mli
@@ -1,3 +1,4 @@
+module Types = Types_
 open Types
 
 type t

--- a/src/frontend/types.ml
+++ b/src/frontend/types.ml
@@ -2,7 +2,6 @@
 open LengthInterface
 open GraphicData
 
-
 exception ParseErrorDetail of string
 exception IllegalArgumentLength of Range.t * int * int
 
@@ -456,6 +455,87 @@ and environment = location EvalVarIDMap.t * (syntactic_value StoreIDHashTable.t)
 
 and location = syntactic_value ref
 
+and vmenv = environment * (syntactic_value array) list
+
+and compiled_intermediate_input_horz_element =
+  | CompiledImInputHorzText         of string
+  | CompiledImInputHorzEmbedded     of instruction list
+  | CompiledImInputHorzContent of instruction list 
+  | CompiledImInputHorzEmbeddedMath of instruction list
+
+and compiled_intermediate_input_vert_element =
+  | CompiledImInputVertEmbedded of instruction list
+  | CompiledImInputVertContent  of instruction list
+
+and ir_input_horz_element =
+  | IRInputHorzText         of string
+  | IRInputHorzEmbedded     of ir * ir list
+  | IRInputHorzContent      of ir 
+  | IRInputHorzEmbeddedMath of ir
+
+
+and ir_input_vert_element =
+  | IRInputVertEmbedded of ir * ir list
+  | IRInputVertContent  of ir
+
+and 'a ir_path_component =
+  | IRPathLineTo        of 'a
+  | IRPathCubicBezierTo of ir * ir * 'a
+
+and 'a compiled_path_component =
+  | CompiledPathLineTo of 'a
+  | CompiledPathCubicBezierTo of instruction list * instruction list * 'a
+
+and varloc = 
+  | GlobalVar of location * EvalVarID.t * int ref
+  | LocalVar  of int * int * EvalVarID.t * int ref
+
+and ir =
+  | IRConstant              of syntactic_value
+  | IRTerminal
+  | IRInputHorz             of ir_input_horz_element list
+  | IRInputVert             of ir_input_vert_element list
+  | IRRecord                of Assoc.key list * ir list
+      [@printer (fun fmt _ -> Format.fprintf fmt "IRRecord(...)")]
+  | IRAccessField           of ir * field_name 
+  | IRLetRecIn              of (varloc * ir) list * ir
+  | IRLetNonRecIn           of ir * ir_pattern_tree * ir
+  | IRContentOf             of varloc 
+  | IRIfThenElse            of ir * ir * ir
+  | IRFunction              of int * ir_pattern_tree list * ir
+  | IRApply                 of int * ir * ir list
+  | IRApplyPrimitive        of instruction * int * ir list
+  | IRTuple                 of int * ir list
+  | IRPatternMatch          of Range.t * ir * ir_pattern_branch list
+  | IRNonValueConstructor   of constructor_name * ir
+  | IRLetMutableIn          of varloc * ir * ir
+  | IRSequential            of ir * ir
+  | IRWhileDo               of ir * ir
+  | IROverwrite             of varloc * ir
+  | IRModule                of ir * ir
+  | IRPath                  of ir * ir ir_path_component list * (unit ir_path_component) option
+
+and ir_pattern_branch =
+  | IRPatternBranch      of ir_pattern_tree * ir
+  | IRPatternBranchWhen  of ir_pattern_tree * ir * ir
+
+and ir_pattern_tree =
+  | IRPUnitConstant
+  | IRPBooleanConstant      of bool
+  | IRPIntegerConstant      of int
+  | IRPStringConstant       of string
+  | IRPListCons             of ir_pattern_tree * ir_pattern_tree
+  | IRPEndOfList
+  | IRPTupleCons             of ir_pattern_tree * ir_pattern_tree
+  (*| IRPTupleCons            of int * ir_pattern_tree list*)
+  | IRPEndOfTuple
+  | IRPWildCard
+  | IRPVariable             of varloc
+  | IRPAsVariable           of varloc * ir_pattern_tree
+  | IRPConstructor          of constructor_name * ir_pattern_tree
+
+  (**** include: __insttype.ml ****)
+
 and input_horz_element =
   | InputHorzText         of string
   | InputHorzEmbedded     of abstract_tree * abstract_tree list
@@ -481,6 +561,8 @@ and 'a path_component =
   | PathCubicBezierTo of abstract_tree * abstract_tree * 'a
 
 and syntactic_value =
+  | Nil
+  | SimpleRef             of syntactic_value ref
   | UnitConstant
   | BooleanConstant       of bool
   | IntegerConstant       of int
@@ -494,6 +576,9 @@ and syntactic_value =
   | Constructor           of constructor_name * syntactic_value
 
   | FuncWithEnvironment   of pattern_branch list * environment
+  | PrimitiveWithEnvironment   of pattern_branch list * environment * int * (abstract_tree list -> abstract_tree)
+  | CompiledFuncWithEnvironment of int * syntactic_value list * int * instruction list * vmenv
+  | CompiledPrimitiveWithEnvironment of int * syntactic_value list * int * instruction list * vmenv * (abstract_tree list -> abstract_tree)
 
   | EvaluatedEnvironment  of environment
 
@@ -509,7 +594,11 @@ and syntactic_value =
   | Location              of StoreID.t
 
   | InputHorzWithEnvironment of intermediate_input_horz_element list * environment
+  | CompiledInputHorzIntermediate    of compiled_intermediate_input_horz_element list
+  | CompiledInputHorzWithEnvironment    of compiled_intermediate_input_horz_element list * vmenv 
   | InputVertWithEnvironment of intermediate_input_vert_element list * environment
+  | CompiledInputVertIntermediate    of compiled_intermediate_input_vert_element list
+  | CompiledInputVertWithEnvironment    of compiled_intermediate_input_vert_element list * vmenv
 
   | Horz                  of HorzBox.horz_box list
   | Vert                  of HorzBox.vert_box list
@@ -533,30 +622,11 @@ and abstract_tree =
   | FinishHeaderFile
   | FinishStruct
   | LengthDescription     of float * length_unit_name
-  | Concat                of abstract_tree * abstract_tree
 (* -- input texts -- *)
   | InputHorz             of input_horz_element list
   | InputVert             of input_vert_element list
 (* -- graphics -- *)
   | Path                        of abstract_tree * (abstract_tree path_component) list * (unit path_component) option
-  | PathUnite                   of abstract_tree * abstract_tree
-  | PrePathBeginning            of abstract_tree
-  | PrePathLineTo               of abstract_tree * abstract_tree
-  | PrePathCubicBezierTo        of abstract_tree * abstract_tree * abstract_tree * abstract_tree
-  | PrePathTerminate            of abstract_tree
-  | PrePathCloseWithLine        of abstract_tree
-  | PrePathCloseWithCubicBezier of abstract_tree * abstract_tree * abstract_tree
-  | PrimitiveDrawStroke         of abstract_tree * abstract_tree * abstract_tree
-  | PrimitiveDrawDashedStroke   of abstract_tree * abstract_tree * abstract_tree * abstract_tree
-  | PrimitiveDrawFill           of abstract_tree * abstract_tree
-(* -- horizontal box list -- *)
-  | HorzConcat            of abstract_tree * abstract_tree
-(* -- vertical box list -- *)
-  | VertConcat            of abstract_tree * abstract_tree
-(* -- list value -- *)
-  | PrimitiveListCons     of abstract_tree * abstract_tree
-(* -- tuple value -- *)
-  | PrimitiveTupleCons    of abstract_tree * abstract_tree
 (* -- record value -- *)
   | Record                of abstract_tree Assoc.t
       [@printer (fun fmt _ -> Format.fprintf fmt "Record(...)")]
@@ -576,128 +646,13 @@ and abstract_tree =
   | Sequential            of abstract_tree * abstract_tree
   | WhileDo               of abstract_tree * abstract_tree
   | Overwrite             of EvalVarID.t * abstract_tree
-  | Dereference           of abstract_tree
 (* -- module system -- *)
   | Module                of abstract_tree * abstract_tree
-(* -- basic primitive operations -- *)
-  | Times                 of abstract_tree * abstract_tree
-  | Divides               of abstract_tree * abstract_tree
-  | Mod                   of abstract_tree * abstract_tree
-  | Plus                  of abstract_tree * abstract_tree
-  | Minus                 of abstract_tree * abstract_tree
-  | GreaterThan           of abstract_tree * abstract_tree
-  | LessThan              of abstract_tree * abstract_tree
-  | EqualTo               of abstract_tree * abstract_tree
-  | LogicalAnd            of abstract_tree * abstract_tree
-  | LogicalOr             of abstract_tree * abstract_tree
-  | LogicalNot            of abstract_tree
-  | PrimitiveSame         of abstract_tree * abstract_tree
-  | PrimitiveStringMatch  of abstract_tree * abstract_tree
-  | PrimitiveStringSub    of abstract_tree * abstract_tree * abstract_tree
-  | PrimitiveStringLength of abstract_tree
-  | PrimitiveStringUnexplode of abstract_tree
-  | PrimitiveSplitIntoLines  of abstract_tree
-  | PrimitiveSplitOnRegExp   of abstract_tree * abstract_tree
-  | PrimitiveRegExpOfString  of abstract_tree
-  | PrimitiveArabic       of abstract_tree
-  | PrimitiveFloat        of abstract_tree
-  | PrimitiveRound        of abstract_tree
-  | FloatPlus             of abstract_tree * abstract_tree
-  | FloatMinus            of abstract_tree * abstract_tree
-  | FloatTimes            of abstract_tree * abstract_tree
-  | FloatDivides          of abstract_tree * abstract_tree
-  | FloatSine             of abstract_tree
-  | FloatArcSine          of abstract_tree
-  | FloatCosine           of abstract_tree
-  | FloatArcCosine        of abstract_tree
-  | FloatTangent          of abstract_tree
-  | FloatArcTangent       of abstract_tree
-  | FloatArcTangent2      of abstract_tree * abstract_tree
-  | LengthPlus            of abstract_tree * abstract_tree
-  | LengthMinus           of abstract_tree * abstract_tree
-  | LengthTimes           of abstract_tree * abstract_tree
-  | LengthDivides         of abstract_tree * abstract_tree
-  | LengthLessThan        of abstract_tree * abstract_tree
-  | LengthGreaterThan     of abstract_tree * abstract_tree
-(* -- backend primitives -- *)
-  | BackendMathChar             of abstract_tree * bool * abstract_tree
-  | BackendMathCharWithKern     of abstract_tree * bool * abstract_tree * abstract_tree * abstract_tree
-  | BackendMathGroup            of abstract_tree * abstract_tree * abstract_tree
-  | BackendMathConcat           of abstract_tree * abstract_tree
   | BackendMathList             of abstract_tree list
-  | BackendMathSuperscript      of abstract_tree * abstract_tree
-  | BackendMathSubscript        of abstract_tree * abstract_tree
-  | BackendMathFraction         of abstract_tree * abstract_tree
-  | BackendMathRadical          of abstract_tree * abstract_tree  (* temporary *)
-  | BackendMathParen            of abstract_tree * abstract_tree * abstract_tree
-  | BackendMathUpperLimit       of abstract_tree * abstract_tree
-  | BackendMathLowerLimit       of abstract_tree * abstract_tree
-  | BackendMathText             of abstract_tree * abstract_tree
-  | BackendMathColor            of abstract_tree * abstract_tree
-  | BackendMathCharClass        of abstract_tree * abstract_tree
-  | BackendMathVariantCharDirect of abstract_tree * abstract_tree
-  | BackendEmbeddedMath         of abstract_tree * abstract_tree
-  | BackendTabular              of abstract_tree * abstract_tree
-  | BackendRegisterPdfImage     of abstract_tree * abstract_tree
-  | BackendRegisterOtherImage   of abstract_tree
-  | BackendUseImageByWidth      of abstract_tree * abstract_tree
-  | BackendHookPageBreak        of abstract_tree
-
   | LambdaHorz                  of EvalVarID.t * abstract_tree
   | LambdaVert                  of EvalVarID.t * abstract_tree
-
-  | HorzLex                     of abstract_tree * abstract_tree
-  | VertLex                     of abstract_tree * abstract_tree
-  | PrimitiveGetInitialContext  of abstract_tree * abstract_tree
-  | PrimitiveSetSpaceRatio      of abstract_tree * abstract_tree
-  | PrimitiveSetParagraphMargin of abstract_tree * abstract_tree * abstract_tree
-  | PrimitiveSetFontSize        of abstract_tree * abstract_tree
-  | PrimitiveGetFontSize        of abstract_tree
-  | PrimitiveSetFont            of abstract_tree * abstract_tree * abstract_tree
-  | PrimitiveGetFont            of abstract_tree * abstract_tree
-  | PrimitiveSetMathFont        of abstract_tree * abstract_tree
-  | PrimitiveSetDominantWideScript of abstract_tree * abstract_tree
-  | PrimitiveGetDominantWideScript of abstract_tree
-  | PrimitiveSetDominantNarrowScript of abstract_tree * abstract_tree
-  | PrimitiveGetDominantNarrowScript of abstract_tree
-  | PrimitiveSetLangSys         of abstract_tree * abstract_tree * abstract_tree
-  | PrimitiveGetLangSys         of abstract_tree * abstract_tree
-  | PrimitiveSetTextColor       of abstract_tree * abstract_tree
-  | PrimitiveGetTextColor       of abstract_tree
-  | PrimitiveSetLeading         of abstract_tree * abstract_tree
-  | PrimitiveGetTextWidth       of abstract_tree
-  | PrimitiveSetManualRising    of abstract_tree * abstract_tree
-  | PrimitiveSetHyphenPenalty   of abstract_tree * abstract_tree
-  | PrimitiveEmbed              of abstract_tree
-  | PrimitiveGetNaturalWidth    of abstract_tree
-  | PrimitiveGetNaturalLength   of abstract_tree
-  | PrimitiveDisplayMessage     of abstract_tree
-  | PrimitiveDrawText           of abstract_tree * abstract_tree
-  | PrimitiveSetMathVariantToChar of abstract_tree * abstract_tree * abstract_tree * abstract_tree * abstract_tree
-  | PrimitiveSetMathCommand     of abstract_tree * abstract_tree
-  | PrimitiveGetAxisHeight      of abstract_tree
-  | PrimitiveSetEveryWordBreak  of abstract_tree * abstract_tree * abstract_tree
-  | BackendFont                 of abstract_tree * abstract_tree * abstract_tree
-  | BackendLineBreaking         of abstract_tree * abstract_tree * abstract_tree * abstract_tree
-  | BackendPageBreaking         of abstract_tree * abstract_tree * abstract_tree * abstract_tree
-  | BackendFixedEmpty           of abstract_tree
-  | BackendOuterEmpty           of abstract_tree * abstract_tree * abstract_tree
-  | BackendOuterFrame           of abstract_tree * abstract_tree * abstract_tree
-  | BackendInnerFrame           of abstract_tree * abstract_tree * abstract_tree
-  | BackendFixedFrame           of abstract_tree * abstract_tree * abstract_tree * abstract_tree
-  | BackendOuterFrameBreakable  of abstract_tree * abstract_tree * abstract_tree
-  | BackendVertFrame            of abstract_tree * abstract_tree * abstract_tree * abstract_tree
-  | BackendVertSkip             of abstract_tree
-  | BackendEmbeddedVertTop      of abstract_tree * abstract_tree * abstract_tree
-  | BackendEmbeddedVertBottom   of abstract_tree * abstract_tree * abstract_tree
-  | BackendInlineGraphics       of abstract_tree * abstract_tree * abstract_tree * abstract_tree
-  | BackendLineStackTop         of abstract_tree
-  | BackendLineStackBottom      of abstract_tree
-  | BackendScriptGuard          of abstract_tree * abstract_tree
-  | BackendDiscretionary        of abstract_tree * abstract_tree * abstract_tree * abstract_tree
-  | BackendRegisterCrossReference of abstract_tree * abstract_tree
-  | BackendProbeCrossReference    of abstract_tree
-  | BackendGetCrossReference      of abstract_tree
+  | PrimitiveTupleCons    of abstract_tree * abstract_tree
+ (**** include: __attype.ml ****)
 
 and pattern_branch =
   | PatternBranch      of pattern_tree * abstract_tree
@@ -1008,7 +963,7 @@ let register_location (env : environment) (value : syntactic_value) : StoreID.t 
   stid
 
 
-let update_location (env :environment) (stid : StoreID.t) (value : syntactic_value) : unit =
+let update_location (env : environment) (stid : StoreID.t) (value : syntactic_value) : unit =
   let (_, stenvref) = env in
   let stenv = !stenvref in
   if StoreIDHashTable.mem stenv stid then


### PR DESCRIPTION
This pull-request adds a bytecode compiler and a virtual machine.
SATySFi interpreter is slow(see #63). This bytecode compiler improves an evaluation performance.
For example, it takes about 90 minutes to make a pdf of [pi](https://twitter.com/zr_tex8r/status/973842520965656576) on my laptop by
the interpreter. By using the bytecode compiler, it only takes about 4 minutes.
The bytecode compiler can coexist with interpreter. You can use it by adding --bytecomp command line option.

To build the virtual machine, a Ruby script 'gen_code.rb' is used. This script reads 'src/frontend/bytecomp/vminstdef.yaml' and generates OCaml codes.
'vminstdef.yaml' is written in YAML format and contains instruction & primitive definitions. This mechanism makes it easier to add a new VM instruction or primtive. But now, interpreter and virtual machine are not share the code. Therefore you have to update both an interpreter and a virtual machine if you modify evaluator or add a new primitive.