### PR TITLE
Add --no-default-config option

### DIFF
--- a/src/backend/optionState.ml
+++ b/src/backend/optionState.ml
@@ -19,6 +19,7 @@ type state = {
   mutable debug_show_block_space : bool;
   mutable mode             : (string list) option;
   mutable extra_config_paths : string list option;
+  mutable no_default_config_paths : bool;
 }
 
 
@@ -36,6 +37,7 @@ let state = {
   debug_show_block_space = false;
   mode             = None;
   extra_config_paths = None;
+  no_default_config_paths = false;
 }
 
 let set_input_kind ikd = state.input_kind <- ikd
@@ -85,3 +87,6 @@ let is_text_mode () =
 
 let set_extra_config_paths lst = state.extra_config_paths <- Some(lst)
 let get_extra_config_paths () = state.extra_config_paths
+
+let set_no_default_config_paths () = state.no_default_config_paths <- true
+let get_no_default_config_paths () = state.no_default_config_paths

--- a/src/backend/optionState.mli
+++ b/src/backend/optionState.mli
@@ -46,3 +46,6 @@ val is_text_mode : unit -> bool
 
 val set_extra_config_paths : string list -> unit
 val get_extra_config_paths : unit -> string list option
+
+val set_no_default_config_paths : unit -> unit
+val get_no_default_config_paths : unit -> bool

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -433,7 +433,8 @@ let error_log_environment suspended =
   | NoLibraryRootDesignation ->
       report_error Interface [
         NormalLine("cannot determine where the SATySFi library root is;");
-        NormalLine("set appropriate environment variables.");
+        NormalLine("set appropriate environment variables");
+        NormalLine("or specify configuration search paths with -C option.");
       ]
 
   | NoInputFileDesignation ->

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -956,6 +956,7 @@ let arg_spec_list curdir =
     ("--show-fonts"      , Arg.Unit(OptionState.set_show_fonts)      , " Displays all the available fonts"                      );
     ("-C"                , Arg.String(arg_config)                    , " Add colon-separated paths to configuration search path");
     ("--config"          , Arg.String(arg_config)                    , " Add colon-separated paths to configuration search path");
+    ("--no-default-config", Arg.Unit(OptionState.set_no_default_config_paths), "Do not use default configuration search path"         );
   ]
 
 
@@ -978,12 +979,18 @@ let setup_root_dirs () =
       | None    -> []
       | Some(s) -> [Filename.concat s ".satysfi"]
   in
+  let default_dirs =
+    if OptionState.get_no_default_config_paths () then
+      []
+    else
+      List.concat [home_dirs; runtime_dirs]
+  in
   let extra_dirs =
     match OptionState.get_extra_config_paths () with
     | None -> [Filename.concat (Sys.getcwd ()) ".satysfi"]
     | Some(lst) -> lst
   in
-  let ds = List.concat [extra_dirs; home_dirs; runtime_dirs] in
+  let ds = List.append extra_dirs default_dirs in
   match ds with
   | []     -> raise NoLibraryRootDesignation
   | _ :: _ -> Config.initialize ds


### PR DESCRIPTION
This PR introduces a new option, `--no-default-config`, which keeps SATySFi from searching files from default configuration search paths.

This option `--no-default-config` will be used with `--config` option introduced by #161.

|Commandline Options|Search paths|
|---|---|
| (default) | `~/.satysfi`, `/usr/local/share/satysfi`, `/usr/share/satysfi` |
| `-C <paths>` | paths, `~/.satysfi`, `/usr/local/share/satysfi`, `/usr/share/satysfi` |
| `-C <paths> --no-default-config` | paths |

## Background

Library authors want to ensure if their library depend on only explicitly specified libraries. 

Currently, users or their build scripts need to manually update/clean-up files under the default search paths. This is not always possible. Non-sudo users cannot modify `/usr/...`. Build scripts in OPAM package cannot make any modification on `~/.satysfi` or `/usr/...`, either.

This can be useful for reproducible builds.

Cf. https://github.com/na4zagin3/satyrographos/issues/5