### PR TITLE
fix bug: calculation in getting LinearTrans bbox

### DIFF
--- a/src/backend/graphicD.ml
+++ b/src/backend/graphicD.ml
@@ -42,10 +42,16 @@ let op_cm_linear_trans (a, b, c, d) (xoff, yoff) =
   in
     Pdfops.Op_cm(matr)
 
-let linear_trans_point (a, b, c, d) (x, y) =
-  let xx = ~% x in
-  let yy = ~% y in
-  (Length.of_pdf_point (a *. xx +. b *. yy), Length.of_pdf_point (c *. xx +. d *. yy))
+(* linear transform centered at point (cx, cy) *)
+let linear_trans_point (a, b, c, d) (cx, cy) (x, y) =
+  let x = ~% x in
+  let y = ~% y in
+  let cx = ~% cx in
+  let cy = ~% cy in
+  let relx = x -. cx in
+  let rely = y -. cy in
+  (Length.of_pdf_point (a *. relx +. b *. rely +. cx),
+  Length.of_pdf_point (c *. relx +. d *. rely +. cy))
 
 let op_Tm_translate (xpos, ypos) =
   Pdfops.Op_Tm(Pdftransform.matrix_of_transform
@@ -143,10 +149,10 @@ let rec get_element_bbox textbboxf grelem =
   | HorzText(pt, textvalue) -> textbboxf pt textvalue
   | LinearTrans(pt, mat, subelem) ->
       let ((xmin, ymin), (xmax, ymax)) = get_element_bbox textbboxf subelem in
-      let (x1, y1) = linear_trans_point mat (xmin, ymin) in
-      let (x2, y2) = linear_trans_point mat (xmin, ymax) in
-      let (x3, y3) = linear_trans_point mat (xmax, ymin) in
-      let (x4, y4) = linear_trans_point mat (xmax, ymax) in
+      let (x1, y1) = linear_trans_point mat pt (xmin, ymin) in
+      let (x2, y2) = linear_trans_point mat pt (xmin, ymax) in
+      let (x3, y3) = linear_trans_point mat pt (xmax, ymin) in
+      let (x4, y4) = linear_trans_point mat pt (xmax, ymax) in
       let xmin = x1 |> Length.min x2 |> Length.min x3 |> Length.min x4 in
       let xmax = x1 |> Length.max x2 |> Length.max x3 |> Length.max x4 in
       let ymin = y1 |> Length.min y2 |> Length.min y3 |> Length.min y4 in


### PR DESCRIPTION
My previous PR #241 had a bug in the bounding box calculation.
This PR resolves it.

Test code:
```
@require: standalone
@require: gr
@require: color

let-block ctx +canvas grlst =
  let frame =
    stroke 0.5pt Color.black (Gr.rectangle (0pt, 0pt) (300pt, 300pt))
  in
  let grlst = frame :: grlst in
  let ib =
    inline-graphics 0pt 0pt 0pt
      (fun _ -> grlst |> List.map (shift-graphics (150pt, 150pt)))
  in
  line-break true true ctx (ib ++ inline-fil)

in

standalone '<
  +canvas(
    let ctx =
      get-initial-context 440pt (command \math)
        |> set-font-size 20pt
        |> set-dominant-narrow-script Latin
        |> set-dominant-wide-script Kana
    in

    let draw-bbox gr =
      let (gr-bbox-min, gr-bbox-max) = get-graphics-bbox gr in
      stroke 0.5pt Color.blue (Gr.rectangle gr-bbox-min gr-bbox-max)
    in

    let text = draw-text (30pt, 20pt) (read-inline ctx {ABC}) in
    let text-bbox = draw-bbox text in

    let text-shift = text |> shift-graphics (10pt, 20pt) in
    let text-shift-bbox = draw-bbox text-shift in

    let text-rotate = text |> linear-transform-graphics 0. (0. -. 1.) 1. 0. in
    let text-rotate-bbox = draw-bbox text-rotate in

    let text-rotate-shift = text-rotate |> shift-graphics (50pt, 0pt) in
    let text-rotate-shift-bbox = draw-bbox text-rotate-shift in

    [
      text;
      text-shift;
      text-rotate;
      text-bbox;
      text-rotate-shift;
      text-shift-bbox;
      text-rotate-bbox;
      text-rotate-shift-bbox;
    ]
  );
>
```

---

Before this PR: the bounding box of `text-rotate-shift` is wrong.

![result1.png](https://user-images.githubusercontent.com/48883418/102709499-8a9b1100-42ee-11eb-86d9-dc2c31c9c32e.png)

---

After: all bounding boxes are calculated correctly.

![result2.png](https://user-images.githubusercontent.com/48883418/102709500-8c64d480-42ee-11eb-837a-1f8a6f9496c5.png)
