### PR TITLE
Add read external file support

### DIFF
--- a/lib-satysfi/dist/packages/code.satyh
+++ b/lib-satysfi/dist/packages/code.satyh
@@ -13,6 +13,7 @@ module Code : sig
   direct \console : [string] inline-cmd
   direct \d-code : [string] inline-cmd
   direct +file-code : [string] block-cmd
+  direct \file-code : [string] inline-cmd
 
 end = struct
 
@@ -139,5 +140,10 @@ end = struct
     let str-list = ` ` :: read-file file-name in
     let code = List.map (fun s -> (0, s)) str-list in
       scheme-sub decoset-code Color.black ctx code
+
+
+  let-inline ctx \file-code file-name =
+    inline-fil ++ embed-block-breakable ctx
+      (read-block ctx '<+file-code(file-name);>)
 
 end

--- a/lib-satysfi/dist/packages/code.satyh
+++ b/lib-satysfi/dist/packages/code.satyh
@@ -12,6 +12,7 @@ module Code : sig
   direct \code : [string] inline-cmd
   direct \console : [string] inline-cmd
   direct \d-code : [string] inline-cmd
+  direct +file-code : [string] block-cmd
 
 end = struct
 
@@ -69,7 +70,7 @@ end = struct
         |> set-hyphen-penalty 100000
 
 
-  let scheme decoset txtcolor ctx code =
+  let scheme-sub decoset txtcolor ctx code-list =
     let pads = (5pt, 5pt, 5pt, 5pt) in
     block-frame-breakable ctx pads decoset (fun ctx -> (
       let fontsize = get-font-size ctx in
@@ -80,7 +81,7 @@ end = struct
             |> set-text-color txtcolor
       in
 
-      let lstraw = split-into-lines code in
+      let lstraw = code-list in
       let lst =
         match lstraw with
         | []        -> lstraw
@@ -106,6 +107,11 @@ end = struct
     ))
 
 
+  let scheme decoset txtcolor ctx code =
+    let code-list = split-into-lines code in
+      scheme-sub decoset txtcolor ctx code-list
+
+
   let-block ctx +code code =
     scheme decoset-code Color.black ctx code
 
@@ -127,5 +133,11 @@ end = struct
   let-inline ctx \code code =
     script-guard Latin
       (read-inline (ctx |> set-code-font) (embed-string code))
+
+
+  let-block ctx +file-code file-name =
+    let str-list = ` ` :: read-file file-name in
+    let code = List.map (fun s -> (0, s)) str-list in
+      scheme-sub decoset-code Color.black ctx code
 
 end

--- a/lib-satysfi/dist/packages/code.satyh
+++ b/lib-satysfi/dist/packages/code.satyh
@@ -71,7 +71,7 @@ end = struct
         |> set-hyphen-penalty 100000
 
 
-  let scheme-sub decoset txtcolor ctx code-list =
+  let scheme decoset txtcolor ctx code =
     let pads = (5pt, 5pt, 5pt, 5pt) in
     block-frame-breakable ctx pads decoset (fun ctx -> (
       let fontsize = get-font-size ctx in
@@ -82,7 +82,7 @@ end = struct
             |> set-text-color txtcolor
       in
 
-      let lstraw = code-list in
+      let lstraw = split-into-lines code in
       let lst =
         match lstraw with
         | []        -> lstraw
@@ -106,11 +106,6 @@ end = struct
       in
         line-break true true ctx ib-code
     ))
-
-
-  let scheme decoset txtcolor ctx code =
-    let code-list = split-into-lines code in
-      scheme-sub decoset txtcolor ctx code-list
 
 
   let-block ctx +code code =
@@ -137,9 +132,13 @@ end = struct
 
 
   let-block ctx +file-code file-name =
-    let str-list = ` ` :: read-file file-name in
-    let code = List.map (fun s -> (0, s)) str-list in
-      scheme-sub decoset-code Color.black ctx code
+    let lf = string-unexplode [10] in
+    let join s1 s2 = s1 ^ lf ^ s2 in
+    let str-list = read-file file-name in
+    let code =
+      List.fold-left join ` ` str-list
+    in
+      scheme decoset-code Color.black ctx code
 
 
   let-inline ctx \file-code file-name =

--- a/src/frontend/bytecomp/vminstdef.yaml
+++ b/src/frontend/bytecomp/vminstdef.yaml
@@ -2622,3 +2622,33 @@ params:
 
 code: |
   raise (report_dynamic_error msg)
+
+---
+inst: ReadFile
+is-pdf-mode-primitive : yes
+is-text-mode-primitive : yes
+name: "read-file"
+type: |
+  ~% (tS @-> tL(tS))
+
+params:
+  - relpath : string
+
+code: |
+  let path =
+    Filename.concat (OptionState.job_directory ()) relpath
+  in
+  let str_list = ref [] in
+  let read filename =
+    let f = open_in filename in
+    try
+      while true do (str_list := (input_line f) :: !str_list) done
+    with End_of_file -> ()
+  in
+  let () =
+    read path
+  in
+  let list =
+    List.rev !str_list
+  in
+    make_list make_string list


### PR DESCRIPTION
This PR adds read external file support.


Added primitives

- `read-file : string -> string list`
Extract contents from file name.


Example

```
% This file's name is readfile.saty.
@require: stdjareport

document (|
  title = {test};
  author = {puripuri2100};
  show-title = true;
  show-toc = true;
|) '<
  +p(read-file `readfile.saty` |> List.fold-left (^) ` ` |> embed-string);
>
```
compile ==>
``% This file's name is readfile.saty.@require: stdjareportdocument (| title = {test}; author = {puripuri2100}; show-title =
true; show-toc = true;|) '< +p(read-file `readfile.saty` |> List.fold-left (^) ` ` |> embed-
string);>``

This primitive is useful for creating code examples.
I think it's safe because it only returns a string list.
