### PR TITLE
WSL 2 is recommended for OPAM on Windows

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -39,8 +39,9 @@ $ brew install --HEAD nyuichi/satysfi/satysfi
 * unzip
 * wget or curl
 * ruby
-* [opam](https://opam.ocaml.org/) 2.0 （インストール手順は[こちら](https://opam.ocaml.org/doc/Install.html)。）
-    * opam 2 をインストールするのに必要なツールである bubblewrap は，いくつかの環境において未だ簡単にはインストールできません。たとえば Windows Subsystem for Linux（WSL）や Ubuntu 16.04 が該当します。さしあたりの回避法として，`opam init` をする際に `--disable-sandboxing` オプションを渡すことで opam 2 を bubblewrap 無しにインストールすることができます。**詳細を [opam の FAQ](https://opam.ocaml.org/doc/FAQ.html#Why-does-opam-require-bwrap) で必ずご確認ください。**
+* [opam](https://opam.ocaml.org/) 2
+    * インストール方法：<https://opam.ocaml.org/doc/Install.html>
+    * Windows の場合，bubblewrap 関係の問題を回避するため，Windows Subsystem for Linux (WSL) 2 をオススメします。
 * ocaml 4.10.0 （OPAM からインストールします）
 
 また，ビルドには外部 OPAM リポジトリの追加が必要です。これは以下のコマンドでできます：

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ Here is a list of minimally required softwares.
 * unzip
 * wget or curl
 * ruby
-* [opam](https://opam.ocaml.org/) 2.0 (Installation instructions are [here](https://opam.ocaml.org/doc/Install.html).)
-    * Bubblewrap, a tool required for opam 2, cannot be installed easily yet on some kinds of environment such as Windows Subsystem for Linux (WSL) and Ubuntu 16.04. As a workaround for the time being, opam 2 can be installed without bubblewrap by passing `--disable-sandboxing` option when running `opam init`. **Please see [opam's FAQ](https://opam.ocaml.org/doc/FAQ.html#Why-does-opam-require-bwrap) for details.**
+* [opam](https://opam.ocaml.org/) 2
+    * See <https://opam.ocaml.org/doc/Install.html>.
+    * On Windows, Windows Subsystem for Linux (WSL) 2 is recommended to avoid bubblewrap-related issues.
 * ocaml 4.10.0 (installed by OPAM)
 
 Also, we must add an external OPAM repo to build. This can be done by the following command.


### PR DESCRIPTION
Since bubblewrap-related issues are resolved on WSL 2 <https://github.com/ocaml/opam-repository/issues/12050#issuecomment-628654052>, this pull req recommends WSL 2 for installation of OPAM on Windows.
