### PR TITLE
math.satyh: '\approx' is defined twice

### DIFF
--- a/lib-satysfi/dist/packages/math.satyh
+++ b/lib-satysfi/dist/packages/math.satyh
@@ -130,7 +130,6 @@ module Math : sig
   direct \nsim : [] math-cmd
   direct \simeq : [] math-cmd
   direct \nsimeq : [] math-cmd
-  direct \approx : [] math-cmd
   direct \propto : [] math-cmd
   direct \coloneq : [] math-cmd
   direct \eqcolon : [] math-cmd
@@ -729,7 +728,6 @@ end = struct
   let-math \nsim = rel `≁`
   let-math \simeq = rel `≃`
   let-math \nsimeq = rel `≄`
-  let-math \approx = rel `≈`
   let-math \propto = rel `∝`
   let-math \coloneq = rel `≔`
   let-math \eqcolon = rel `≕`


### PR DESCRIPTION
In `math.satyh`, there are 2 same specifications and 2 same definitions for `\approx`. This PR removes the duplicates.