### PR TITLE
Improve image related error

### DIFF
--- a/src/backend/imageHashTable.ml
+++ b/src/backend/imageHashTable.ml
@@ -53,7 +53,7 @@ let add_pdf (srcpath : file_path) (pageno : int) =
     | Pdf.PDFError(msg) -> raise (CannotLoadPdf(msg, srcpath, pageno))
   in
     if pageno < 1 then
-      raise (CannotLoadPdf("Page number should be greater than 1", srcpath, pageno))
+      raise (CannotLoadPdf("Page number should be greater than 0", srcpath, pageno))
     else
       match LoadPdf.get_page pdfext (pageno - 1) with
       | None               -> raise (CannotLoadPdf("Invalid page number", srcpath, pageno))

--- a/src/backend/imageHashTable.ml
+++ b/src/backend/imageHashTable.ml
@@ -13,9 +13,10 @@ type value_main =
 
 type value = tag * bbox * value_main
 
-exception CannotLoadPdf          of file_path * int
+exception CannotLoadPdf          of string * file_path * int
+exception CannotLoadImage        of string * file_path
 exception ImageOfWrongFileType   of file_path
-exception UnsupportedColorModel  of Images.colormodel
+exception UnsupportedColorModel  of Images.colormodel * file_path
 
 
 let main_hash_table : (key, value) Hashtbl.t = Hashtbl.create 32
@@ -49,22 +50,26 @@ let generate_tag () : key * tag =
 let add_pdf (srcpath : file_path) (pageno : int) =
   let pdfext =
     try Pdfread.pdf_of_file None None srcpath with
-    | Pdf.PDFError(_) -> raise (CannotLoadPdf(srcpath, pageno))
+    | Pdf.PDFError(msg) -> raise (CannotLoadPdf(msg, srcpath, pageno))
   in
-    match LoadPdf.get_page pdfext (pageno - 1) with
-    | None               -> raise (CannotLoadPdf(srcpath, pageno))
-    | Some((bbox, page)) ->
-        let (key, tag) = generate_tag () in
-        begin
-          Hashtbl.add main_hash_table key (tag, bbox, PDFImage(pdfext, page));
-          key
-        end
+    if pageno < 1 then
+      raise (CannotLoadPdf("Page number should be greater than 1", srcpath, pageno))
+    else
+      match LoadPdf.get_page pdfext (pageno - 1) with
+      | None               -> raise (CannotLoadPdf("Invalid page number", srcpath, pageno))
+      | Some((bbox, page)) ->
+          let (key, tag) = generate_tag () in
+          begin
+            Hashtbl.add main_hash_table key (tag, bbox, PDFImage(pdfext, page));
+            key
+          end
 
 
 let add_image (srcpath : file_path) =
   let (imgfmt, imgheader) =
     try Images.file_format srcpath with
     | Images.Wrong_file_type -> raise (ImageOfWrongFileType(srcpath))
+    | Sys_error(msg)         -> raise (CannotLoadImage(msg, srcpath))
   in
   let infolst = imgheader.Images.header_infos in
   let widdots = imgheader.Images.header_width in
@@ -97,7 +102,7 @@ let add_image (srcpath : file_path) =
     | Images.RGB   -> Pdf.Name("/DeviceRGB")
     | Images.YCbCr -> Pdf.Name("/DeviceRGB")
     | Images.CMYK  -> Logging.warn_cmyk_image srcpath; Pdf.Name("/DeviceCMYK")
-    | _            -> raise (UnsupportedColorModel(colormodel))
+    | _            -> raise (UnsupportedColorModel(colormodel, srcpath))
   in
   let pdf_points_of_inches inch = 72. *. inch in
   let wid = pdf_points_of_inches ((float_of_int widdots) /. dpi) in

--- a/src/backend/imageHashTable.mli
+++ b/src/backend/imageHashTable.mli
@@ -13,6 +13,11 @@ type value_main =
 
 type value = tag * bbox * value_main
 
+exception CannotLoadPdf          of string * file_path * int
+exception CannotLoadImage        of string * file_path
+exception ImageOfWrongFileType   of file_path
+exception UnsupportedColorModel  of Images.colormodel * file_path
+
 val initialize : unit -> unit
 
 val add_pdf : file_path -> int -> key

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -467,6 +467,30 @@ let error_log_environment suspended =
         NormalLine("is not a single font file; it is a TrueType collection.");
       ]
 
+  | ImageHashTable.CannotLoadPdf(msg, srcpath, pageno) ->
+      report_error Interface [
+        NormalLine("cannot load PDF file '" ^ srcpath ^ "' page #" ^ (string_of_int pageno) ^ ";");
+        DisplayLine(msg);
+      ]
+
+  | ImageHashTable.CannotLoadImage(msg, srcpath) ->
+      report_error Interface [
+        NormalLine("cannot load image file '" ^ srcpath ^ "';");
+        DisplayLine(msg);
+      ]
+
+  | ImageHashTable.ImageOfWrongFileType(srcpath) ->
+      report_error Interface [
+        NormalLine("cannot load image file '" ^ srcpath ^ "';");
+        DisplayLine("This file format is not supported.");
+      ]
+
+  | ImageHashTable.UnsupportedColorModel(_, srcpath) ->
+      report_error Interface [
+        NormalLine("cannot load image file '" ^ srcpath ^ "';");
+        DisplayLine("This color model is not supported.");
+      ]
+
   | Lexer.LexError(rng, s) ->
       report_error Lexer [
         NormalLine("at " ^ (Range.to_string rng) ^ ":");


### PR DESCRIPTION
Currently, error messages about image loading are a bit unkind.

Wrong file format:
```
  evaluating texts ...
Fatal error: exception ImageHashTable.ImageOfWrongFileType("a.png")
Raised at file "src/backend/imageHashTable.ml", line 67, characters 32-69
... backtrace ...
```
PDF file not found:
```
  evaluating texts ...
Fatal error: exception ImageHashTable.CannotLoadPdf("a.pd", 1)
Raised at file "src/backend/imageHashTable.ml", line 52, characters 25-63
... backtrace ...
```
PDF page not found:
```
  evaluating texts ...
Fatal error: exception ImageHashTable.CannotLoadPdf("a.pdf", 2)
Raised at file "src/backend/imageHashTable.ml", line 55, characters 28-66
... backtrace ...
```

This PR improves these error messages as follows:
```
  evaluating texts ...
! [Error] cannot load image file 'a.png';
      This file format is not supported.
```

```
  evaluating texts ...
! [Error] cannot load PDF file 'a.pd' page #1;
      a.pd: No such file or directory
```

```
  evaluating texts ...
! [Error] cannot load PDF file 'a.pdf' page #2;
      Invalid page number
```