### PR TITLE
Change the CI status badge on README from Travis CI to GitHub Actions

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1,7 +1,7 @@
 <!-- -*- coding: utf-8 -*- -->
 ![logo1](https://raw.githubusercontent.com/wiki/gfngfn/SATySFi/img/satysfi-logo.png)
 
-[![Build Status](https://travis-ci.org/gfngfn/SATySFi.svg?branch=master)](https://travis-ci.org/gfngfn/SATySFi)
+[![Build Status](https://github.com/gfngfn/SATySfi/workflows/CI/badge.svg)](https://github.com/gfngfn/SATySFi/actions?query=workflow%3ACI)
 
 [English README is here](https://github.com/gfngfn/SATySFi/blob/master/README.md)
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -1,7 +1,7 @@
 <!-- -*- coding: utf-8 -*- -->
 ![logo1](https://raw.githubusercontent.com/wiki/gfngfn/SATySFi/img/satysfi-logo.png)
 
-[![Build Status](https://github.com/gfngfn/SATySfi/workflows/CI/badge.svg?branch=master)](https://github.com/gfngfn/SATySFi/actions?query=workflow%3ACI)
+[![Build Status](https://github.com/gfngfn/SATySFi/workflows/CI/badge.svg?branch=master)](https://github.com/gfngfn/SATySFi/actions?query=workflow%3ACI)
 
 [English README is here](https://github.com/gfngfn/SATySFi/blob/master/README.md)
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -1,7 +1,7 @@
 <!-- -*- coding: utf-8 -*- -->
 ![logo1](https://raw.githubusercontent.com/wiki/gfngfn/SATySFi/img/satysfi-logo.png)
 
-[![Build Status](https://github.com/gfngfn/SATySfi/workflows/CI/badge.svg)](https://github.com/gfngfn/SATySFi/actions?query=workflow%3ACI)
+[![Build Status](https://github.com/gfngfn/SATySfi/workflows/CI/badge.svg?branch=master)](https://github.com/gfngfn/SATySFi/actions?query=workflow%3ACI)
 
 [English README is here](https://github.com/gfngfn/SATySFi/blob/master/README.md)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![logo1](https://raw.githubusercontent.com/wiki/gfngfn/SATySFi/img/satysfi-logo.png)
 
-[![Build Status](https://github.com/gfngfn/SATySfi/workflows/CI/badge.svg)](https://github.com/gfngfn/SATySFi/actions?query=workflow%3ACI)
+[![Build Status](https://github.com/gfngfn/SATySfi/workflows/CI/badge.svg?branch=master)](https://github.com/gfngfn/SATySFi/actions?query=workflow%3ACI)
 
 [日本語版 README はこちら](https://github.com/gfngfn/SATySFi/blob/master/README-ja.md)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![logo1](https://raw.githubusercontent.com/wiki/gfngfn/SATySFi/img/satysfi-logo.png)
 
-[![Build Status](https://github.com/gfngfn/SATySfi/workflows/CI/badge.svg?branch=master)](https://github.com/gfngfn/SATySFi/actions?query=workflow%3ACI)
+[![Build Status](https://github.com/gfngfn/SATySFi/workflows/CI/badge.svg?branch=master)](https://github.com/gfngfn/SATySFi/actions?query=workflow%3ACI)
 
 [日本語版 README はこちら](https://github.com/gfngfn/SATySFi/blob/master/README-ja.md)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![logo1](https://raw.githubusercontent.com/wiki/gfngfn/SATySFi/img/satysfi-logo.png)
 
-[![Build Status](https://travis-ci.org/gfngfn/SATySFi.svg?branch=master)](https://travis-ci.org/gfngfn/SATySFi)
+[![Build Status](https://github.com/gfngfn/SATySfi/workflows/CI/badge.svg)](https://github.com/gfngfn/SATySFi/actions?query=workflow%3ACI)
 
 [日本語版 README はこちら](https://github.com/gfngfn/SATySFi/blob/master/README-ja.md)
 


### PR DESCRIPTION
The CI service was changed at #250, therefore to change the status badge.