### PR TITLE
Support fixed-length list pattern

### DIFF
--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -1006,11 +1006,17 @@ patbot: /* -> Types_.untyped_pattern_tree */
   | LPAREN patas RPAREN                { make_standard (Tok $1) (Tok $3) (extract_main $2) }
   | LPAREN patas COMMA pattuple RPAREN { make_standard (Tok $1) (Tok $5) (UTPTupleCons($2, $4)) }
   | BLIST ELIST                        { make_standard (Tok $1) (Tok $2) UTPEndOfList }
+  | BLIST patlist ELIST                { make_standard (Tok $1) (Tok $3) (extract_main $2) }
   | tok=LITERAL                        { let (rng, str, pre, post) = tok in make_standard (Tok rng) (Tok rng) (UTPStringConstant(rng, omit_spaces pre post str)) }
 ;
 pattuple: /* -> untyped_pattern_tree */
   | patas                { make_standard (Ranged $1) (Ranged $1) (UTPTupleCons($1, (Range.dummy "end-of-tuple-pattern", UTPEndOfTuple))) }
   | patas COMMA pattuple { make_standard (Ranged $1) (Ranged $3) (UTPTupleCons($1, $3)) }
+;
+patlist: /* -> untyped_pattern_tree */
+  | patas                   { make_standard (Ranged $1) (Ranged $1) (UTPListCons($1, (Range.dummy "end-of-list-pattern", UTPEndOfList))) }
+  | patas LISTPUNCT         { make_standard (Ranged $1) (Tok $2) (UTPListCons($1, (Range.dummy "end-of-list-pattern", UTPEndOfList))) }
+  | patas LISTPUNCT patlist { make_standard (Ranged $1) (Ranged $3) (UTPListCons($1, $3)) }
 ;
 binop:
   | UNOP_EXCLAM


### PR DESCRIPTION
This PR implements fixed-length list pattern.

Example:

```satysfi
@require: standalone
@require: stdja

let show lst =
  let-rec aux
    | [] = ` `
    | [x] = x  % <-- This line!
    | (x :: xs) = x ^ `; `# ^ (aux xs)
  in `[` ^ (aux lst) ^ `]`
let-inline \show-string str = embed-string str

in
standalone '<
  +p {
    \show-string(show [`a`; `b`; `c`]);
  }
>
```

Without this, we must write a fixed-length list explicitly by cons and nil (e.g. `x :: []` instead of `[x]`). In OCaml, we can use this kind of syntactic sugar.