### PR TITLE
Fix for `library file not found` error on Homebrew installation

### DIFF
--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -1055,7 +1055,7 @@ let setup_root_dirs () =
       | None    -> []
       | Some(s) -> [s]
     else
-      ["/usr/local/share/satysfi"; "/usr/share/satysfi"]
+      ["/opt/homebrew/share/satysfi"; "/usr/local/share/satysfi"; "/usr/share/satysfi"]
   in
   let home_dirs =
     if Sys.os_type = "Win32" then

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -1055,7 +1055,7 @@ let setup_root_dirs () =
       | None    -> []
       | Some(s) -> [s]
     else
-      ["/opt/homebrew/share/satysfi"; "/usr/local/share/satysfi"; "/usr/share/satysfi"]
+      ["/opt/homebrew/share/satysfi"; "/home/linuxbrew/.linuxbrew/share/satysfi"; "/usr/local/share/satysfi"; "/usr/share/satysfi"]
   in
   let home_dirs =
     if Sys.os_type = "Win32" then


### PR DESCRIPTION
This is the first time I send Pull Request, so please correct me if I did something wrong.

## Problem Description

SATySFi won't compile documents under M1 Macs, saying that `library file not found`. This problem was originated from hardcoded path in `src/frontend/main.ml`.

Homebrew installs {binaries, libraries, resources} in `/opt/homebrew` by default in ARM Macs; therefore searching `/usr/local` for libraries is insufficient.

## Fix

Add `/opt/homebrew/share/satysfi` (for ARM Macs), `/home/linuxbrew/.linuxbrew/share/satysfi` (for Linuxbrew systems) to default library search path.

(Creating a symlink to `/usr/local` is one thing, but this method is unsafe, since `/usr/local` is the place where Intel {binaries, libraries, resources} are placed.)
