### PR TITLE
CHANGELOG.md: add links to commits between versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/), 
 ### Fixed
 - Does NOT insert spacing between different scripts when the [line breaking class](http://unicode.org/reports/tr14/) of the posterior charcter is CL, CP, QU, NS, JLCP, JLNS, JLCM, or JLFS.
 
-# Added
+### Added
 - Supports the application of math commands to optional arguments.
 - Provides primitives `set-space-ratio-between-scripts` and `get-space-ratio-between-scripts`.
 
@@ -21,6 +21,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/), 
 - Starts reporting error for duplicated fields in a record expression.
 - Improve type error report as to application of non-function expressions.
 
-## [0.0.1] - 2018-08-05
+## 0.0.1 - 2018-08-05
 ### Added
 - Initial version of SATySFi
+
+
+  [Unreleased]: https://github.com/gfngfn/SATySFi/compare/v0.0.3...HEAD
+  [0.0.3]: https://github.com/gfngfn/SATySFi/compare/v0.0.1...v0.0.3
+  [0.0.2]: https://github.com/gfngfn/SATySFi/compare/v0.0.1...v0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,5 +27,5 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/), 
 
 
   [Unreleased]: https://github.com/gfngfn/SATySFi/compare/v0.0.3...HEAD
-  [0.0.3]: https://github.com/gfngfn/SATySFi/compare/v0.0.1...v0.0.3
+  [0.0.3]: https://github.com/gfngfn/SATySFi/compare/v0.0.2...v0.0.3
   [0.0.2]: https://github.com/gfngfn/SATySFi/compare/v0.0.1...v0.0.2


### PR DESCRIPTION
This PR adds links to commits between versions. An example on the official [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) contains them.
