### PR TITLE
Ordering relation on strings

### DIFF
--- a/lib-satysfi/dist/packages/string.satyg
+++ b/lib-satysfi/dist/packages/string.satyg
@@ -1,0 +1,22 @@
+
+module String
+: sig
+    val equal : string -> string -> bool
+    val lt : string -> string -> bool
+    val gt : string -> string -> bool
+    val le : string -> string -> bool
+    val ge : string -> string -> bool
+  end
+= struct
+
+    let equal = string-same
+
+    let lt = string-lt
+
+    let gt s1 s2 = lt s2 s1
+
+    let le s1 s2 = not (gt s1 s2)
+
+    let ge s1 s2 = not (lt s1 s2)
+
+  end

--- a/src/frontend/bytecomp/vminstdef.yaml
+++ b/src/frontend/bytecomp/vminstdef.yaml
@@ -2329,6 +2329,20 @@ code: |
   BooleanConstant(String.equal str1 str2)
 
 ---
+inst: PrimitiveStringLessThan
+is-pdf-mode-primitive: yes
+is-text-mode-primitive: yes
+name: "string-lt"
+type: |
+  ~% (tS @-> tS @-> tB)
+
+params:
+- str1 : string
+- str2 : string
+code: |
+  BooleanConstant(str1 < str2)
+
+---
 inst: PrimitiveStringSub
 is-pdf-mode-primitive: yes
 is-text-mode-primitive: yes

--- a/tools/gencode/vminst.ml
+++ b/tools/gencode/vminst.ml
@@ -2575,6 +2575,22 @@ ListCons(valuehd, valuetl)
         ~code:{|
 BooleanConstant(String.equal str1 str2)
 |}
+    ; inst "PrimitiveLessThan"
+        ~name:"string-lt"
+        ~type_:{|
+~% (tS @-> tS @-> tB)
+|}
+        ~fields:[
+        ]
+        ~params:[
+          param "str1" ~type_:"string";
+          param "str2" ~type_:"string";
+        ]
+        ~is_pdf_mode_primitive:true
+        ~is_text_mode_primitive:true
+        ~code:{|
+BooleanConstant(str1 < str2)
+|}
     ; inst "PrimitiveStringSub"
         ~name:"string-sub"
         ~type_:{|


### PR DESCRIPTION
Ordering relations on strings are needed to define sort functions on strings.
This PR adds 1 primitive and 1 module.

### Added primitive

- `string-lt : string -> string -> bool`
This primitive tests whether the first argument is less than the second argument.

### Added module

- `String`
This module provides operations on strings:
  - `equal`
equal
  - `lt`
less than
  - `gt`
greater than
  - `le`
less than or equal
  - `ge`
greater than or equal

### Note

It would be arguable whether this design is good or not.