### PR TITLE
Use $BINDIR/../share/satysfi.

### DIFF
--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -745,7 +745,7 @@ let setup_root_dirs () =
       | None    -> []
       | Some(s) -> [s]
     else
-      ["/usr/local/share/satysfi"; "/usr/share/satysfi"]
+      [Filename.concat (Filename.dirname Sys.executable_name) "../share/satysfi"; "/usr/local/share/satysfi"; "/usr/share/satysfi"]
   in
   let user_dirs =
     if Sys.os_type = "Win32" then


### PR DESCRIPTION
I confirmed that `rm -rf $HOME/.satysfi; cd doc; make` succeeded with this change + https://github.com/gfngfn/SATySFi/pull/108 using opam 2.0.0.

Fixes https://github.com/gfngfn/SATySFi/issues/38