### PR TITLE
Detect SHA checksum utilities

### DIFF
--- a/download-fonts.sh
+++ b/download-fonts.sh
@@ -4,14 +4,23 @@ set -ue
 
 CACHE=temp
 MESSAGE_PREFIX="[download-fonts.sh]"
-SHA1SUM=sha1sum
-
 cd "$(dirname "$0")"
 mkdir -p "$CACHE"
 
 show_message () {
   echo "$MESSAGE_PREFIX $1."
 }
+
+if shasum --version ; then
+  show_message "Using shasum"
+  SHA1SUM=shasum
+elif sha1sum --version ; then
+  show_message "Using sha1sum"
+  SHA1SUM=sha1sum
+else
+  echo "No SHA checksum checkers found.  Please install shasum or sha1sum" >&2
+  exit 1
+fi
 
 validate_file () {
   (

--- a/download-fonts.sh
+++ b/download-fonts.sh
@@ -11,10 +11,10 @@ show_message () {
   echo "$MESSAGE_PREFIX $1."
 }
 
-if shasum --version ; then
+if command shasum --version >/dev/null 2>&1 ; then
   show_message "Using shasum"
   SHA1SUM=shasum
-elif sha1sum --version ; then
+elif command sha1sum --version >/dev/null 2>&1 ; then
   show_message "Using sha1sum"
   SHA1SUM=sha1sum
 else


### PR DESCRIPTION
This commit has `download-fonts.sh` use `shasum` or `sha1sum` in this order and fail if neither of them exists.

Closes https://github.com/gfngfn/SATySFi/issues/252