### PR TITLE
Provide variants of digits

### DIFF
--- a/src/frontend/primitives.cppo.ml
+++ b/src/frontend/primitives.cppo.ml
@@ -469,6 +469,19 @@ let default_math_variant_char_map : (Uchar.t * HorzBox.math_kind) HorzBox.MathVa
       (range 0 25) |> List.map (fun i ->
         (ascii_small_of_index i, MathDoubleStruck, code_point (0x1D552 + i)));
 
+
+    (* -- Digit to its boldface -- *)
+      (range 0 9) |> List.concat_map (fun i ->
+        [
+          (ascii_digit_of_index i, MathBoldItalic, code_point (0x1D7CE + i));
+          (ascii_digit_of_index i, MathBoldRoman, code_point (0x1D7CE + i));
+          (ascii_digit_of_index i, MathBoldScript, code_point (0x1D7CE + i));
+          (ascii_digit_of_index i, MathBoldFraktur, code_point (0x1D7CE + i));
+        ]);
+
+    (* -- Digit to its double struck -- *)
+      (range 0 9) |> List.map (fun i ->
+        (ascii_digit_of_index i, MathDoubleStruck, code_point (0x1D7D8 + i)));
     ])
 
 

--- a/src/myUtil.ml
+++ b/src/myUtil.ml
@@ -22,6 +22,10 @@ let ascii_small_of_index i =
   Uchar.of_int ((Char.code 'a') + i)
 
 
+let ascii_digit_of_index i =
+  Uchar.of_int ((Char.code '0') + i)
+
+
 let string_of_uchlst uchlst =
   let buffer = Buffer.create ((List.length uchlst) * 4) in
     List.iter (fun u -> Uutf.Buffer.add_utf_8 buffer u) uchlst;

--- a/src/myUtil.mli
+++ b/src/myUtil.mli
@@ -13,6 +13,8 @@ val ascii_capital_of_index : int -> Uchar.t
 
 val ascii_small_of_index : int -> Uchar.t
 
+val ascii_digit_of_index : int -> Uchar.t
+
 val string_of_uchlst : Uchar.t list -> string
 
 val range : int -> int -> int list


### PR DESCRIPTION
This PR enables us to use `\mathbf` and `\mathbb` for digits.

## Sample

```
@require: stdjareport

document (|
  author = {};
  title = {};
|) '<
  +align
    [ ${|\text!{Normal:} | ABCabc0123456789|}

    ; ${|\text!{\\mathbb:} | \mathbb{ABCabc0123456789}|}

    ; ${|\text!{\\mathbf:}     | \mathbf{ABCabc0123456789}|}
    ; ${|\text!{\\bm:}         | \bm{ABCabc0123456789}|}
    ; ${|\text!{Bold script:}  | \math-style-token!(MathBoldScript)!(`ABCabc0123456789`)|}
    ; ${|\text!{Bold Fraktur:} | \math-style-token!(MathBoldFraktur)!(`ABCabc0123456789`)|}
    ];
>
```

Before:
![saty-digit-before](https://user-images.githubusercontent.com/20471989/126623753-4622b66e-75dd-4971-b7d5-a2b4194ebac2.png)

After:
![saty-digit-after](https://user-images.githubusercontent.com/20471989/126623804-5cb5c309-e57d-43b6-a2b8-fd42711d5ceb.png)
