### PR TITLE
limit core_kernel version and use --safe-string

### DIFF
--- a/satysfi.opam
+++ b/satysfi.opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "batteries"
   "camlimages" {>= "5.0.1"}
-  "camlpdf" {= "2.2.2+satysfi"}
+  "camlpdf" {= "2.3.1+satysfi"}
   "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
   "depext"

--- a/satysfi.opam
+++ b/satysfi.opam
@@ -24,7 +24,7 @@ depends: [
   "batteries"
   "camlimages" {>= "5.0.1"}
   "camlpdf" {= "2.2.2+satysfi"}
-  "core_kernel" {>= "v0.10.0"}
+  "core_kernel" {>= "v0.10.0" & < "v0.13.0"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}
   "depext"
   "dune" {build}

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (executable
  (name main)
  (public_name satysfi)
- (flags (-w -3 -bin-annot -thread -unsafe-string))
+ (flags (-w -3 -bin-annot -thread -safe-string))
  (libraries str
             batteries
             camlimages


### PR DESCRIPTION
This update depends on camlpdf.2.3.1. Please update gfngfn/satysfi-external-repo and gfngfn/camlpdf.