### PR TITLE
Fix lexer to handle CR+LF line ending correctly

### DIFF
--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -66,20 +66,23 @@
   let rec increment_line_for_each_break lexbuf str =
     let len = String.length str in
     let has_break = ref false in
-    let rec aux num tail_spaces =
+    let rec aux num tail_spaces prev =
       if num >= len then tail_spaces else
         begin
-          match String.get str num with
-          | ( '\n' | '\r' ) ->
+          match (prev, String.get str num) with
+          | (Some '\r', '\n') ->
+              aux (num + 1) (tail_spaces + 1) (Some '\n')
+
+          | (_, c) when c = '\n' || c = '\r' ->
               has_break := true;
               increment_line lexbuf;
-              aux (num + 1) 0
+              aux (num + 1) 0 (Some c)
 
           | _ ->
-              aux (num + 1) (tail_spaces + 1)
+              aux (num + 1) (tail_spaces + 1) None
         end;
     in
-    let amt = aux 0 0 in
+    let amt = aux 0 0 None in
       if !has_break then
         adjust_bol lexbuf (-amt)
       else
@@ -109,7 +112,7 @@
 }
 
 let space = [' ' '\t']
-let break = ['\n' '\r']
+let break = ('\r' '\n' | '\n' | '\r')
 let nonbreak = [^ '\n' '\r']
 let nzdigit = ['1'-'9']
 let digit = (nzdigit | "0")


### PR DESCRIPTION
When input file's line ending is the Windows style(CR+LF), wrong error position may be shown.
This PR fixes this by treat CR+LF as one line break at lexer.

## Example
simple.saty
```
@require: stdja
  
document (|
  title = {Sample Document}; author = {gfn};
  show-title = false; show-toc = false;
|) '<
  +p{
>
```
"simple-win.saty" is a CR+LF line ending version of "simple.saty".
```
$ satysfi simple.saty
 ---- ---- ---- ----
  target file: 'simple.pdf'
  dump file: 'simple.satysfi-aux' (already exists)
  parsing 'simple.saty' ...
! [Syntax Error at Lexer] at "simple.saty", line 8, characters 0-1:
    illegal token '>' in an inline text area
$ satysfi simple-win.saty 
 ---- ---- ---- ----
  target file: 'simple-win.pdf'
  dump file: 'simple-win.satysfi-aux' (will be created)
  parsing 'simple-win.saty' ...
! [Syntax Error at Lexer] at "simple-win.saty", line 15, characters 0-1:
    illegal token '>' in an inline text area
```
Environment: Ubuntu 16.04 & SATySFi 0.0.3