### PR TITLE
add -C command line option (fix #154)

### DIFF
--- a/src/backend/optionState.ml
+++ b/src/backend/optionState.ml
@@ -15,6 +15,7 @@ type state = {
   mutable debug_show_bbox : bool;
   mutable debug_show_space : bool;
   mutable mode             : (string list) option;
+  mutable extra_config_paths : string list option;
 }
 
 
@@ -28,6 +29,7 @@ let state = {
   debug_show_bbox = false;
   debug_show_space = false;
   mode             = None;
+  extra_config_paths = None;
 }
 
 let set_input_kind ikd = state.input_kind <- ikd
@@ -65,3 +67,6 @@ let is_text_mode () =
   match state.mode with
   | Some(_) -> true
   | None -> false
+
+let set_extra_config_paths lst = state.extra_config_paths <- Some(lst)
+let get_extra_config_paths () = state.extra_config_paths

--- a/src/backend/optionState.mli
+++ b/src/backend/optionState.mli
@@ -34,3 +34,6 @@ val debug_show_space : unit -> bool
 val set_text_mode : string list -> unit
 val get_mode : unit -> (string list) option
 val is_text_mode : unit -> bool
+
+val set_extra_config_paths : string list -> unit
+val get_extra_config_paths : unit -> string list option


### PR DESCRIPTION
Satysfi's config search path is modified as follows:

- without -C option: $(PWD)/.satysfi, $HOME/.satysfi, /usr/local/share/satysfi, /usr/share/satysfi
- with -C path1[:path2,...]: path1, [path2, ..., ] $HOME/.satysfi, /usr/local/share/satysfi, /usr/share/satysfi