### PR TITLE
Force to overwrite existing files while running unzip

### DIFF
--- a/satysfi.opam
+++ b/satysfi.opam
@@ -38,11 +38,11 @@ extra-source "IPAexfont00301.zip" {
 }
 build: [
   ["mkdir" "-p" "temp"]
-  ["unzip" "lm2.004otf.zip" "*.otf" "-d" "lib-satysfi/dist/fonts/"]
-  ["unzip" "latinmodern-math-1959.zip" "*.otf" "-d" "temp/"]
+  ["unzip" "-o" "lm2.004otf.zip" "*.otf" "-d" "lib-satysfi/dist/fonts/"]
+  ["unzip" "-o" "latinmodern-math-1959.zip" "*.otf" "-d" "temp/"]
   ["cp" "temp/latinmodern-math-1959/otf/latinmodern-math.otf" "lib-satysfi/dist/fonts/"]
-  ["unzip" "junicode-1.002.zip" "*.ttf" "-d" "lib-satysfi/dist/fonts/"]
-  ["unzip" "IPAexfont00301.zip" "*.ttf" "-d" "temp/"]
+  ["unzip" "-o" "junicode-1.002.zip" "*.ttf" "-d" "lib-satysfi/dist/fonts/"]
+  ["unzip" "-o" "IPAexfont00301.zip" "*.ttf" "-d" "temp/"]
   ["cp" "temp/IPAexfont00301/ipaexg.ttf" "lib-satysfi/dist/fonts/"]
   ["cp" "temp/IPAexfont00301/ipaexm.ttf" "lib-satysfi/dist/fonts/"]
   [make "-f" "Makefile" "PREFIX=%{prefix}%"]


### PR DESCRIPTION
In my environment, running `opam reinstall satysfi` after running `opam install satysfi` fails due to an error from `unzip` command. A log is the following:

```
$ opam reinstall satysfi

<><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><><><>
[satysfi.0.0.3] synchronised from file:///home/nek/dev/src/github.com/gfngfn/satysfi

The following actions will be performed:
  ↻ recompile satysfi 0.0.3*

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[ERROR] The compilation of satysfi failed at "/home/nek/.opam/opam-init/hooks/sandbox.sh build unzip
        junicode-1.002.zip *.ttf -d lib-satysfi/dist/fonts/".

#=== ERROR while compiling satysfi.0.0.3 ======================================#
# context     2.0.0 | linux/x86_64 | base-bigarray.base base-threads.base base-unix.base ocaml-base-compiler.4.06.1 | pinned(file:///home/nek/dev/src/github.com/gfngfn/satysfi)
# path        ~/.opam/4.06.1/.opam-switch/build/satysfi.0.0.3
# command     ~/.opam/opam-init/hooks/sandbox.sh build unzip junicode-1.002.zip *.ttf -d lib-satysfi/dist/fonts/
# exit-code   1
# env-file    ~/.opam/log/satysfi-7207-2dea01.env
# output-file ~/.opam/log/satysfi-7207-2dea01.out
### output ###
# Archive:  junicode-1.002.zip
# replace lib-satysfi/dist/fonts/FoulisGreek.ttf? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
# (EOF or read error, treating as "[N]one" ...)



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
┌─ The following actions failed
│ λ build satysfi 0.0.3
└─ 
╶─ No changes have been performed
```

It seems that `unzip` command fails because files to be decompressed are already existing.

So this PR adds an option `-o` to `unzip` to force the command to overwrite files. See https://superuser.com/q/100656/680903 for details of the option.