### PR TITLE
Specify root dir to dune build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ INSTDEF=$(GENCODE_DIR)/vminst.ml
 .PHONY: all gen install lib uninstall clean
 
 all: gen
-	$(DUNE) build
+	$(DUNE) build --root .
 	cp _build/install/default/bin/$(TARGET) .
 
 $(INSTDEF): $(INSTDEF_YAML)


### PR DESCRIPTION
This prevents Dune from misunderstanding the root build directory with
OPAM local switch.

Fixes https://github.com/gfngfn/SATySFi/issues/272