### PR TITLE
Force to install camlimages >=5.0.1

### DIFF
--- a/opam
+++ b/opam
@@ -20,7 +20,7 @@ remove: [
 # Packages whose version suffix is "+satysfi" are distributed on satysfi-external-repo.
 depends: [
   "batteries"
-  "camlimages"
+  "camlimages" {>= "5.0.1"}
   "camlpdf" {= "2.2.1+satysfi"}
   "core_kernel" {>= "v0.10.0"}
   "depext"


### PR DESCRIPTION
Fix an installation issue around camlimages reported at https://twitter.com/foresta3_t/status/1009089643625607169 .

It seems that OPAM does not always install the newest version of packages. See https://opam.ocaml.org/doc/Specifying_Solver_Preferences.html .
Due to the necessity of camlimages 5.0.1 (#70), we explicitly write a version constraint for camlimages.

I'm sorry that the constraint was removed by my PR #86. It should be remained even after the fix of the dune's issue.
Also, possibly other packages needs version constraints. But I only wrote a patch for camlimages for a quick fix.