### PR TITLE
Fix a bug of the typechecker

### DIFF
--- a/src/frontend/typechecker.ml
+++ b/src/frontend/typechecker.ml
@@ -451,6 +451,12 @@ let rec unify_sub ((rng1, tymain1) as ty1 : mono_type) ((rng2, tymain2) as ty2 :
             tvref1 := MonoLink(newty2)
 
       | (TypeVariable({contents= MonoFree(tvid1)} as tvref1), _) ->
+          let kd1 = FreeID.get_kind tvid1 in
+          let () =
+            match kd1 with
+            | UniversalKind -> ()
+            | RecordKind(_) -> raise InternalContradictionError
+          in
           let chk = occurs tvid1 ty2 in
           if chk then
             raise InternalInclusionError


### PR DESCRIPTION
## The problem

Surprisingly, the following unsafe code (named `test.saty`) passes typechecking for now.

```
@require: stdjareport

let _ = 0#l in

StdJaReport.document (|
  title = {};
  author = {};
|) '<
>
```
The output of `satysfi test.saty`:

```
 ---- ---- ---- ----
  target file: 'test.pdf'

...

  reading 'test.saty' ...
  type check passed. (document)
 ---- ---- ---- ----
  evaluating texts ...
[Bug] AccessField: not a Record:(Value (IntegerConstant 0)) --->*
(IntegerConstant 0)Fatal error: exception (Failure "bug: AccessField: not a Record")
Raised at file "pervasives.ml", line 32, characters 17-33
Called from file "src/frontend/evaluator.cppo.ml", line 171, characters 19-37
Called from file "src/frontend/main.ml", line 265, characters 6-33
Called from file "src/frontend/main.ml", line 314, characters 27-54
Called from file "src/frontend/main.ml", line 901, characters 14-83
Called from file "src/frontend/directedGraph.ml", line 178, characters 26-42
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/directedGraph.ml", line 202, characters 12-24
Called from file "src/frontend/main.ml", line 898, characters 8-389
Called from file "src/frontend/main.ml", line 350, characters 4-16
Called from file "src/frontend/main.ml", line 856, characters 2-1023
```

In this situation, `0` is treated as a record (with label `l`).

## Solution

This pull request modifies `unify_sub` function so that the typechecker can prevent non-records from being treated as records.