### PR TITLE
Fix the treatment of qualified type identifiers in type definitions

### DIFF
--- a/src/frontend/typeenv.ml
+++ b/src/frontend/typeenv.ml
@@ -545,11 +545,8 @@ let rec fix_manual_type_general (type a) (type b) (dpmode : dependency_mode) (ty
 
           in
           begin
-            match dpmode with
-            | NoDependency ->
-                find_in_variant_environment ()
-
-            | DependentMode(dg) ->
+            match mdlnmlst, dpmode with
+            | [], DependentMode(dg) ->
                 begin
                   try
                     match DependencyGraph.find_vertex dg tynm with
@@ -577,6 +574,9 @@ let rec fix_manual_type_general (type a) (type b) (dpmode : dependency_mode) (ty
                   with
                   | DependencyGraph.UndefinedSourceVertex -> find_in_variant_environment ()
                 end
+
+            | _ ->
+                find_in_variant_environment ()
           end
 
       | MTypeParam(tyargnm) ->


### PR DESCRIPTION
This PR will fix how to interpret a qualified type identifier, a type identifier prefixed by (one or more) module identifiers, in a type definition, when the type identifier is the same as some identifier which is defined at the same time.

Fixes #184 and fixes #185.

## How #184 happen

In my example from #184:

```
module M = struct
  type t = int
end

type t = M.t
```

At the last line, the typechecker first checks cycles in type definitions. Since `M.t` is different from `t`, the definition is considered acyclic. But when interpreting `M.t`, the typechecker mistakenly identifies `M.t` as `t`. This situation must not happen, as indicated by `assert false`, because the definition passes the cycle check. Hence SATySFi crashes.

## How #185 happen

In the example from #185:

```
module Hoge : sig
  type 'a t
end = struct
  type 'a t = Hoge
end

module Fuga : sig
  type 'a t
  val get : 'a t -> 'a Hoge.t
end = struct
  type 'a t = C of 'a Hoge.t

  let-rec get (C r) = r    % r should be of 'a Hoge.t but has 'a Fuga.t
end
```

In the definition of `Fuga.t`, `Hoge.t` is mistakenly interpreted as `t`, hence `get` acquires a wrong type `'a Fuga.t -> 'a Fuga.t`, leading to a signature mismatch error.