### PR TITLE
Report ParseErrorDetail in common format

### DIFF
--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -608,7 +608,11 @@ let error_log_environment suspended =
       ]
 
   | Parsing.Parse_error -> report_error Parser [ NormalLine("something is wrong."); ]
-  | ParseErrorDetail(s) -> report_error Parser [ NormalLine(s); ]
+  | ParseErrorDetail(rng, s) ->
+      report_error Parser [
+        NormalLine("at " ^ (Range.to_string rng) ^ ":");
+        NormalLine(s)
+      ]
 
   | IllegalArgumentLength(rng, len, lenexp) ->
       report_error Parser [

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -340,9 +340,8 @@
           let newresitmz = insert_last [] resitmz 1 depth utast in
             make_list_to_itemize_sub newresitmz tail depth
         else
-          raise (ParseErrorDetail("syntax error: illegal item depth "
-            ^ (string_of_int depth) ^ " after " ^ (string_of_int crrntdp) ^ "\n"
-            ^ "    " ^ (Range.to_string rng)))
+          raise (ParseErrorDetail(rng, "syntax error: illegal item depth "
+            ^ (string_of_int depth) ^ " after " ^ (string_of_int crrntdp)))
 
   and insert_last (resitmzlst : untyped_itemize list) (itmz : untyped_itemize) (i : int) (depth : int) (utast : untyped_abstract_tree) : untyped_itemize =
     match itmz with
@@ -361,14 +360,14 @@
     match rngknd with
     | Tok(rng) ->
           raise (ParseErrorDetail(
+            rng,
             "syntax error:\n"
-            ^ "    unexpected token after '" ^ tok ^ "'\n"
-            ^ "    " ^ (Range.to_string rng)))
+            ^ "    unexpected token after '" ^ tok ^ "'"))
     | Ranged((rng, nm)) ->
           raise (ParseErrorDetail(
+            rng,
             "syntax error:\n"
-            ^ "    unexpected token after '" ^ nm ^ "'\n"
-            ^ "    " ^ (Range.to_string rng)))
+            ^ "    unexpected token after '" ^ nm ^ "'"))
     | _ -> assert false
 
 

--- a/src/frontend/types.cppo.ml
+++ b/src/frontend/types.cppo.ml
@@ -2,7 +2,7 @@
 open LengthInterface
 open GraphicBase
 
-exception ParseErrorDetail of string
+exception ParseErrorDetail of Range.t * string
 exception IllegalArgumentLength of Range.t * int * int
 
 


### PR DESCRIPTION
For ease of editor support, this patch changes the reporting format for `ParseErrorDetail` so that the range of error is printed on the same line with the "!" marker, as for other types of errors.

I'm developing Emacs support for SATySFi and find it would be helpful if all kinds of errors would be reported in the same format to highlight error locations correctly in the editor.