### PR TITLE
Add font subset tag

### DIFF
--- a/src/backend/fontFormat.ml
+++ b/src/backend/fontFormat.ml
@@ -1249,14 +1249,37 @@ let to_flate_pdf_bytes (data : string) : string * Pdfio.bytes =
   ("/FlateDecode", bt)
 
 
-let pdfstream_of_decoder (pdf : Pdf.t) (dcdr : decoder) (subtypeopt : string option) : Pdf.pdfobject =
+let subset_tag_id = ref 0
+
+let get_subset_tag () =
+  let tag_len = 6 in
+  let base_str = Bytes.make tag_len 'A' in
+  let rec aux pos cnt =
+    if pos = tag_len then
+      Bytes.to_string base_str
+    else
+      let c = Char.chr ((Char.code 'A') + (cnt mod 26)) in
+      Bytes.set base_str pos c;
+      aux (pos + 1) (cnt / 26)
+  in
+  incr subset_tag_id;
+  aux 0 !subset_tag_id
+
+
+let add_subset_tag tagopt fontname =
+  match tagopt with
+  | None      -> fontname
+  | Some(tag) -> tag ^ "+" ^ fontname
+
+
+let pdfstream_of_decoder (pdf : Pdf.t) (dcdr : decoder) (subtypeopt : string option) : (Pdf.pdfobject * string option) =
   let d = dcdr.main in
-  let data =
+  let (data, subset_tag) =
       match SubsetMap.to_list dcdr.subset_map with
       | None ->
           begin
             match Otfm.decoder_src d with
-            | `String(s) -> s
+            | `String(s) -> (s, None)
           end
 
       | Some(gidorglst) ->
@@ -1264,7 +1287,7 @@ let pdfstream_of_decoder (pdf : Pdf.t) (dcdr : decoder) (subtypeopt : string opt
             match OtfSubset.make d gidorglst with
             | Error(e)    -> broken dcdr.file_path e "pdfstream_of_decoder"
             | Ok(None)    -> assert false
-            | Ok(Some(s)) -> s
+            | Ok(Some(s)) -> (s, Some(get_subset_tag ()))
           end
   in
   let (filter, bt) = to_flate_pdf_bytes data in
@@ -1281,7 +1304,7 @@ let pdfstream_of_decoder (pdf : Pdf.t) (dcdr : decoder) (subtypeopt : string opt
   in
   let objstream = Pdf.Stream(ref (Pdf.Dictionary(dict), Pdf.Got(bt))) in
   let irstream = Pdf.addobj pdf objstream in
-  Pdf.Indirect(irstream)
+  (Pdf.Indirect(irstream), subset_tag)
 
 
 let get_glyph_id_main srcpath (cmapsubtbl : Otfm.cmap_subtable) (uch : Uchar.t) : Otfm.glyph_id option =
@@ -1719,14 +1742,19 @@ module Type0
       }
 
 
-    let pdfobject_of_font_descriptor (pdf : Pdf.t) (dcdr : decoder) fontdescr base_font embedding : Pdf.pdfobject =
+    let pdfobject_of_font_descriptor (pdf : Pdf.t) (dcdr : decoder) fontdescr base_font embedding : (Pdf.pdfobject * string option) =
       let (font_file_key, tagopt) = font_file_info_of_embedding embedding in
-      let objstream = pdfstream_of_decoder pdf dcdr tagopt in
+      let (objstream, subset_tag_opt) = pdfstream_of_decoder pdf dcdr tagopt in
         (* -- add to the PDF the stream in which the font file is embedded -- *)
+      let base_font =
+        match subset_tag_opt with
+        | None      -> base_font
+        | Some(pre) -> pre ^ "+" ^ base_font
+      in
       let objdescr =
         Pdf.Dictionary[
           ("/Type"       , Pdf.Name("/FontDescriptor"));
-          ("/FontName"   , Pdf.Name("/" ^ base_font));
+          ("/FontName"   , Pdf.Name("/" ^ (add_subset_tag subset_tag_opt base_font)));
           ("/Flags"      , Pdf.Integer(4));  (* temporary; should be variable *)
           ("/FontBBox"   , pdfobject_of_bbox fontdescr.font_bbox);
           ("/ItalicAngle", Pdf.Real(fontdescr.italic_angle));
@@ -1737,7 +1765,7 @@ module Type0
         ]
       in
       let irdescr = Pdf.addobj pdf objdescr in
-      Pdf.Indirect(irdescr)
+      (Pdf.Indirect(irdescr), subset_tag_opt)
 
 
     let pdfdict_of_cid_system_info cidsysinfo =
@@ -1804,11 +1832,11 @@ module Type0
        pdfobject_of_cid_type_0:
          returns a descendant font dictionary of Type 0 CIDFont as an indirect reference
        -- *)
-    let pdfobject_of_cid_type_0 pdf cidty0font dcdr : Pdf.pdfobject =
+    let pdfobject_of_cid_type_0 pdf cidty0font dcdr : (Pdf.pdfobject * string option) =
       let cidsysinfo = cidty0font.CIDFontType0.cid_system_info in
       let base_font  = cidty0font.CIDFontType0.base_font in
       let fontdescr  = cidty0font.CIDFontType0.font_descriptor in
-      let objdescr = pdfobject_of_font_descriptor pdf dcdr fontdescr base_font (FontFile3("OpenType")) in
+      let (objdescr, subset_tag_opt) = pdfobject_of_font_descriptor pdf dcdr fontdescr base_font (FontFile3("OpenType")) in
       let objwarr = pdfobject_of_width_array pdf dcdr in
       let pmoptdw =
         cidty0font.CIDFontType0.dw |> option_map (per_mille dcdr)
@@ -1820,7 +1848,7 @@ module Type0
         Pdf.Dictionary[
           ("/Type"          , Pdf.Name("/Font"));
           ("/Subtype"       , Pdf.Name("/CIDFontType0"));
-          ("/BaseFont"      , Pdf.Name("/" ^ base_font));
+          ("/BaseFont"      , Pdf.Name("/" ^ (add_subset_tag subset_tag_opt base_font)));
           ("/CIDSystemInfo" , pdfdict_of_cid_system_info cidsysinfo);
           ("/FontDescriptor", objdescr);
           ("/DW"            , of_per_mille_opt pmoptdw);
@@ -1830,14 +1858,14 @@ module Type0
         ]
       in
       let irdescend = Pdf.addobj pdf objdescend in
-      Pdf.Indirect(irdescend)
+      (Pdf.Indirect(irdescend), subset_tag_opt)
 
 
     (* --
        pdfobject_of_cid_type_2:
          returns a descendant font dictionary of Type 2 CIDFont as an indirect reference
        -- *)
-    let pdfobject_of_cid_type_2 pdf cidty2font dcdr : Pdf.pdfobject =
+    let pdfobject_of_cid_type_2 pdf cidty2font dcdr : (Pdf.pdfobject * string option) =
       let cidsysinfo = cidty2font.CIDFontType2.cid_system_info in
       let base_font  = cidty2font.CIDFontType2.base_font in
       let fontdescr  = cidty2font.CIDFontType2.font_descriptor in
@@ -1848,7 +1876,7 @@ module Type0
         else
           FontFile3("OpenType")
       in
-      let objdescr = pdfobject_of_font_descriptor pdf dcdr fontdescr base_font font_file in
+      let (objdescr, subset_tag_opt) = pdfobject_of_font_descriptor pdf dcdr fontdescr base_font font_file in
       let objcidtogidmap =
         match cidty2font.CIDFontType2.cid_to_gid_map with
         | CIDToGIDIdentity -> Pdf.Name("/Identity")
@@ -1865,7 +1893,7 @@ module Type0
         Pdf.Dictionary[
           ("/Type"          , Pdf.Name("/Font"));
           ("/Subtype"       , Pdf.Name("/CIDFontType2"));
-          ("/BaseFont"      , Pdf.Name("/" ^ base_font));
+          ("/BaseFont"      , Pdf.Name("/" ^ (add_subset_tag subset_tag_opt base_font)));
           ("/CIDSystemInfo" , pdfdict_of_cid_system_info cidsysinfo);
           ("/FontDescriptor", objdescr);
           ("/DW"            , of_per_mille_opt dwpmopt);
@@ -1876,14 +1904,14 @@ module Type0
         ]
       in
       let irdescend = Pdf.addobj pdf objdescend in
-      Pdf.Indirect(irdescend)
+      (Pdf.Indirect(irdescend), subset_tag_opt)
 
 
     let to_pdfdict pdf ty0font dcdr =
       let cidfont       = ty0font.descendant_fonts in
       let base_font_ty0 = ty0font.base_font in
       let cmap          = ty0font.encoding in
-      let objdescend =
+      let (objdescend, subset_tag_opt) =
         match cidfont with
         | CIDFontType0(cidty0font) -> pdfobject_of_cid_type_0 pdf cidty0font dcdr
         | CIDFontType2(cidty2font) -> pdfobject_of_cid_type_2 pdf cidty2font dcdr
@@ -1893,7 +1921,7 @@ module Type0
           ("/Type"           , Pdf.Name("/Font"));
           ("/Subtype"        , Pdf.Name("/Type0"));
           ("/Encoding"       , pdfobject_of_cmap pdf cmap);
-          ("/BaseFont"       , Pdf.Name("/" ^ base_font_ty0));  (* -- can be arbitrary name -- *)
+          ("/BaseFont"       , Pdf.Name("/" ^ (add_subset_tag subset_tag_opt base_font_ty0)));  (* -- can be arbitrary name -- *)
           ("/DescendantFonts", Pdf.Array[objdescend]);
           ("/ToUnicode"      , pdfobjtouc);
         ]

--- a/src/backend/fontFormat.ml
+++ b/src/backend/fontFormat.ml
@@ -1746,11 +1746,6 @@ module Type0
       let (font_file_key, tagopt) = font_file_info_of_embedding embedding in
       let (objstream, subset_tag_opt) = pdfstream_of_decoder pdf dcdr tagopt in
         (* -- add to the PDF the stream in which the font file is embedded -- *)
-      let base_font =
-        match subset_tag_opt with
-        | None      -> base_font
-        | Some(pre) -> pre ^ "+" ^ base_font
-      in
       let objdescr =
         Pdf.Dictionary[
           ("/Type"       , Pdf.Name("/FontDescriptor"));


### PR DESCRIPTION
According to the PDF 1.7 specification section 5.5.3 "Font Subsets", FontName entry and BaseName entry of a subset font should begin with a tag which is composed of 6 uppercase letters and a plus sign (e.g. ABCDEF+Junicode-Composite).
I fixed to add such tags and show the change of `pdffonts` tool's output below.
Before:
```
$ pdffonts demo.pdf 
name                                 type              encoding         emb sub uni object ID
------------------------------------ ----------------- ---------------- --- --- --- ---------
lmodern-Composite-Math               CID Type 0C (OT)  Identity-H       yes no  no  [none]
Junicode-Composite                   CID TrueType      Identity-H       yes no  no  [none]
lmsans-Composite                     CID Type 0C (OT)  Identity-H       yes no  no  [none]
lmmono-Composite                     CID Type 0C (OT)  Identity-H       yes no  no  [none]
ipaexm-Composite                     CID TrueType      Identity-H       yes no  no  [none]
ipaexg-Composite                     CID TrueType      Identity-H       yes no  no  [none]
```
After:
```
$ pdffonts demo.pdf 
name                                 type              encoding         emb sub uni object ID
------------------------------------ ----------------- ---------------- --- --- --- ---------
GAAAAA+lmodern-Composite-Math        CID Type 0C (OT)  Identity-H       yes yes no  [none]
FAAAAA+Junicode-Composite            CID TrueType      Identity-H       yes yes no  [none]
EAAAAA+lmsans-Composite              CID Type 0C (OT)  Identity-H       yes yes no  [none]
DAAAAA+lmmono-Composite              CID Type 0C (OT)  Identity-H       yes yes no  [none]
CAAAAA+ipaexm-Composite              CID TrueType      Identity-H       yes yes no  [none]
BAAAAA+ipaexg-Composite              CID TrueType      Identity-H       yes yes no  [none]
```