### PR TITLE
Stop using dune cache on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Setup OCaml ${{ matrix.ocaml-version }} and pin satysfi
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ matrix.ocaml-version }}
-          dune-cache: true
+          ocaml-compiler: ${{ matrix.ocaml-version }}
+          dune-cache: ${{ matrix.os != 'macos-latest' }}
 
           opam-depext: true
           opam-pin: true


### PR DESCRIPTION
Apparently dune cache does not work well in GitHub Action on MacOS.

This change includes https://github.com/gfngfn/SATySFi/pull/292 as well.