### PR TITLE
Fix empty filename bug on parser error message

### DIFF
--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -29,13 +29,10 @@
     | MathState       (* math mode *)
 
 
-  let file_name_ref = ref ""
-
-
   let get_pos lexbuf =
     let posS = Lexing.lexeme_start_p lexbuf in
     let posE = Lexing.lexeme_end_p lexbuf in
-    let fname = !file_name_ref (* posS.Lexing.pos_fname *) in
+    let fname = posS.Lexing.pos_fname in
     let lnum = posS.Lexing.pos_lnum in
     let cnumS = posS.Lexing.pos_cnum - posS.Lexing.pos_bol in
     let cnumE = posE.Lexing.pos_cnum - posE.Lexing.pos_bol in
@@ -95,13 +92,11 @@
     stack
 
 
-  let reset_to_progexpr fname =
-    file_name_ref := fname;
+  let reset_to_progexpr () =
     initialize ProgramState
 
 
-  let reset_to_vertexpr fname =
-    file_name_ref := fname;
+  let reset_to_vertexpr () =
     initialize VerticalState
 
 

--- a/src/frontend/parserInterface.ml
+++ b/src/frontend/parserInterface.ml
@@ -3,6 +3,8 @@ exception Error of Range.t
 
 module I = Parser.MenhirInterpreter
 
+open Lexing
+
 
 let k_success utast =
   utast
@@ -23,6 +25,7 @@ let k_fail chkpt =
 
 let process fname lexbuf =
   (* print_endline "parserInterface.process";  (* for debug *) *)
-  let stack = Lexer.reset_to_progexpr fname in
+  let stack = Lexer.reset_to_progexpr () in
+  let () = lexbuf.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname = fname } in
   let supplier = I.lexer_lexbuf_to_supplier (Lexer.cut_token stack) lexbuf in
     I.loop_handle k_success k_fail supplier (Parser.Incremental.main lexbuf.Lexing.lex_curr_p)


### PR DESCRIPTION
In a parser error message, filename is not shown. 
```
---- ---- ---- ----
  target file: 'demo.pdf'
  dump file: 'demo.satysfi-aux' (already exists)
  parsing 'demo.saty' ...
! [Syntax Error at Parser] at "", line 38, characters 6-6:
```

This PR fixes this problem by setting filename to lexbuf.lex_curr_p.pos_fname manually.