### PR TITLE
Rename 'open' to 'include', then deprecate 'open'

### DIFF
--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -292,6 +292,7 @@ rule progexpr stack = parse
           | "math-cmd"          -> MATHCMDTYPE(pos)
           | "command"           -> COMMAND(pos)
           | "open"              -> OPEN(pos)
+          | "include"           -> INCLUDE(pos)
           | _                   -> VAR(pos, tokstr)
       }
   | constructor { CONSTRUCTOR(get_pos lexbuf, Lexing.lexeme lexbuf) }

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -505,6 +505,7 @@ nxtoplevel:
   | top=MODULE; mdlnmtok=CONSTRUCTOR; sigopt=nxsigopt;
       DEFEQ; STRUCT; strct=nxstruct; subseq=nxtopsubseq                      { make_module top mdlnmtok sigopt strct subseq }
   | top=OPEN; mdlnmtok=CONSTRUCTOR; subseq=nxtopsubseq {
+      let () = Logging.warn_deprecated ("at " ^ (Range.to_string top) ^ ": this form of 'open' is deprecated. Use 'include' instead.") in
       let (rng, mdlnm) = mdlnmtok in
       make_standard (Tok top) (Ranged subseq) (UTOpenIn(rng, mdlnm, subseq))
     }
@@ -550,6 +551,7 @@ nxstruct:
   | top=MODULE; tok=CONSTRUCTOR; sigopt=nxsigopt;
       DEFEQ; STRUCT; strct=nxstruct; tail=nxstruct                   { make_module top tok sigopt strct tail }
   | top=OPEN; mdlnmtok=CONSTRUCTOR; tail=nxstruct {
+      let () = Logging.warn_deprecated ("at " ^ (Range.to_string top) ^ ": this form of 'open' is deprecated. Use 'include' instead.") in
       let (rng, mdlnm) = mdlnmtok in
       make_standard (Tok top) (Ranged tail) (UTOpenIn(rng, mdlnm, tail))
     }

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -400,7 +400,7 @@
 %token <Range.t * int> PRIMES
 %token <Range.t> SUBSCRIPT SUPERSCRIPT
 %token <Range.t> LAMBDA ARROW COMMAND
-%token <Range.t> LETREC LETNONREC DEFEQ LETAND IN OPEN
+%token <Range.t> LETREC LETNONREC DEFEQ LETAND IN OPEN INCLUDE
 %token <Range.t * Types.module_name> OPENMODULE
 %token <Range.t> MODULE STRUCT END DIRECT SIG VAL CONSTRAINT
 %token <Range.t> TYPE OF MATCH WITH BAR WILDCARD WHEN AS COLON
@@ -508,6 +508,10 @@ nxtoplevel:
       let (rng, mdlnm) = mdlnmtok in
       make_standard (Tok top) (Ranged subseq) (UTOpenIn(rng, mdlnm, subseq))
     }
+  | top=INCLUDE; mdlnmtok=CONSTRUCTOR; subseq=nxtopsubseq {
+      let (rng, mdlnm) = mdlnmtok in
+      make_standard (Tok top) (Ranged subseq) (UTOpenIn(rng, mdlnm, subseq))
+    }
 ;
 nxtopsubseq:
   | utast=nxtoplevel     { utast }
@@ -546,6 +550,10 @@ nxstruct:
   | top=MODULE; tok=CONSTRUCTOR; sigopt=nxsigopt;
       DEFEQ; STRUCT; strct=nxstruct; tail=nxstruct                   { make_module top tok sigopt strct tail }
   | top=OPEN; mdlnmtok=CONSTRUCTOR; tail=nxstruct {
+      let (rng, mdlnm) = mdlnmtok in
+      make_standard (Tok top) (Ranged tail) (UTOpenIn(rng, mdlnm, tail))
+    }
+  | top=INCLUDE; mdlnmtok=CONSTRUCTOR; tail=nxstruct {
       let (rng, mdlnm) = mdlnmtok in
       make_standard (Tok top) (Ranged tail) (UTOpenIn(rng, mdlnm, tail))
     }


### PR DESCRIPTION
Currently, SATySFi has 3 forms of `open`:

1. `open M`: global `open`
2. `open M in expr`: local `open`
3. `M.(expr)`: lightweight local `open`

Only (1) is related to this PR. The other 2 forms are **irrelevant**.

SATySFi's global `open` (hereafter, just call `open`) is similar to OCaml's `include`, not OCaml's `open`, because it re-exports the definitions in a module.

`open` / `include` in modules, wrap-up:

|                        | Standard ML | OCaml       | SATySFi   | 
| ------------- | ------------- | ---------- | --------- |
| re-export       | `open`           | `include` | `open`    |
| not re-export |                        | `open`     |                 |

In my experience with Standard ML, the absence of OCaml-style `open` is to some extent painful, even though Standard ML has `local ... in ... end`, which makes Standard ML-style `open` a bit more local.

Moreover, we cannot omit module prefixes in signatures (in natural way) if OCaml-style `open` is not supported. Compare these OCaml programs:

```ocaml
sig
  type s = int * Mod.t
  val v : Mod.t list -> Mod.u option
  val f : Mod.t -> s
end
```

```ocaml
sig
  open Mod
  type s = int * t
  val v : t list -> u option
  val f : t -> s
end
```

On the other hand, OCaml-style `include` is also useful, especially when combined with functors and to extend modules with additional definitions. 

So I believe both `open` and `include` should be implemented in SATySFi. Since SATySFi has many similarities with OCaml, it would be appropriate to use the same keywords as OCaml. As a first step, this PR adds a keyword `include` as an alias to `open`. Furthermore, if a program contains (global) `open`, SATySFi warns about it, leading the programmer to refrain from using `open`.

## Plan

I propose the following plan.

- Phase 1: Introduce `include`, and warn the use of `open`. (What this PR does.)
- Phase 2: Remove `open`.
- Phase 3: Introduce OCaml-style `open`.