### PR TITLE
update ocaml version in satysfi.opam

### DIFF
--- a/satysfi.opam
+++ b/satysfi.opam
@@ -20,7 +20,7 @@ remove: [
 ]
 # Packages whose version suffix is "+satysfi" are distributed on satysfi-external-repo.
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.10.0"}
   "batteries"
   "camlimages" {>= "5.0.1"}
   "camlpdf" {= "2.3.1+satysfi"}


### PR DESCRIPTION
OCaml `4.09.1` doesn't work. 

```
$ ocaml --version
The OCaml toplevel, version 4.09.1
$ opam pin add satysfi .
...
The following dependencies couldn't be met:
  - satysfi → camlpdf >= 2.3.1+satysfi
      no matching version

[NOTE] Pinning command successful, but your installed packages may be out of sync.
```