### PR TITLE
Fix the registration of section labels in stdjareport

### DIFF
--- a/lib-satysfi/dist/packages/stdjareport.satyh
+++ b/lib-satysfi/dist/packages/stdjareport.satyh
@@ -360,7 +360,7 @@ end = struct
     in
     let ib-title = read-inline ctx-title title in
     let bb-title =
-      block-frame-breakable ctx no-pads (Annot.register-location-frame label) (fun ctx -> (
+      block-frame-breakable ctx no-pads (Annot.register-location-frame (`section:` ^ label)) (fun ctx -> (
         (section-heading ctx
           (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil)))))
     in


### PR DESCRIPTION
The current implementation of `+section` in `stdjareport` is a bit wrong so that `\ref` does not work well for section labels. This PR fixes the problem.