### PR TITLE
Fix build failure caused by core_kernel.v0.13.0

### DIFF
--- a/satysfi.opam
+++ b/satysfi.opam
@@ -24,7 +24,7 @@ depends: [
   "batteries"
   "camlimages" {>= "5.0.1"}
   "camlpdf" {= "2.2.2+satysfi"}
-  "core_kernel" {>= "v0.10.0"}
+  "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
   "depext"
   "dune" {build}


### PR DESCRIPTION
From `core_kernel.v0.13.0`, `Core_kernel.Heap` which is used in `src/backend/flowGraph.ml` is removed.
So I have restricted `core_kernel` version `< v0.13.0`.

This failure only happens with `ocaml {>= 4.08.0 & < 4.10.0}` because `core_kernel.v0.13.0` requires it.

(I noticed this by [nightly build of satysfi-docker](https://github.com/amutake/satysfi-docker/commit/676f7c5b91c2a8bab67e376ea33cf80fc7ac8c21/checks?check_suite_id=347370794))