### PR TITLE
Fix: suppress page break just after +section commands

### DIFF
--- a/lib-satysfi/dist/packages/stdja.satyh
+++ b/lib-satysfi/dist/packages/stdja.satyh
@@ -443,9 +443,9 @@ let title-deco =
     let outline-title = Option.from (extract-string ib-title) outline-title-opt in
     let () = outline-ref <- (0, s-num ^ `. `#  ^ outline-title, label, false) :: !outline-ref in
     let bb-title =
-      block-frame-breakable ctx no-pads (Annot.register-location-frame label) (fun ctx -> (
-        (line-break true false (ctx |> set-paragraph-margin section-top-margin section-bottom-margin)
-        (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil)))))
+      line-break true false (ctx |> set-paragraph-margin section-top-margin section-bottom-margin)
+        (inline-frame-breakable no-pads (Annot.register-location-frame label)
+          (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil)))
     in
     let bb-inner = read-block ctx inner in
       bb-title +++ bb-inner

--- a/lib-satysfi/dist/packages/stdjabook.satyh
+++ b/lib-satysfi/dist/packages/stdjabook.satyh
@@ -131,7 +131,7 @@ end = struct
 
   let get-standard-context wid =
     get-initial-context wid (command \math)
-      |> set-code-text-command (command \code)
+      |> set-code-text-command Code.(command \code)
       |> set-dominant-wide-script Kana
       |> set-language Kana Japanese
       |> set-language HanIdeographic Japanese

--- a/lib-satysfi/dist/packages/stdjabook.satyh
+++ b/lib-satysfi/dist/packages/stdjabook.satyh
@@ -545,9 +545,11 @@ let title-deco =
     let outline-title = Option.from (extract-string ib-title) outline-title-opt in
     let () = outline-ref <- (0, s-num ^ `. `#  ^ outline-title, label, false) :: !outline-ref in
     let bb-title =
-      block-frame-breakable ctx no-pads (Annot.register-location-frame label) (fun ctx -> (
-        (section-heading ctx
-          (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil)))))
+      let ib =
+        inline-frame-breakable no-pads (Annot.register-location-frame label)
+          (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil))
+      in
+      section-heading ctx ib
     in
     let bb-inner = read-block ctx inner in
       bb-title +++ bb-inner

--- a/lib-satysfi/dist/packages/stdjareport.satyh
+++ b/lib-satysfi/dist/packages/stdjareport.satyh
@@ -393,8 +393,11 @@ end = struct
     let outline-title = Option.from (extract-string ib-title) outline-title-opt in
     let () = outline-ref <- (0, s-num ^ `. `#  ^ outline-title, label, false) :: !outline-ref in
     let bb-title =
-      block-frame-breakable ctx no-pads (Annot.register-location-frame label) (fun ctx -> (
-        chapter-heading ctx (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil))))
+      let ib =
+        inline-frame-breakable no-pads (Annot.register-location-frame label)
+          (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil))
+      in
+      chapter-heading ctx ib
     in
     let bb-inner = read-block ctx inner in
       bb-title +++ bb-inner
@@ -417,9 +420,11 @@ end = struct
     let outline-title = Option.from (extract-string ib-title) outline-title-opt in
     let () = outline-ref <- (1, s-num ^ `. `#  ^ outline-title, label, false) :: !outline-ref in
     let bb-title =
-      block-frame-breakable ctx no-pads (Annot.register-location-frame label) (fun ctx -> (
-        (section-heading ctx
-          (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil)))))
+      let ib =
+        inline-frame-breakable no-pads (Annot.register-location-frame label)
+          (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil))
+      in
+      section-heading ctx ib
     in
     let bb-inner = read-block ctx inner in
       bb-title +++ bb-inner


### PR DESCRIPTION
This PR fixes that the page break does not appear right after the chapter/section title.

# Example

The second and third page of `doc/doc-primitives.saty` is shown as an example.

---
Before:
![before](https://user-images.githubusercontent.com/48883418/82725932-82103700-9d1b-11ea-836a-7ab75c9805ea.png)

---
After:
![after](https://user-images.githubusercontent.com/48883418/82725934-85a3be00-9d1b-11ea-8c2a-b97d4fbe36ba.png)

---