### PR TITLE
Fix the URL of IPAexfont

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -118,7 +118,7 @@ opam install satysfi
 ここでインストールされるフォントは以下の通りです。ライセンスを確認した上で使用してください：
 
 * [Junicode](http://junicode.sourceforge.net)
-* [IPA Font](https://ipafont.ipa.go.jp/old/ipafont/download.html)
+* [IPA Font](https://moji.or.jp/ipafont/)
 * [Latin Modern](http://www.gust.org.pl/projects/e-foundry/latin-modern/)
 * [Latin Modern Math](http://www.gust.org.pl/projects/e-foundry/lm-math)
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The former downloads the fonts required by the default settings into `lib-satysf
 During this setup, the following fonts are downloaded. Consult their license before using them.
 
 * [Junicode](http://junicode.sourceforge.net)
-* [IPA Font](https://ipafont.ipa.go.jp/old/ipafont/download.html)
+* [IPA Font](https://moji.or.jp/ipafont/)
 * [Latin Modern](http://www.gust.org.pl/projects/e-foundry/latin-modern/)
 * [Latin Modern Math](http://www.gust.org.pl/projects/e-foundry/lm-math)
 

--- a/download-fonts.sh
+++ b/download-fonts.sh
@@ -53,7 +53,7 @@ unzip -o "$CACHE/$NAME.zip" "*.ttf" -d lib-satysfi/dist/fonts/
 
 # IPAexfont
 NAME=IPAexfont00401
-download_file "$NAME.zip" "https://ipafont.ipa.go.jp/IPAexfont/IPAexfont00401.zip"
+download_file "$NAME.zip" "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip"
 unzip -o "$CACHE/$NAME.zip" "*.ttf" -d "$CACHE/"
 cp "$CACHE"/IPAexfont00401/ipaexg.ttf lib-satysfi/dist/fonts/
 cp "$CACHE"/IPAexfont00401/ipaexm.ttf lib-satysfi/dist/fonts/


### PR DESCRIPTION
The URL of IPAexfont has been changed.
see: https://ipafont.ipa.go.jp/