### PR TITLE
Fix typo in EvalUtil.get_script which prevents from setting fonts for OtherScript

### DIFF
--- a/src/frontend/evalUtil.ml
+++ b/src/frontend/evalUtil.ml
@@ -208,7 +208,7 @@ let get_script (value : syntactic_value) =
   | Constructor("HanIdeographic", UnitConstant) -> CharBasis.HanIdeographic
   | Constructor("Kana"          , UnitConstant) -> CharBasis.HiraganaOrKatakana
   | Constructor("Latin"         , UnitConstant) -> CharBasis.Latin
-  | Constructor("Other"         , UnitConstant) -> CharBasis.OtherScript
+  | Constructor("OtherScript"   , UnitConstant) -> CharBasis.OtherScript
   | _                                           -> report_bug_value "get_script" value
 
 


### PR DESCRIPTION
There’s a bug where it’s not possible to set a font for `OtherScript`. This PR fixes that.

## Reproducive Example
```satysfi
@require: stdjabook

let-inline ctx \greek it =
  let ctx =
    ctx |> set-font Latin (`Junicode`, 1., 0.)
      |> set-font OtherScript (`Junicode`, 1., 0.)
  in
  read-inline ctx it
in
document (|
  title = {Test file};
  author = {\@na4zagin3};
  show-title = false;
  show-toc = false;
|) '<
  +p {
    \greek{β}
  }
>
```

## Result
```
$ satysfi test.saty
 ---- ---- ---- ----
  target file: 'test.pdf'
  dump file: 'test.satysfi-aux' (already exists)
  parsing 'test.saty' ...
  parsing 'stdjabook.satyh' ...
  parsing 'pervasives.satyh' ...
  parsing 'gr.satyh' ...
  parsing 'geom.satyh' ...
  parsing 'list.satyg' ...
  parsing 'math.satyh' ...
  parsing 'color.satyh' ...
  parsing 'footnote-scheme.satyh' ...
 ---- ---- ---- ----
  reading 'list.satyg' ...
  type check passed.
 ---- ---- ---- ----
  reading 'color.satyh' ...
  type check passed.
 ---- ---- ---- ----
  reading 'pervasives.satyh' ...
  type check passed.
 ---- ---- ---- ----
  reading 'geom.satyh' ...
  type check passed.
 ---- ---- ---- ----
  reading 'gr.satyh' ...
  type check passed.
 ---- ---- ---- ----
  reading 'footnote-scheme.satyh' ...
  type check passed.
 ---- ---- ---- ----
  reading 'math.satyh' ...
  type check passed.
 ---- ---- ---- ----
  reading 'stdjabook.satyh' ...
  type check passed.
 ---- ---- ---- ----
  reading 'test.saty' ...
  type check passed. (document)
 ---- ---- ---- ----
  evaluating texts ...
[Bug]
get_script:(Constructor ("OtherScript", UnitConstant))Fatal error: exception (Failure "bug: get_script")
Raised at file "stdlib.ml", line 33, characters 17-33
Called from file "src/frontend/__evaluator.gen.ml", line 698, characters 19-51
Called from file "src/frontend/evaluator_.cppo.ml", line 173, characters 19-37
Called from file "src/frontend/evaluator_.cppo.ml", line 455, characters 26-72
Called from file "list.ml", line 88, characters 20-23
Called from file "src/frontend/evaluator_.cppo.ml", line 452, characters 4-486
Called from file "src/frontend/evaluator_.cppo.ml", line 472, characters 14-44
Called from file "src/frontend/evaluator_.cppo.ml", line 173, characters 19-37
Called from file "src/frontend/evaluator_.cppo.ml", line 409, characters 26-72
Called from file "list.ml", line 88, characters 20-23
Called from file "src/frontend/evaluator_.cppo.ml", line 406, characters 4-309
Called from file "src/frontend/evaluator_.cppo.ml", line 417, characters 16-46
Called from file "src/frontend/evaluator_.cppo.ml", line 173, characters 19-37
Called from file "src/frontend/main.ml", line 243, characters 6-33
Called from file "src/frontend/main.ml", line 292, characters 27-54
Called from file "src/frontend/main.ml", line 875, characters 14-83
Called from file "src/frontend/directedGraph.ml", line 178, characters 26-42
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/main.ml", line 872, characters 8-389
Called from file "src/frontend/main.ml", line 327, characters 4-16
Called from file "src/frontend/main.ml", line 837, characters 2-1023
zsh: exit 2     satysfi test.saty
```

## Expected Result
Must out put a PDF file which has “β”.
