### PR TITLE
Recommend Satyrographos for non-dev users

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -17,12 +17,35 @@
 
 また，2021年2月現在も発展を続けています。
 
-## Homebrew を使ったインストール方法 (Mac ユーザ向け)
+## Satyrographos を使ったインストール方法 (初心者向け)
 
-Homebrew のフォーミュラが用意されています。
+パッケージマネージャー [Satyrographos](https://github.com/na4zagin3/satyrographos/blob/master/README-ja.md) を用いたインストール方法が用意されています。
+詳しくは [SATySFi インストール手引き](https://qiita.com/na4zagin3/items/a6e025c17ef991a4c923) をご覧下さい。
 
 ```sh
-$ brew install --HEAD nyuichi/satysfi/satysfi
+# Ubuntu 20.04 の場合
+sudo apt-get update
+sudo apt-get install build-essential git m4 unzip curl pkg-config
+sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+
+# Mac の場合
+# 要 homebrew (https://brew.sh/index_ja に従いインストールして下さい)
+brew update
+brew install opam
+
+# 共通 OPAM の設定
+opam init
+eval $(opam env)
+opam repository add satysfi-external https://github.com/gfngfn/satysfi-external-repo.git
+opam repository add satyrographos https://github.com/na4zagin3/satyrographos-repo.git
+opam update
+
+# 共通 SATySFi のインストール
+opam depext satysfi satysfi-dist satyrographos
+opam install satysfi satysfi-dist satyrographos
+
+# 共通 SATySFi 標準ライブラリのセットアップ
+satyrographos install
 ```
 
 ## OPAM を使ったインストール方法

--- a/README.md
+++ b/README.md
@@ -16,12 +16,34 @@ This software was supported by:
 
 and its development continues to this day (February 2021).
 
-## Install using Homebrew (for OS X users)
+## Install using Satyrographos (for non-devs)
 
-A Homebrew formula is provided for SATySFi (v0.0.2).
+You can install SATySFi with package manager [Satyrographos](https://github.com/na4zagin3/satyrographos/blob/master/README.md).
 
 ```sh
-$ brew install --HEAD nyuichi/satysfi/satysfi
+# For Ubuntu 20.04
+sudo apt-get update
+sudo apt-get install build-essential git m4 unzip curl pkg-config
+sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+
+# For Mac
+# Please make sure homebrew is installed. Otherwise, follow https://brew.sh/
+brew update
+brew install opam
+
+# Common: Set up OPAM
+opam init
+eval $(opam env)
+opam repository add satysfi-external https://github.com/gfngfn/satysfi-external-repo.git
+opam repository add satyrographos https://github.com/na4zagin3/satyrographos-repo.git
+opam update
+
+# Common: Install SATySFi
+opam depext satysfi satysfi-dist satyrographos
+opam install satysfi satysfi-dist satyrographos
+
+# Common: Set up the SATySFi standard library
+satyrographos install
 ```
 
 ## Install using OPAM


### PR DESCRIPTION
This PR replaces section “Install using Homebrew” with “Install using Satyrographos” to solve the following problems:

1. Due to the directory hierarchy of M1 Mac, `-C` option is required for the casual users that install SATySFi with Homebrew, which I think is not ideal. (See https://github.com/gfngfn/SATySFi/pull/269 for more details)
2. Users need to clone the git repo to install historical versions of SATySFi
3. Users need to manually copy files to install third-party libraries

Does this PR look okay, @nyuichi?  I'd love to restore the secton “Install using Homebrew” with a special mention for M1 Mac and Linuxbrew if you would like.

This partially addresses https://github.com/gfngfn/SATySFi/issues/265, in other words, this PR does not add a method with @amutake’s docker-satysfi because I'm not strongly sure which image we should recommend.