### PR TITLE
remove camlimages' version constraint for OPAM

### DIFF
--- a/opam
+++ b/opam
@@ -20,9 +20,7 @@ remove: [
 # Packages whose version suffix is "+satysfi" are distributed on satysfi-external-repo.
 depends: [
   "batteries"
-# Issue #46: we temporarily pin camlimages to avoid Graphics-related problems.
-# See https://github.com/ocaml/dune/issues/563 for details.
-  "camlimages" {>= "5.0.1"}
+  "camlimages"
   "camlpdf" {= "2.2.1+satysfi"}
   "core_kernel" {>= "v0.10.0"}
   "depext"


### PR DESCRIPTION
We can now safely remove the version constraint in the `opam` file because ocaml/dune#567 has resolved.

Related: #65, also closes #46 