### PR TITLE
Check whether constrained type variables match record types

### DIFF
--- a/src/frontend/typeenv.ml
+++ b/src/frontend/typeenv.ml
@@ -1034,7 +1034,9 @@ let reflects (Poly(pty1) : poly_type) (Poly(pty2) : poly_type) : bool =
               let binc =
                 match kd2 with
                 | UniversalKind      -> true
-                | RecordKind(tyasc2) -> Assoc.domain_included tyasc2 tyasc1
+                | RecordKind(tyasc2) ->
+                    Assoc.domain_included tyasc2 tyasc1 &&
+                    List.fold_left (fun b (x, y) -> b && aux x y) true (Assoc.intersection tyasc1 tyasc2)
               in
               if not binc then false else
                 begin


### PR DESCRIPTION
This pull request fixes #127.

I think matching a type variable which has a record kind to a record type should consider not only the domain of the 2 records, but also the range of 2 records.

Note that I'm not familiar with OCaml and I don't so understand the source code.
