### PR TITLE
Allow setting LIBDIR from commandline argument

### DIFF
--- a/install-libs.sh
+++ b/install-libs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-LIBDIR=/usr/local/share/satysfi
+LIBDIR=${1:-/usr/local/share/satysfi}
 
 install -d ${LIBDIR}
 install -d ${LIBDIR}/dist


### PR DESCRIPTION
This commit has install-libs.sh take an optional argument `LIBDIR`.