### PR TITLE
add PDF outline support

### DIFF
--- a/lib-satysfi/dist/packages/stdja.satyh
+++ b/lib-satysfi/dist/packages/stdja.satyh
@@ -4,6 +4,7 @@
 @require: list
 @require: math
 @require: color
+@require: option
 @require: annot
 
 module StdJa : sig
@@ -22,8 +23,8 @@ module StdJa : sig
   direct \figure : [inline-text; block-text] inline-cmd
   direct +p : [inline-text] block-cmd
   direct +pn : [inline-text] block-cmd
-  direct +section : [string?; inline-text; block-text] block-cmd
-  direct +subsection : [string?; inline-text; block-text] block-cmd
+  direct +section : [string?; string?; inline-text; block-text] block-cmd
+  direct +subsection : [string?; string?; inline-text; block-text] block-cmd
   direct \emph : [inline-text] inline-cmd
 
 end = struct
@@ -219,6 +220,7 @@ let title-deco =
 
 
   let-mutable toc-acc-ref <- []
+  let-mutable outline-ref <- []
 
 
   let get-cross-reference-number label =
@@ -348,7 +350,9 @@ let title-deco =
           footer-content = footer;
         |)
     in
-      page-break page pagecontf pagepartsf (bb-title +++ bb-toc +++ bb-main)
+    let doc = page-break page pagecontf pagepartsf (bb-title +++ bb-toc +++ bb-main) in
+    let () = register-outline (List.reverse !outline-ref) in
+      doc
 
 
   let-mutable needs-indentation-ref <- true
@@ -383,7 +387,7 @@ let title-deco =
       form-paragraph ctx (ib-inner ++ inline-fil)
 
 
-  let section-scheme ctx label title inner =
+  let section-scheme ctx label title outline-title-opt inner =
     let ctx-title = make-section-title ctx in
     let () = num-section <- !num-section + 1 in
     let () = num-subsection <- 0 in
@@ -396,6 +400,8 @@ let title-deco =
         ++ hook-page-break (fun pbinfo _ -> register-cross-reference (label ^ `:page`) (arabic pbinfo#page-number))
     in
     let ib-title = read-inline ctx-title title in
+    let outline-title = Option.from (extract-string ib-title) outline-title-opt in
+    let () = outline-ref <- (0, s-num ^ `. `#  ^ outline-title, label, false) :: !outline-ref in
     let bb-title =
       block-frame-breakable ctx no-pads (Annot.register-location-frame label) (fun ctx -> (
         (line-break true false (ctx |> set-paragraph-margin section-top-margin section-bottom-margin)
@@ -405,7 +411,7 @@ let title-deco =
       bb-title +++ bb-inner
 
 
-  let subsection-scheme ctx label title inner =
+  let subsection-scheme ctx label title outline-title-opt inner =
     let () = num-subsection <- !num-subsection + 1 in
     let () = needs-indentation-ref <- false in
     let s-num = arabic (!num-section) ^ `.` ^ arabic (!num-subsection) in
@@ -417,6 +423,8 @@ let title-deco =
         ++ hook-page-break (fun pbinfo _ -> register-cross-reference (label ^ `:page`) (arabic pbinfo#page-number))
     in
     let ib-title = read-inline ctx-title title in
+    let outline-title = Option.from (extract-string ib-title) outline-title-opt in
+    let () = outline-ref <- (1, s-num ^ `. `#  ^ outline-title, label, false) :: !outline-ref in
     let bb-title =
       line-break true false (ctx |> set-paragraph-margin section-top-margin section-bottom-margin)
         (inline-frame-breakable no-pads (Annot.register-location-frame label)
@@ -426,22 +434,22 @@ let title-deco =
       bb-title +++ bb-inner
 
 
-  let-block ctx +section ?:labelopt title inner =
+  let-block ctx +section ?:labelopt ?:outline-title-opt title inner =
     let label =
       match labelopt with
       | None        -> generate-fresh-label ()
       | Some(label) -> label
     in
-      section-scheme ctx label title inner
+      section-scheme ctx label title outline-title-opt inner
 
 
-  let-block ctx +subsection ?:labelopt title inner =
+  let-block ctx +subsection ?:labelopt ?:outline-title-opt title inner =
     let label =
       match labelopt with
       | None        -> generate-fresh-label ()
       | Some(label) -> label
     in
-      subsection-scheme ctx label title inner
+      subsection-scheme ctx label title outline-title-opt inner
 
 
   let-inline ctx \emph inner =

--- a/lib-satysfi/dist/packages/stdjabook.satyh
+++ b/lib-satysfi/dist/packages/stdjabook.satyh
@@ -4,6 +4,7 @@
 @require: list
 @require: math
 @require: color
+@require: option
 @require: annot
 @require: footnote-scheme
 
@@ -30,8 +31,8 @@ module StdJaBook : sig
   direct \figure : [string?; inline-text; block-text] inline-cmd
   direct +p : [inline-text] block-cmd
   direct +pn : [inline-text] block-cmd
-  direct +section : [string?; inline-text; block-text] block-cmd
-  direct +subsection : [string?; inline-text; block-text] block-cmd
+  direct +section : [string?; string?; inline-text; block-text] block-cmd
+  direct +subsection : [string?; string?; inline-text; block-text] block-cmd
   direct \emph : [inline-text] inline-cmd
   direct \footnote : [inline-text] inline-cmd
 
@@ -259,6 +260,7 @@ let title-deco =
 
 
   let-mutable toc-acc-ref <- []
+  let-mutable outline-ref <- []
 
 
   let get-cross-reference-number label =
@@ -450,7 +452,9 @@ let title-deco =
           footer-content = footer;
         |)
     in
-      page-break page pagecontf pagepartsf (bb-title +++ bb-toc +++ bb-main)
+    let doc = page-break page pagecontf pagepartsf (bb-title +++ bb-toc +++ bb-main) in
+    let () = register-outline (List.reverse !outline-ref) in
+      doc
 
 
   let-mutable needs-indentation-ref <- true
@@ -485,7 +489,7 @@ let title-deco =
       form-paragraph ctx (ib-inner ++ inline-fil)
 
 
-  let section-scheme ctx label title inner =
+  let section-scheme ctx label title outline-title-opt inner =
     let ctx-title = make-section-title ctx in
     let () = num-section <- !num-section + 1 in
     let () = num-subsection <- 0 in
@@ -498,6 +502,8 @@ let title-deco =
         ++ hook-page-break (fun pbinfo _ -> register-cross-reference (label ^ `:page`) (arabic pbinfo#page-number))
     in
     let ib-title = read-inline ctx-title title in
+    let outline-title = Option.from (extract-string ib-title) outline-title-opt in
+    let () = outline-ref <- (0, s-num ^ `. `#  ^ outline-title, label, false) :: !outline-ref in
     let bb-title =
       block-frame-breakable ctx no-pads (Annot.register-location-frame label) (fun ctx -> (
         (section-heading ctx
@@ -507,7 +513,7 @@ let title-deco =
       bb-title +++ bb-inner
 
 
-  let subsection-scheme ctx label title inner =
+  let subsection-scheme ctx label title outline-title-opt inner =
     let () = num-subsection <- !num-subsection + 1 in
     let () = needs-indentation-ref <- false in
     let s-num = arabic (!num-section) ^ `.` ^ arabic (!num-subsection) in
@@ -519,6 +525,8 @@ let title-deco =
         ++ hook-page-break (fun pbinfo _ -> register-cross-reference (label ^ `:page`) (arabic pbinfo#page-number))
     in
     let ib-title = read-inline ctx-title title in
+    let outline-title = Option.from (extract-string ib-title) outline-title-opt in
+    let () = outline-ref <- (1, s-num ^ `. `#  ^ outline-title, label, false) :: !outline-ref in
     let bb-title =
       line-break true false (ctx |> set-paragraph-margin section-top-margin section-bottom-margin)
         (inline-frame-breakable no-pads (Annot.register-location-frame label)
@@ -528,22 +536,22 @@ let title-deco =
       bb-title +++ bb-inner
 
 
-  let-block ctx +section ?:labelopt title inner =
+  let-block ctx +section ?:labelopt ?:outline-title-opt title inner =
     let label =
       match labelopt with
       | None        -> generate-fresh-label ()
       | Some(label) -> label
     in
-      section-scheme ctx label title inner
+      section-scheme ctx label title outline-title-opt inner
 
 
-  let-block ctx +subsection ?:labelopt title inner =
+  let-block ctx +subsection ?:labelopt ?:outline-title-opt title inner =
     let label =
       match labelopt with
       | None        -> generate-fresh-label ()
       | Some(label) -> label
     in
-      subsection-scheme ctx label title inner
+      subsection-scheme ctx label title outline-title-opt inner
 
 
   let-inline ctx \emph inner =

--- a/lib-satysfi/dist/packages/stdjareport.satyh
+++ b/lib-satysfi/dist/packages/stdjareport.satyh
@@ -4,6 +4,7 @@
 @require: list
 @require: math
 @require: color
+@require: option
 @require: annot
 @require: footnote-scheme
 
@@ -28,9 +29,9 @@ module StdJaReport : sig
   direct \ref-page : [string] inline-cmd
   direct \figure : [string?; inline-text; block-text] inline-cmd
   direct +p : [inline-text] block-cmd
-  direct +chapter : [string?; inline-text; block-text] block-cmd
-  direct +section : [string?; inline-text; block-text] block-cmd
-  direct +subsection : [string?; inline-text; block-text] block-cmd
+  direct +chapter : [string?; string?; inline-text; block-text] block-cmd
+  direct +section : [string?; string?; inline-text; block-text] block-cmd
+  direct +subsection : [string?; string?; inline-text; block-text] block-cmd
   direct \emph : [inline-text] inline-cmd
   direct \dfn : [inline-text] inline-cmd
   direct \footnote : [inline-text] inline-cmd
@@ -180,6 +181,7 @@ end = struct
 
 
 %  let-mutable toc-acc-ref <- []
+  let-mutable outline-ref <- []
 
 
   let get-cross-reference-number label =
@@ -307,7 +309,9 @@ end = struct
           footer-content = footer;
         |)
     in
-      page-break page pagecontf pagepartsf (bb-title +++ bb-main)
+    let doc = page-break page pagecontf pagepartsf (bb-title +++ bb-main) in
+    let () = register-outline (List.reverse !outline-ref) in
+      doc
 
 
   let-mutable num-chapter <- 0
@@ -325,7 +329,7 @@ end = struct
       form-paragraph ctx ib-parag
 
 
-  let chapter-scheme ctx label title inner =
+  let chapter-scheme ctx label title outline-title-opt inner =
     let ctx-title = make-chapter-title ctx in
     let () = increment num-chapter in
     let () = num-section <- 0 in
@@ -340,12 +344,14 @@ end = struct
                register-cross-reference (`chapter:` ^ label ^ `:page`) (arabic pageno)))
     in
     let ib-title = read-inline ctx-title title in
+    let outline-title = Option.from (extract-string ib-title) outline-title-opt in
+    let () = outline-ref <- (0, s-num ^ `. `#  ^ outline-title, `chapter:` ^ label, false) :: !outline-ref in
     let bb-title = chapter-heading ctx (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil)) in
     let bb-inner = read-block ctx inner in
       bb-title +++ bb-inner
 
 
-  let section-scheme ctx label title inner =
+  let section-scheme ctx label title outline-title-opt inner =
     let ctx-title = make-section-title ctx in
     let () = increment num-section in
     let () = num-subsection <- 0 in
@@ -359,6 +365,8 @@ end = struct
                register-cross-reference (`section:` ^ label ^ `:page`) (arabic pageno)))
     in
     let ib-title = read-inline ctx-title title in
+    let outline-title = Option.from (extract-string ib-title) outline-title-opt in
+    let () = outline-ref <- (1, s-num ^ `. `#  ^ outline-title, `section:` ^ label, false) :: !outline-ref in
     let bb-title =
       block-frame-breakable ctx no-pads (Annot.register-location-frame (`section:` ^ label)) (fun ctx -> (
         (section-heading ctx
@@ -368,7 +376,7 @@ end = struct
       bb-title +++ bb-inner
 
 
-  let subsection-scheme ctx label title inner =
+  let subsection-scheme ctx label title outline-title-opt inner =
     let () = num-subsection <- !num-subsection + 1 in
     let s-num = arabic (!num-chapter) ^ `.` ^ arabic (!num-section) ^ `.` ^ arabic (!num-subsection) in
     let () = register-cross-reference (label ^ `:num`) s-num in
@@ -379,6 +387,8 @@ end = struct
         ++ hook-page-break (fun pbinfo _ -> register-cross-reference (label ^ `:page`) (arabic pbinfo#page-number))
     in
     let ib-title = read-inline ctx-title title in
+    let outline-title = Option.from (extract-string ib-title) outline-title-opt in
+    let () = outline-ref <- (2, s-num ^ `. `#  ^ outline-title, label, false) :: !outline-ref in
     let bb-title =
       line-break true false (ctx |> set-paragraph-margin section-top-margin section-bottom-margin)
         (inline-frame-breakable no-pads (Annot.register-location-frame label)
@@ -388,31 +398,31 @@ end = struct
       bb-title +++ bb-inner
 
 
-  let-block ctx +chapter ?:labelopt title inner =
+  let-block ctx +chapter ?:labelopt ?:outline-title-opt title inner =
     let label =
       match labelopt with
       | None        -> generate-fresh-label ()
       | Some(label) -> label
       in
-        chapter-scheme ctx label title inner
+        chapter-scheme ctx label title outline-title-opt inner
 
 
-  let-block ctx +section ?:labelopt title inner =
+  let-block ctx +section ?:labelopt ?:outline-title-opt title inner =
     let label =
       match labelopt with
       | None        -> generate-fresh-label ()
       | Some(label) -> label
     in
-      section-scheme ctx label title inner
+      section-scheme ctx label title outline-title-opt inner
 
 
-  let-block ctx +subsection ?:labelopt title inner =
+  let-block ctx +subsection ?:labelopt ?:outline-title-opt title inner =
     let label =
       match labelopt with
       | None        -> generate-fresh-label ()
       | Some(label) -> label
     in
-      subsection-scheme ctx label title inner
+      subsection-scheme ctx label title outline-title-opt inner
 
 
   let-inline ctx \emph inner =

--- a/src/backend/handlePdf.ml
+++ b/src/backend/handlePdf.ml
@@ -375,6 +375,8 @@ let write_to_file ((PDF(pdf, pageacc, flnm)) : t) : unit =
     )
   in
   let (pdfsub, irpageroot) = Pdfpage.add_pagetree pagelst pdf in
-  let pdfout = Pdfpage.add_root irpageroot [] pdfsub in
-  let pdfout = NamedDest.add_to_pdf pdfout in
+  let pdfout = pdfsub |> (Pdfpage.add_root irpageroot [])
+                      |> Outline.add_to_pdf
+                      |> NamedDest.add_to_pdf
+  in
     Pdfwrite.pdf_to_file pdfout flnm

--- a/src/backend/horzBox.ml
+++ b/src/backend/horzBox.ml
@@ -1,4 +1,5 @@
 
+open MyUtil
 open LengthInterface
 open GraphicBase
 
@@ -515,3 +516,21 @@ let get_metrics_of_intermediate_horz_box_list (imhblst : intermediate_horz_box l
     in
       (wid +% w, Length.max hgt h, Length.min dpt d)
   ) (Length.zero, Length.zero, Length.zero)
+
+
+let rec extract_string (hblst : horz_box list) : string =
+  let rec extract_one hb =
+    match hb with
+    | HorzPure(PHCInnerString(_, uchlst))             -> string_of_uchlst uchlst
+    | HorzPure(PHCInnerMathGlyph(_, _, _, _, otxt))   -> ""
+    | HorzPure(PHGRising(_, hblst))                   -> extract_string hblst
+    | HorzPure(PHGFixedFrame(_, _, _, hblst))         -> extract_string hblst
+    | HorzPure(PHGInnerFrame(_, _, hblst))            -> extract_string hblst
+    | HorzPure(PHGOuterFrame(_, _, hblst))            -> extract_string hblst
+    | HorzDiscretionary(_, hblst1, hblst2, hblst3) ->
+      extract_string hblst1 ^ extract_string hblst2 ^ extract_string hblst3
+    | HorzFrameBreakable(_, _, _, _, _, _, _, hblst)  -> extract_string hblst
+    | HorzScriptGuard(_, hblst)                       -> extract_string hblst
+    | _ -> ""
+  in
+    String.concat "" (List.map extract_one hblst)

--- a/src/backend/internalText.mli
+++ b/src/backend/internalText.mli
@@ -9,6 +9,8 @@ val to_utf8 : t -> string
 
 val to_utf16be_hex : t -> string
 
+val to_utf16be : t -> string
+
 val to_uchar_list : t -> Uchar.t list
 
 val of_uchar : Uchar.t -> t

--- a/src/backend/outline.ml
+++ b/src/backend/outline.ml
@@ -1,0 +1,26 @@
+
+open MyUtil
+open LengthInterface
+open Length
+
+
+let registered_outline : (int * string * string * bool) list ref = ref []
+
+
+let make_entry (level, text, key, isopen) =
+  let destname = NamedDest.get key in
+    {
+      Pdfmarks.level  = level;
+      Pdfmarks.text   = InternalText.to_utf16be (InternalText.of_utf8 text);
+      Pdfmarks.dest   = Pdfdest.NullDestination;
+      Pdfmarks.action = Pdfaction.GotoName(destname);
+      Pdfmarks.isopen = isopen;
+    }
+
+
+let add_to_pdf pdf =
+  Pdfmarks.add_bookmarks (List.map make_entry !registered_outline) pdf
+
+
+let register ol =
+  registered_outline := ol

--- a/src/backend/outline.mli
+++ b/src/backend/outline.mli
@@ -1,0 +1,4 @@
+
+val add_to_pdf : Pdf.t -> Pdf.t
+
+val register : (int * string * string * bool) list -> unit

--- a/src/frontend/bytecomp/vminstdef.yaml
+++ b/src/frontend/bytecomp/vminstdef.yaml
@@ -2041,6 +2041,18 @@ code-interp: |
   InputHorzWithEnvironment([ImInputHorzText(str)], env)
 
 ---
+inst: PrimitiveExtract
+is-pdf-mode-primitive: yes
+is-text-mode-primitive: yes
+name: "extract-string"
+type: |
+  ~% (tIB @-> tS)
+params:
+  - hblst : horz
+code: |
+  StringConstant(HorzBox.extract_string hblst)
+
+---
 inst: PrimitiveGetAxisHeight
 is-pdf-mode-primitive: yes
 name: "get-axis-height"
@@ -3131,4 +3143,16 @@ code: |
   let borderopt = get_option (get_pair get_length get_color) vborderopt in
   let destname = NamedDest.get name in
   Annotation.register (Annotation.Link(Action.GotoName(destname))) (pt, wid, hgt, dpt) borderopt;
+  UnitConstant
+
+---
+inst: BackendRegisterOutline
+is-pdf-mode-primitive : yes
+name: "register-outline"
+type: |
+  ~% ((tL(tPROD [tI; tS; tS; tB])) @-> tU)
+params:
+  - ol
+code: |
+  Outline.register (get_list get_outline ol);
   UnitConstant

--- a/src/frontend/evalUtil.ml
+++ b/src/frontend/evalUtil.ml
@@ -480,6 +480,16 @@ let get_math_variant_style value =
     | _ -> report_bug_value "get_math_variant_style: missing some fields" value
 
 
+let get_outline (value : syntactic_value) =
+  match value with
+  | TupleCons(IntegerConstant(level),
+      TupleCons(StringConstant(text),
+        TupleCons(StringConstant(key),
+          TupleCons(BooleanConstant(isopen), EndOfTuple)))) ->
+    (level, text, key, isopen)
+  | _ -> report_bug_value "get_outline" value
+
+
 let make_page_break_info pbinfo =
   let asc =
     Assoc.of_list [

--- a/src/myUtil.ml
+++ b/src/myUtil.ml
@@ -14,6 +14,12 @@ let ascii_small_of_index i =
   Uchar.of_int ((Char.code 'a') + i)
 
 
+let string_of_uchlst uchlst =
+  let buffer = Buffer.create ((List.length uchlst) * 4) in
+    List.iter (fun u -> Uutf.Buffer.add_utf_8 buffer u) uchlst;
+    Buffer.contents buffer
+
+
 let rec range i j =
   if i > j then [] else
     i :: (range (i + 1) j)

--- a/src/myUtil.mli
+++ b/src/myUtil.mli
@@ -7,6 +7,8 @@ val ascii_capital_of_index : int -> Uchar.t
 
 val ascii_small_of_index : int -> Uchar.t
 
+val string_of_uchlst : Uchar.t list -> string
+
 val range : int -> int -> int list
 
 val list_make : int -> 'a -> 'a list


### PR DESCRIPTION
This PR adds PDF outline support(also called "Bookmark").

This PR requires some camlpdf extensions of gfngfn/camlpdf#2. (So, CI tests may fail.)

# Added primitives
* `register-outline : (int * string * string * bool) list -> unit`
This primitive registers a document outline. Given quartet contains depth of hierarchy, text, label of named destination and default open state.
* `extract-string : inline-boxes -> string`
This primitive extracts string from inline-boxes. Some contents like a math command are ignored. This primitive is used to get a section title as string.

# Changed packages
* `+chapter` `+section` `+subsection` in `stdja` `stdjabook` `stdjareport`
2nd optional argument `outline-titile-opt : string?` is added to these commands. If this optional argument is specified, that string is used as an alternative title for PDF outline.