### PR TITLE
Follow upstream change of Core

### DIFF
--- a/satysfi.opam
+++ b/satysfi.opam
@@ -24,7 +24,7 @@ depends: [
   "batteries"
   "camlimages" {>= "5.0.1"}
   "camlpdf" {= "2.2.2+satysfi"}
-  "core_kernel" {>= "v0.10.0"}
+  "core_kernel" {>= "v0.13"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
   "depext"
   "dune" {build}

--- a/src/backend/flowGraph.ml
+++ b/src/backend/flowGraph.ml
@@ -5,7 +5,7 @@ let print_for_debug msg =
 *)
   ()
 
-module Heap = Core_kernel.Heap
+module Heap = Core_kernel.Pairing_heap
 
 
 module type VertexType =


### PR DESCRIPTION
`Heap` has been renamed with `Pairing_heap` since Core v0.13.

Here is the summary of the discussion in https://github.com/gfngfn/SATySFi/pull/206.

There are two ways to workaround the incompatibility: 1) drop support of OCaml 4.07 and earlier or 2) stick at Core v0.12.

The second option implies SATySFi would be left behind development of OCaml forever. I am thus for the first option, i.e., supporting only 4.08 and later.