### PR TITLE
Add Junicode Bold Italic to fonts.satysfi-hash

### DIFF
--- a/lib-satysfi/dist/hash/fonts.satysfi-hash
+++ b/lib-satysfi/dist/hash/fonts.satysfi-hash
@@ -8,5 +8,6 @@
   "lmsans"    : <Single: {"src": "dist/fonts/lmsans10-regular.otf"}>,
   "Junicode"  : <Single: {"src": "dist/fonts/Junicode.ttf"}>,
   "Junicode-b": <Single: {"src": "dist/fonts/Junicode-Bold.ttf"}>,
+  "Junicode-b-it": <Single: {"src": "dist/fonts/Junicode-BoldItalic.ttf"}>,
   "Junicode-it": <Single: {"src": "dist/fonts/Junicode-Italic.ttf"}>
 }


### PR DESCRIPTION
This PR adds new font identifier `Junicode-b-it` for Junicode-BoldItalic.ttf