### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  [pull_request, push]
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        ocaml-version:
+          - 4.10.1
+          - 4.11.1
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup OCaml ${{ matrix.ocaml-version }}
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: ${{ matrix.ocaml-version }}
+        
+      - name: Install SATySFi dependencies
+        run: |
+          opam repository add satysfi-external https://github.com/gfngfn/satysfi-external-repo.git
+          opam update
+          opam pin add satysfi.dev . --no-action
+          opam depext satysfi --yes --with-doc --with-test
+          opam install . --deps-only --with-doc --with-test
+
+      - name: Build SATySFi
+        run: opam exec -- make all


### PR DESCRIPTION
- Travis CI( [travis-ci.**com**](https://travis-ci.com) ) has been required an application to use their resource unlimitedly even though we are OSS works
    - https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
    - > We will be offering an allotment of OSS minutes that will be reviewed and allocated on a case by case basis. Should you want to apply for these credits please open a request with Travis CI support stating that you’d like to be considered for the OSS allotment
    - See also: [今までありがとうTravis CI、さよならTravis CI - xuwei-k's blog](https://xuwei-k.hatenablog.com/entry/2020/11/04/161400)
- We use [travis-ci.**org**](https://travis-ci.org) so it's not irrelevant for now.....
    - But [travis-ci.org](https://travis-ci.org) is now _deprecated_ 😢 
    - Since [travis-ci.org](https://travis-ci.org) is using GitHub V1 API, it causes many problems such like the build status would not be updated
    - In the common sense, we have to move [travis-ci.com](https://travis-ci.com) even if we keep using Travis CI
        - https://github.com/gfngfn/SATySFi/issues/224#issuecomment-616461196
- Then I make GitHub Action setting, which could be the next our CI service
- Travis CI build test takes 40-50minutes, GitHub Actions seems to be faster than Travis CI
    - <img src="https://user-images.githubusercontent.com/612043/99938393-0450e500-2dab-11eb-8c25-ba0f855e144a.png" width="60%" />
    - On the other hand, GitHub Actions CI took 16 minutes
        - Example result: https://github.com/y-yu/Macrodown/actions/runs/375810549
        - <img src="https://user-images.githubusercontent.com/612043/99938509-48dc8080-2dab-11eb-866d-35b109e7f7cb.png" width="50%">
- So it should be better to use GitHub Actions instead of Travis CI, shouldn't it? 🤔 

 
