### PR TITLE
Fix docs regarding recent breaking changes.

### DIFF
--- a/doc/local-math.satyh
+++ b/doc/local-math.satyh
@@ -25,7 +25,7 @@ let-math \valit m =
   ${\text!{\{}#m\text!{\}}}
 
 let-math \valbt m =
-  ${\angle{#m}}
+  ${\angle-bracket{#m}}
 
 let-math \wildcard = ${\synt-color{\_}}
 
@@ -51,7 +51,7 @@ let-math \exprabsB x e =
   ${\synt-color{\lambda^{\mathrm{B}}}#x\token!{.\ }#e}
 
 let-math \valB m =
-  ${\synt-color{\angle{#m}}}
+  ${\synt-color{\angle-bracket{#m}}}
 
 let-math \BNF nontm mlst =
   let defs = Math.join ${\|} mlst in

--- a/tests/first.saty
+++ b/tests/first.saty
@@ -189,7 +189,7 @@ document (|
     }
   >);
   +math (${
-    \derive{A \and-also \derive{B \and-also C}{D}}{E}
+    \derive{| A | \derive{|B | C|}{D} |}{E}
   });
   +p {
     A table

--- a/tests/head.satyh
+++ b/tests/head.satyh
@@ -1,5 +1,6 @@
 @require: list
 @require: math
+@require: proof
 
 let form-paragraph = line-break true true
 
@@ -221,7 +222,7 @@ let-block ctx +section title inner =
     bc-title +++ bc-inner
 
 let-inline ctx \expand-spaces inner =
-  let ctx-inner = set-space-ratio 1.0 ctx in
+  let ctx-inner = set-space-ratio 1.0 0.08 0.16 ctx in
     read-inline ctx-inner inner
 
 %let-block-detailed ctx +px inner =
@@ -542,7 +543,7 @@ let-block ctx +code code =
     let charwid = get-natural-width (read-inline ctx {0}) in
     let ctx-code =
       ctx |> set-latin-font font-latin-mono
-          |> set-space-ratio (charwid /' fontsize)
+          |> set-space-ratio (charwid /' fontsize) 0.08 0.16
     in
 
     let lst = split-into-lines code in


### PR DESCRIPTION
Recent changes broke some portions in the docs. This patch is a minimal aid to fix these obvious errors. It doesn't go further e.g. adding images to let `tests/first.saty` compile.