### PR TITLE
Fix math1.saty in the doc directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,5 @@ install:
   - opam install -y --deps-only satysfi
 script:
   - make all
+  - cd demo
+  - make

--- a/doc/math1.saty
+++ b/doc/math1.saty
@@ -1,7 +1,7 @@
 % -*- coding: utf-8 -*-
 @require: stdja
 @require: proof
-@import: tabular
+@require: tabular
 
 let-math \overwrite mf ma mb =
   ${#mf\sqbracket{#ma \mapsto #mb}}


### PR DESCRIPTION
I fixed `math1.saty` to be able to compile. Before I fixed it `satysfi` said this error:

```
! [Type Error] at "math1.saty", line 92, character 12 to line 94, character 6:
    this expression has type
      (inline-text -> 'a) -> (...?-> int -> ...?-> int -> ...?-> inline-text -> 'a) -> 'a -> ('a list) list,
    but is expected of type
      (cell-record (= (|left : bool; right : bool|)) option -> inline-text -> cell) -> (cell-record (= (|left : bool; right : bool|)) option -> int -> int -> inline-text -> cell) -> cell -> (cell list) list.
    This constraint is required by the expression
```

I changed `@import` to `@required` then this error was gone. However I don't understand why the problem could be fixed... 🤔 