### PR TITLE
Add `clip-graphics-by-path` primitive

### DIFF
--- a/doc/doc-primitives.saty
+++ b/doc/doc-primitives.saty
@@ -411,6 +411,9 @@ document (|
       +command (`unite-path`) (tPATH --> (tPATH --> tPATH)) {
         2つのパスを統合して1つにする．これはドーナツ形など中空のパスをつくるのに必須である．
       }
+      +command (`clip-graphics-by-path`) (tPATH --> (tGR --> tGR)) {
+        \code{clip-graphics-by-path pat gr}でグラフィクス\code{gr}をパス\code{pat}で切り抜く。
+      }
       +command (`fill`) (tCLR --> (tPATH --> tGR)) {
         \code{fill ${color} ${path}}でパス\code{${path}}の内側を色\code{${color}}で塗ったグラフィックスを返す．
         パスのどこが内側であるかは偶奇則によって決められる．

--- a/src/backend/graphicBase.ml
+++ b/src/backend/graphicBase.ml
@@ -182,3 +182,4 @@ let get_path_list_bbox pathlst =
     let (ptmin1, ptmax1) = get_path_bbox path in
       (update_min ptmin0 ptmin1, update_max ptmax0 ptmax1)
   ) bboxinit
+

--- a/src/backend/graphicD.mli
+++ b/src/backend/graphicD.mli
@@ -46,3 +46,5 @@ val pdfops_test_skip_margins : color -> point -> length -> (bool * length) optio
 val pdfops_test_scale : color -> point -> length -> Pdfops.t list
 
 val to_pdfops : 'a t -> (point -> 'a -> Pdfops.t list) -> Pdfops.t list
+
+val clip_graphics : 'a element -> path -> 'a element

--- a/tests/clip.saty
+++ b/tests/clip.saty
@@ -1,0 +1,39 @@
+% -*- coding: utf-8 -*-
+@import: head
+
+
+let-inline ctx \do-clip wid f =
+    let ib = use-image-by-width (load-image `images/lenna-cmyk.jpg`) wid
+    in
+    let (w, h, d) = get-natural-metrics ib in
+    inline-graphics w h d (fun (x, y) -> [
+        draw-text (x, y) ib
+            |> clip-graphics-by-path (f x y w (h +' d))
+    ])
+
+let path-circle x y w h =
+    start-path (x +' w *' 0.5, y)
+        |> bezier-to (x +' w *' 0.25, y) (x, y +' h *' 0.25) (x, y +' h *' 0.5)
+        |> bezier-to (x, y +' h *' 0.75) (x +' w *' 0.25, y +' h) (x +' w *' 0.5, y +' h)
+        |> bezier-to (x +' w *' 0.75, y +' h) (x +' w, y +' h *' 0.75) (x +' w, y +' h *' 0.5)
+        |> bezier-to (x +' w *' 0.25, y +' h) (x +' w *' 0.75, y) (x +' w *' 0.5, y)
+        |> close-with-line
+in
+
+let path-donut x y w h =
+    unite-path
+        (path-circle x y w h)
+        (path-circle (x +' w *' 0.25) (y +' h *' 0.25) (w *' 0.5) (h *' 0.5))
+in
+
+
+
+document (|
+  title  = {Clipping Examples};
+  author = {Yasuo Ozu};
+|) '<
+    +p {
+        \do-clip (5cm) (path-circle);
+        \do-clip (5cm) (path-donut);
+    }
+>

--- a/tools/gencode/vminst.ml
+++ b/tools/gencode/vminst.ml
@@ -3399,4 +3399,25 @@ let lines = aux Alist.empty in
 close_in inc;
 make_list make_string lines
 |}
+    ; inst "ClipGraphicsByPath"
+        ~name:"clip-graphics-by-path"
+        ~type_:{|
+~% (tPATH @-> tGR @-> tGR)
+|}
+        ~fields:[
+        ]
+        ~params:[
+          param "pathlst" ~type_:"path_value";
+          param "grelem" ~type_:"graphics_element";
+        ]
+        ~is_pdf_mode_primitive:true
+        ~code:{|
+let rec gen_clipel_f l = match l with
+    el :: xs -> GraphicD.clip_graphics (gen_clipel_f xs) el
+    | [] -> grelem
+in
+let grelem = gen_clipel_f pathlst in
+make_graphics grelem
+(* Does it work correctly when len(pathlst) > 1 ?? *)
+|}
     ])


### PR DESCRIPTION
```ml
clip-graphics-by-path : path -> graphics -> graphics
```

This new primitive allows users to clip any graphics with capricious path.