### PR TITLE
Add some font functions and add bold type

### DIFF
--- a/lib-satysfi/dist/packages/stdja.satyh
+++ b/lib-satysfi/dist/packages/stdja.satyh
@@ -15,7 +15,13 @@ module StdJa : sig
       show-title : bool;
     |)
 
+  val font-latin-roman  : string * float * float
+  val font-latin-bold   : string * float * float
   val font-latin-italic : string * float * float
+  val font-latin-sans   : string * float * float
+  val font-latin-mono   : string * float * float
+  val font-cjk-mincho   : string * float * float
+  val font-cjk-gothic   : string * float * float
   direct \ref : [string] inline-cmd
   direct \ref-page : [string] inline-cmd
   direct \figure : [inline-text; block-text] inline-cmd
@@ -73,6 +79,7 @@ end = struct
   let font-ratio-cjk = 0.88
 
   let font-latin-roman  = (`Junicode`   , font-ratio-latin, 0.)
+  let font-latin-bold   = (`Junicode-b` , font-ratio-latin, 0.)
   let font-latin-italic = (`Junicode-it`, font-ratio-latin, 0.)
   let font-latin-sans   = (`lmsans`    , font-ratio-latin, 0.)
   let font-cjk-mincho   = (`ipaexm`    , font-ratio-cjk  , 0.)

--- a/lib-satysfi/dist/packages/stdjabook.satyh
+++ b/lib-satysfi/dist/packages/stdjabook.satyh
@@ -17,6 +17,7 @@ module StdJaBook : sig
     |)
 
   val font-latin-roman  : string * float * float
+  val font-latin-bold   : string * float * float
   val font-latin-italic : string * float * float
   val font-latin-sans   : string * float * float
   val font-latin-mono   : string * float * float
@@ -92,6 +93,7 @@ end = struct
   let font-ratio-cjk = 0.88
 
   let font-latin-roman  = (`Junicode`   , font-ratio-latin, 0.)
+  let font-latin-bold   = (`Junicode-b` , font-ratio-latin, 0.)
   let font-latin-italic = (`Junicode-it`, font-ratio-latin, 0.)
   let font-latin-sans   = (`lmsans`    , font-ratio-latin, 0.)
   let font-latin-mono   = (`lmmono`    , font-ratio-latin, 0.)

--- a/lib-satysfi/dist/packages/stdjareport.satyh
+++ b/lib-satysfi/dist/packages/stdjareport.satyh
@@ -16,6 +16,7 @@ module StdJaReport : sig
     |)
 
   val font-latin-roman  : string * float * float
+  val font-latin-bold   : string * float * float
   val font-latin-italic : string * float * float
   val font-latin-sans   : string * float * float
   val font-latin-mono   : string * float * float
@@ -87,6 +88,7 @@ end = struct
   let font-ratio-cjk = 0.88
 
   let font-latin-roman  = (`Junicode`   , font-ratio-latin, 0.)
+  let font-latin-bold   = (`Junicode-b` , font-ratio-latin, 0.)
   let font-latin-italic = (`Junicode-it`, font-ratio-latin, 0.)
   let font-latin-sans   = (`lmsans`    , font-ratio-latin, 0.)
   let font-latin-mono   = (`lmmono`    , font-ratio-latin, 0.)


### PR DESCRIPTION
This PR adds font functions to some class files.

Since font's function was not provided in `std.satyh`, I will add it.

- `font-latin-roman`
- `font-latin-sans`
- `font-latin-mono`
- `font-cjk-mincho`
- `font-cjk-gothic`

Since bold type was not provided, I will add it.

- `font-latin-bold`