### PR TITLE
Change OCaml CI script URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - OCAML_VERSION=4.07
 sudo: required
 install:
-  - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-ocaml.sh
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-ocaml.sh
   - bash -ex .travis-ocaml.sh
   - eval `opam config env`
   - opam repository add satysfi-external https://github.com/gfngfn/satysfi-external-repo.git


### PR DESCRIPTION
- [OCaml CI Script](https://github.com/ocaml/ocaml-ci-scripts) was changed GitHub repository name
- 
    ```console
    $ curl https://github.com/ocaml/ocaml-travisci-skeleton -I
    HTTP/1.1 301 Moved Permanently
    date: Sat, 28 Mar 2020 07:52:02 GMT
    content-type: text/html; charset=utf-8
    server: GitHub.com
    status: 301 Moved Permanently
    vary: X-PJAX, Accept-Encoding, Accept, X-Requested-With
    location: https://github.com/ocaml/ocaml-ci-scripts
    ```
    - `location` header is https://github.com/ocaml/ocaml-ci-scripts
- So I change the URL to the new one where the script actually is now