### PR TITLE
Restrict omd version to fix build

### DIFF
--- a/satysfi.opam
+++ b/satysfi.opam
@@ -35,7 +35,7 @@ depends: [
   "re" {build}
   "uutf"
   "yojson-with-position" {= "1.4.2+satysfi"}
-  "omd"
+  "omd" {< "2.0.0~"}
 ]
 synopsis: "A statically-typed, functional typesetting system"
 description: """


### PR DESCRIPTION
Currently, the build seems to fail because [new version of `omd`](http://opam.ocaml.org/packages/omd/omd.2.0.0~alpha1/) is released (on 2021/03/09).

I have restricted `omd` version for first aid.

Build error:

```
[ERROR] The compilation of satysfi failed at "/usr/bin/make -f Makefile PREFIX=/root/.opam/4.11.1".

#=== ERROR while compiling satysfi.0.0.6 ======================================#
# context              2.0.7 | linux/x86_64 | ocaml-base-compiler.4.11.1 | pinned(file:///root/SATySFi)
# path                 ~/.opam/4.11.1/.opam-switch/build/satysfi.0.0.6
# command              /usr/bin/make -f Makefile PREFIX=/root/.opam/4.11.1
# exit-code            2
# env-file             ~/.opam/log/satysfi-7-b972e7.env
# output-file          ~/.opam/log/satysfi-7-b972e7.out
### output ###
# [...]
# Entering directory '/root/.opam/4.11.1/.opam-switch/build/satysfi.0.0.6/tools/gencode'
# Entering directory '/root/.opam/4.11.1/.opam-switch/build/satysfi.0.0.6/tools/gencode'
# dune exec --root tools/gencode ./gencode.exe -- --gen-text-mode-prims > src/frontend/__primitives_text_mode.gen.ml
# Entering directory '/root/.opam/4.11.1/.opam-switch/build/satysfi.0.0.6/tools/gencode'
# Entering directory '/root/.opam/4.11.1/.opam-switch/build/satysfi.0.0.6/tools/gencode'
# dune build
#       menhir src/parser.{ml,mli}
# Warning: 2 states have shift/reduce conflicts.
# Warning: 2 shift/reduce conflicts were arbitrarily resolved.
# File "src/md/decodeMD.ml", line 17, characters 17-25:
# Error: Unbound type constructor Omd.name
# make: *** [Makefile:47: all] Error 1
```