### PR TITLE
Add show-pages option to stdja*.satyh

### DIFF
--- a/lib-satysfi/dist/packages/stdja.satyh
+++ b/lib-satysfi/dist/packages/stdja.satyh
@@ -7,12 +7,15 @@
 
 module StdJa : sig
 
-  val document : 'a -> block-text -> document
+  val document : 'a -> 'b ?-> block-text -> document
     constraint 'a :: (|
       title : inline-text;
       author : inline-text;
       show-toc : bool;
       show-title : bool;
+    |)
+    constraint 'b :: (|
+      show-pages : bool;
     |)
 
   val font-latin-italic : string * float * float
@@ -229,7 +232,7 @@ let title-deco =
     | Some(s) -> s
 
 
-  let document record inner =
+  let document record ?:recordopt inner =
     % -- constants --
     let title = record#title in
     let author = record#author in
@@ -242,6 +245,11 @@ let title-deco =
     let hdrwid = 520pt in
     let ftrwid = 520pt in
     let thickness = 0.5pt in
+    let show-pages =
+      match recordopt with
+      | None -> true
+      | Some(flags) -> flags#show-pages
+    in
 
     let ctx-doc = get-standard-context txtwid in
 
@@ -329,10 +337,13 @@ let title-deco =
             +++ bb-float-boxes
       in
       let footer =
-        let ctx = get-standard-context ftrwid in
-        let it-pageno = embed-string (arabic pbinfo#page-number) in
-          line-break true true ctx
-            (inline-fil ++ (read-inline ctx {— #it-pageno; —}) ++ inline-fil)
+        if show-pages then
+          let ctx = get-standard-context ftrwid in
+          let it-pageno = embed-string (arabic pbinfo#page-number) in
+            line-break true true ctx
+              (inline-fil ++ (read-inline ctx {— #it-pageno; —}) ++ inline-fil)
+        else
+          block-nil
       in
         (|
           header-origin  = hdrorg;

--- a/lib-satysfi/dist/packages/stdjabook.satyh
+++ b/lib-satysfi/dist/packages/stdjabook.satyh
@@ -8,12 +8,15 @@
 
 module StdJaBook : sig
 
-  val document : 'a -> block-text -> document
+  val document : 'a -> 'b ?-> block-text -> document
     constraint 'a :: (|
       title : inline-text;
       author : inline-text;
       show-toc : bool;
       show-title : bool;
+    |)
+    constraint 'b :: (|
+      show-pages : bool;
     |)
 
   val font-latin-roman  : string * float * float
@@ -304,7 +307,7 @@ let title-deco =
       inline-fil ++ (repeat-inline n ib)
 
 
-  let document record inner =
+  let document record ?:recordopt inner =
     % -- constants --
     let title = record#title in
     let author = record#author in
@@ -317,6 +320,11 @@ let title-deco =
     let hdrwid = 520pt in
     let ftrwid = 520pt in
     let thickness = header-line-thickness in
+    let show-pages =
+      match recordopt with
+      | None -> true
+      | Some(flags) -> flags#show-pages
+    in
 
     let () =
       register-cross-reference `changed` `F`
@@ -428,10 +436,13 @@ let title-deco =
             +++ bb-float-boxes
       in
       let footer =
-        let ctx = get-standard-context ftrwid in
-        let it-pageno = embed-string (arabic pbinfo#page-number) in
-          line-break true true ctx
-            (inline-fil ++ (read-inline ctx {— #it-pageno; —}) ++ inline-fil)
+        if show-pages then
+          let ctx = get-standard-context ftrwid in
+          let it-pageno = embed-string (arabic pbinfo#page-number) in
+            line-break true true ctx
+              (inline-fil ++ (read-inline ctx {— #it-pageno; —}) ++ inline-fil)
+        else
+          block-nil
       in
         (|
           header-origin  = hdrorg;

--- a/lib-satysfi/dist/packages/stdjareport.satyh
+++ b/lib-satysfi/dist/packages/stdjareport.satyh
@@ -9,10 +9,13 @@
 
 module StdJaReport : sig
 
-  val document : 'a -> block-text -> document
+  val document : 'a -> 'b ?-> block-text -> document
     constraint 'a :: (|
       title : inline-text;
       author : inline-text;
+    |)
+    constraint 'b :: (|
+      show-pages : bool;
     |)
 
   val font-latin-roman  : string * float * float
@@ -185,7 +188,7 @@ end = struct
       ib ++ inline-skip (0pt -' w)
 
 
-  let document record inner =
+  let document record ?:recordopt inner =
     % -- constants --
     let title = record#title in
     let author = record#author in
@@ -197,6 +200,11 @@ end = struct
     let ftrorg = (40pt, 780pt) in
     let hdrwid = 520pt in
     let ftrwid = 520pt in
+    let show-pages =
+      match recordopt with
+      | None -> true
+      | Some(flags) -> flags#show-pages
+    in
 
     let () =
       register-cross-reference `changed` `F`
@@ -268,10 +276,13 @@ end = struct
           bb-float-boxes
       in
       let footer =
-        let ctx = get-standard-context ftrwid in
-        let it-pageno = embed-string (arabic pbinfo#page-number) in
-          line-break true true ctx
-            (inline-fil ++ (read-inline ctx {— #it-pageno; —}) ++ inline-fil)
+        if show-pages then
+          let ctx = get-standard-context ftrwid in
+          let it-pageno = embed-string (arabic pbinfo#page-number) in
+            line-break true true ctx
+              (inline-fil ++ (read-inline ctx {— #it-pageno; —}) ++ inline-fil)
+        else
+          block-nil
       in
         (|
           header-origin  = hdrorg;


### PR DESCRIPTION
Add an option `show-pages` to `document` of stdja.satyh, stdjabook.satyh, and stdjareport.satyh.

### Usage

The option `show-pages` can be passed to the second argument of `document` as an optional argument. If `show-pages` is `false`, page numbers are not shown on page footer.

```satysfi
@require: stdjareport

document (|
  title = {Example};
  author = {nekketsuuu};
|) ?:(|
  show-pages = false;
|) '<
  +p {
    pohe
  }
>
```

This PR does not break compatibility. Existing documents can be compiled as before. The default value of `show-pages` is `true`.

```satysfi
@require: stdjareport

document (|
  title = {Example};
  author = {nekketsuuu};
|) '<
  +p {
    pohe
  }
>
```