### PR TITLE
add string-explode

### DIFF
--- a/src/frontend/bytecomp/vminstdef.yaml
+++ b/src/frontend/bytecomp/vminstdef.yaml
@@ -1883,6 +1883,26 @@ code: |
   let ilst = get_list get_int valueilst in
   let s = (List.map Uchar.of_int ilst) |> InternalText.of_uchar_list |> InternalText.to_utf8 in
   make_string s
+---
+inst: PrimitiveStringExplode
+is-pdf-mode-primitive: yes
+is-text-mode-primitive: yes
+name: "string-explode"
+type: |
+  ~% (tS @-> (tL tI))
+
+params:
+- string
+code: |
+  let str = get_string string in
+  let ilst =
+    str
+    |> InternalText.of_utf8
+    |> InternalText.to_uchar_list
+    |> List.map Uchar.to_int
+  in
+  make_list make_int ilst
+
 
 ---
 inst: PrimitiveRegExpOfString


### PR DESCRIPTION
This PR adds `string-explode: string -> int list`.

`string-explode` converts string to Unicode code point sequence.


ex.
```
  string-explode `SATySFiは組版ソフトです`
    => [83; 65; 84; 121; 83; 70; 105; 12399; 32068; 29256; 12477; 12501; 12488; 12391; 12377]
  string-explode `SATySFiは組版ソフトです` |> string-unexplode
    => SATySFiは組版ソフトです
```