### PR TITLE
[RFC] Support processing Omd.Img for Markdown image

### DIFF
--- a/lib-satysfi/dist/md/mdja.satysfi-md
+++ b/lib-satysfi/dist/md/mdja.satysfi-md
@@ -29,6 +29,7 @@
   "code-default": "\\code",
   "url": "\\link",
   "reference": "\\reference",
+  "img": "\\img",
   "embed-block": "\\embed-block",
   "err-inline": "\\error"
 }

--- a/lib-satysfi/dist/packages/mdja.satyh
+++ b/lib-satysfi/dist/packages/mdja.satyh
@@ -32,6 +32,7 @@ module MDJa : sig
   direct \bold : [inline-text] inline-cmd
   direct \link : [string; inline-text] inline-cmd
   direct \reference : [string; string; (string * string) option] inline-cmd
+  direct \img : [string; string; string] inline-cmd
   direct \hard-break : [] inline-cmd
   direct \embed-block : [block-text] inline-cmd
   direct \error : [string] inline-cmd
@@ -354,6 +355,8 @@ end = struct
         let it-tag = embed-string tag in
         read-inline ctx {\jump(key-pdf-loc){#it; [#it-tag;]}}
 
+  let-inline ctx \img alt src title =
+    use-image-by-width (load-image src) 5cm
 
   let-inline ctx \hard-break =
     mandatory-break ctx
@@ -367,5 +370,3 @@ end = struct
     let ctx = ctx |> set-text-color Color.red in
     let it = embed-string s in
     read-inline ctx {ERROR (I): \"#it;\"}
-
-end

--- a/src/frontend/loadMDSetting.ml
+++ b/src/frontend/loadMDSetting.ml
@@ -143,6 +143,7 @@ let read_assoc (srcpath : file_path) (assoc : MYU.assoc) =
       code_default       = assoc |> inline "code-default";
       url                = assoc |> inline "url";
       reference          = assoc |> inline "reference";
+      img                = assoc |> inline "img";
       embed_block        = assoc |> inline "embed-block";
       err_inline         = assoc |> inline "err-inline";
     }

--- a/src/md/decodeMD.ml
+++ b/src/md/decodeMD.ml
@@ -30,6 +30,7 @@ and inline_element =
   | Br
   | Url of string * inline * string
   | Ref of string * string * (string * string) option
+  | Img of string * string * string
   | InlineRaw of string
   | EmbeddedBlock of block
 
@@ -95,7 +96,7 @@ let rec make_inline_of_element (mde : Omd.element) =
 *)
 
   | Omd.Img(alt, src, title) ->
-      failwith (Printf.sprintf "Img; remiains to be supported: alt='%s', src'%s', title='%s'" alt src title)
+      single @@ Img(alt, src, title)
 
   | Omd.Img_ref(_, name, alt, _) ->
       failwith (Printf.sprintf "Img_ref; remains to be supported: name='%s', alt='%s'" name alt)
@@ -260,6 +261,7 @@ type command_record = {
   code_default       : command;
   url                : command;
   reference          : command;
+  img                : command;
   embed_block        : command;
   err_inline         : command;
 }
@@ -347,6 +349,12 @@ let rec convert_inline_element (cmdrcd : command_record) (ilne : inline_element)
 
       in
       make_inline_application cmdrcd.reference [utastarg1; utastarg2; utastarg3]
+
+  | Img(alt, src, title) ->
+      let utastarg1 = (dummy_range, UTStringConstant(alt)) in
+      let utastarg2 = (dummy_range, UTStringConstant(src)) in
+      let utastarg3 = (dummy_range, UTStringConstant(title)) in
+      make_inline_application cmdrcd.img [utastarg1; utastarg2; utastarg3]
 
   | EmbeddedBlock(blk) ->
       let utastarg = convert_block cmdrcd blk in

--- a/src/md/decodeMD.mli
+++ b/src/md/decodeMD.mli
@@ -33,6 +33,7 @@ type command_record = {
   code_default       : command;
   url                : command;
   reference          : command;
+  img                : command;
   embed_block        : command;
   err_inline         : command;
 }


### PR DESCRIPTION
[This document](https://github.com/gfngfn/SATySFi/wiki/SATySFiによるMarkdown文書からのPDF出力) written by @gfngfn says that the current SATySFi does not support Markdown image intentionally.
However, implementing this functionality is quite simple as shown in this p-r. (This patch is not completed but you can see that the change is very small.) 
I want to discuss about why this functionality is not supported for now and what is the potential solution. 
