### PR TITLE
Change OCaml version into 4.10.0 of .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ os:
   - linux
   - osx
 env:
-  - OCAML_VERSION=4.06
-  - OCAML_VERSION=4.07
+  - OCAML_VERSION=4.10
 sudo: required
 install:
   - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-ocaml.sh


### PR DESCRIPTION
- I was trying to add OCaml 4.10 testing on Travis CI
    - ~~but it failed...... 😇~~
    - It seems to be success! https://travis-ci.org/github/y-yu/Macrodown/builds/674997020
- It requires to update `camlpdf` to verison 2.3.1
    - so this PR depends on https://github.com/gfngfn/camlpdf/pull/3
    - 👆 was merged. Thanks! 
