### PR TITLE
fix \ref in stdjareport

### DIFF
--- a/lib-satysfi/dist/packages/stdjareport.satyh
+++ b/lib-satysfi/dist/packages/stdjareport.satyh
@@ -345,7 +345,7 @@ end = struct
     in
     let ib-title = read-inline ctx-title title in
     let outline-title = Option.from (extract-string ib-title) outline-title-opt in
-    let () = outline-ref <- (0, s-num ^ `. `#  ^ outline-title, `chapter:` ^ label, false) :: !outline-ref in
+    let () = outline-ref <- (0, s-num ^ `. `#  ^ outline-title, label, false) :: !outline-ref in
     let bb-title =
       block-frame-breakable ctx no-pads (Annot.register-location-frame label) (fun ctx -> (
         chapter-heading ctx (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil))))
@@ -369,7 +369,7 @@ end = struct
     in
     let ib-title = read-inline ctx-title title in
     let outline-title = Option.from (extract-string ib-title) outline-title-opt in
-    let () = outline-ref <- (1, s-num ^ `. `#  ^ outline-title, `section:` ^ label, false) :: !outline-ref in
+    let () = outline-ref <- (1, s-num ^ `. `#  ^ outline-title, label, false) :: !outline-ref in
     let bb-title =
       block-frame-breakable ctx no-pads (Annot.register-location-frame label) (fun ctx -> (
         (section-heading ctx

--- a/lib-satysfi/dist/packages/stdjareport.satyh
+++ b/lib-satysfi/dist/packages/stdjareport.satyh
@@ -331,16 +331,19 @@ end = struct
     let () = num-section <- 0 in
     let () = num-subsection <- 0 in
     let s-num = arabic (!num-chapter) in
-    let () = register-cross-reference (`chapter:` ^ label ^ `:num`) s-num in
+    let () = register-cross-reference (label ^ `:num`) s-num in
 %    let () = toc-acc-ref <- (TOCElementChapter(label, title)) :: !toc-acc-ref in
     let ib-num =
       read-inline ctx-title (embed-string (s-num ^ `.`))
         ++ hook-page-break (fun pbinfo _ -> (
              let pageno = pbinfo#page-number in
-               register-cross-reference (`chapter:` ^ label ^ `:page`) (arabic pageno)))
+               register-cross-reference (label ^ `:page`) (arabic pageno)))
     in
     let ib-title = read-inline ctx-title title in
-    let bb-title = chapter-heading ctx (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil)) in
+    let bb-title =
+      block-frame-breakable ctx no-pads (Annot.register-location-frame label) (fun ctx -> (
+        chapter-heading ctx (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil))))
+    in
     let bb-inner = read-block ctx inner in
       bb-title +++ bb-inner
 
@@ -350,17 +353,17 @@ end = struct
     let () = increment num-section in
     let () = num-subsection <- 0 in
     let s-num = arabic (!num-chapter) ^ `.` ^ arabic (!num-section) in
-    let () = register-cross-reference (`section:` ^ label ^ `:num`) s-num in
+    let () = register-cross-reference (label ^ `:num`) s-num in
 %    let () = toc-acc-ref <- (TOCElementSection(label, title)) :: !toc-acc-ref in
     let ib-num =
       read-inline ctx-title (embed-string (s-num ^ `.`))
         ++ hook-page-break (fun pbinfo _ -> (
              let pageno = pbinfo#page-number in
-               register-cross-reference (`section:` ^ label ^ `:page`) (arabic pageno)))
+               register-cross-reference (label ^ `:page`) (arabic pageno)))
     in
     let ib-title = read-inline ctx-title title in
     let bb-title =
-      block-frame-breakable ctx no-pads (Annot.register-location-frame (`section:` ^ label)) (fun ctx -> (
+      block-frame-breakable ctx no-pads (Annot.register-location-frame label) (fun ctx -> (
         (section-heading ctx
           (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil)))))
     in


### PR DESCRIPTION
`\ref` in `stdjareport` was fixed in #130 but it seems to be still wrong.
* When `section-scheme` registers section number or page number with `register-cross-reference`,  extra string `section:` is added in front of label. `\ref` command doesn't add `section:` to label when search label with `get-cross-reference`. So, it couldn't find appropriate section number or page number.
* `Annot.register-location-frame` isn't called in `chapter-scheme`. So, hyperlink doesn't work. (I missed `chapter-scheme`. Sorry!) 