### PR TITLE
OPAM: add synopsis and description

### DIFF
--- a/satysfi.opam
+++ b/satysfi.opam
@@ -72,3 +72,6 @@ depends: [
   "yojson" {= "1.4.1+satysfi"}
   "omd"
 ]
+synopsis: "A statically-typed, functional typesetting system"
+description: """
+SATySFi is a typesetting system with a static type system. It consists mainly of two “layers” ― the text layer and the program layer. The former is for writing documents in LaTeX-like syntax. The latter, which has ML-like syntax, is for defining functions and commands. SATySFi enables you to write documents markuped with flexible commands of your own making. In addition, its informative type error reporting will be a good help to your writing."""


### PR DESCRIPTION
Currently, OPAM2 produces the following warning after running `opam pin add satysfi .`:

```
[WARNING] Failed checks on satysfi package definition from source at git+file:///mnt/c/Users/nek/go/src/github.com/gfngfn/satysfi#master:
    error 57: Synopsis and description must not be both empty
```

This PR resolves this warning by adding synopsis and description copied from README.md.

See [this document](https://opam.ocaml.org/doc/Packaging.html) or [other packages' OPAM files](https://github.com/ocaml/opam-repository/tree/master/packages) for detailed explanation of these fields.