### PR TITLE
Add Wiki's link to README

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -119,3 +119,7 @@ satysfi doc.saty -o output.pdf
 * `--type-check-only`: 型検査だけをして終了します。
 * `--debug-show-bbox`: （デバッグ目的で）各グリフにバウンディングボックスをつけて出力します。
 * `--debug-show-space`: （デバッグ目的で）スペース部分に目印をつけて出力します。
+
+## SATySFiを学ぶ
+
+[Wiki](https://github.com/gfngfn/SATySFi/wiki/SATySFi-Wiki#%E5%AD%A6%E7%BF%92%E7%94%A8%E8%B3%87%E6%96%99)に学習用の資料があります。

--- a/README.md
+++ b/README.md
@@ -134,3 +134,7 @@ in order to convert `<input file>` into `<output file>`. For example, when you w
 * `--type-check-only`: Stops after type checking.
 * `--debug-show-bbox`: Outputs bounding boxes for each glyph (for the purpose of debugging).
 * `--debug-show-space`: Outputs boxes for spaces (for the purpose of debugging).
+
+## Learning SATySFi
+
+[Wiki(Japanese)](https://github.com/gfngfn/SATySFi/wiki/SATySFi-Wiki#%E5%AD%A6%E7%BF%92%E7%94%A8%E8%B3%87%E6%96%99) has some information about learning SATySFi.


### PR DESCRIPTION
Adding [Wiki](https://github.com/gfngfn/SATySFi/wiki/SATySFi-Wiki#%E5%AD%A6%E7%BF%92%E7%94%A8%E8%B3%87%E6%96%99)'s link to README will help beginners.

Currently, README has no information about syntax of SATySFi.
Though reading Wiki is common sense, wiki's link in README will help some careless beginners(me).