### PR TITLE
Add a new primitive: linear-transform-path

### DIFF
--- a/lib-satysfi/dist/packages/gr.satyh
+++ b/lib-satysfi/dist/packages/gr.satyh
@@ -19,6 +19,8 @@ module Gr : sig
   val text-rightward : point -> inline-boxes -> graphics
   val arrow : length -> color -> length -> length -> length -> point -> point -> graphics list
   val dashed-arrow : length -> length * length * length -> color -> length -> length -> length -> point -> point -> graphics list
+  val rotate-path : point -> float -> path -> path
+  val scale-path : point -> float -> float -> path -> path
 
 end = struct
 
@@ -167,5 +169,20 @@ end = struct
 
   let dashed-arrow thkns dash =
     arrow-scheme (dashed-stroke thkns dash)
+
+
+  let rotate-path centpt angle path =
+    let (centx, centy) = centpt in
+    let rad = angle *. math-pi /. 180. in
+    path |> shift-path (0pt -' centx, 0pt -' centy)
+         |> linear-transform-path (cos rad) (0. -. (sin rad)) (sin rad) (cos rad)
+         |> shift-path centpt
+
+
+  let scale-path centpt scalex scaley path =
+    let (centx, centy) = centpt in
+    path |> shift-path (0pt -' centx, 0pt -' centy)
+         |> linear-transform-path scalex 0. 0. scaley
+         |> shift-path centpt
 
 end

--- a/lib-satysfi/dist/packages/pervasives.satyh
+++ b/lib-satysfi/dist/packages/pervasives.satyh
@@ -102,19 +102,3 @@ let math-pi = 3.1415926536
 
 let increment r =
   r <- !r + 1
-
-
-let rotate-path centpt angle path =
-  let (centx, centy) = centpt in
-  let rad = angle *. math-pi /. 180. in
-  path |> shift-path (0pt -' centx, 0pt -' centy)
-       |> linear-transform-path (cos rad) (0. -. (sin rad)) (sin rad) (cos rad)
-       |> shift-path centpt
-
-
-let scale-path centpt scalex scaley path =
-  let (centx, centy) = centpt in
-  path |> shift-path (0pt -' centx, 0pt -' centy)
-       |> linear-transform-path scalex 0. 0. scaley
-       |> shift-path centpt
-

--- a/lib-satysfi/dist/packages/pervasives.satyh
+++ b/lib-satysfi/dist/packages/pervasives.satyh
@@ -102,3 +102,19 @@ let math-pi = 3.1415926536
 
 let increment r =
   r <- !r + 1
+
+
+let rotate-path centpt angle path =
+  let (centx, centy) = centpt in
+  let rad = angle *. math-pi /. 180. in
+  path |> shift-path (0pt -' centx, 0pt -' centy)
+       |> linear-transform-path (cos rad) (0. -. (sin rad)) (sin rad) (cos rad)
+       |> shift-path centpt
+
+
+let scale-path centpt scalex scaley path =
+  let (centx, centy) = centpt in
+  path |> shift-path (0pt -' centx, 0pt -' centy)
+       |> linear-transform-path scalex 0. 0. scaley
+       |> shift-path centpt
+

--- a/src/frontend/bytecomp/vminstdef.yaml
+++ b/src/frontend/bytecomp/vminstdef.yaml
@@ -610,6 +610,22 @@ code: |
   make_path (List.map (shift_path ptshift) pathlst)
 
 ---
+inst: PathLinearTransform
+is-pdf-mode-primitive: yes
+name: "linear-transform-path"
+type: |
+  ~% (tFL @-> tFL @-> tFL @-> tFL @-> tPATH @-> tPATH)
+
+params:
+- a : float
+- b : float
+- c : float
+- d : float
+- pathlst : path_value
+code: |
+  make_path (List.map (linear_transform_path ((a, b), (c, d))) pathlst)
+
+---
 inst: PathGetBoundingBox
 is-pdf-mode-primitive: yes
 name: "get-path-bbox"

--- a/tools/gencode/vminst.ml
+++ b/tools/gencode/vminst.ml
@@ -658,6 +658,24 @@ make_path (List.append pathlst1 pathlst2)
         ~code:{|
 make_path (List.map (shift_path ptshift) pathlst)
 |}
+    ; inst "PathLinearTransform"
+        ~name:"linear-transform-path"
+        ~type_:{|
+~% (tFL @-> tFL @-> tFL @-> tFL @-> tPATH @-> tPATH)
+|}
+        ~fields:[
+        ]
+        ~params:[
+          param "a" ~type_:"float";
+          param "b" ~type_:"float";
+          param "c" ~type_:"float";
+          param "d" ~type_:"float";
+          param "pathlst" ~type_:"path_value";
+        ]
+        ~is_pdf_mode_primitive:true
+        ~code:{|
+make_path (List.map (linear_transform_path ((a, b), (c, d))) pathlst)
+|}
     ; inst "PathGetBoundingBox"
         ~name:"get-path-bbox"
         ~type_:{|


### PR DESCRIPTION
This PR adds a new primitive
`linear-transform-path: float -> float -> float -> float -> path -> path`.
`path-origin |> linear-transform-path a b c d` is evaluated to a path into which the`path-origin` is transformed with the following formula:
<img src="https://user-images.githubusercontent.com/48883418/74663600-6dce1280-51df-11ea-9c9b-9e8e7b2da392.png" width="150pt">
Combining `linear-transform-path` with `shift-path`, you can implement any path-to-path affine transform.

This PR also provides two functions, `rotate-path` and `scale-path`,  in `gr` package.