### PR TITLE
support negation on float/length literal

### DIFF
--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -166,6 +166,23 @@
     let rng = make_range (Ranged utastL) (Ranged utastR) in
       (rng, UTApply((Range.dummy "binary_operator", UTApply((rngop, UTContentOf([], opnm)), utastL)), utastR))
 
+  let make_uminus op = function
+    | (_, UTFloatConstant(_)) as arg ->
+        binary_operator
+          (Range.dummy "zero-of-unary-minus", UTFloatConstant(0.0))
+          (op, "-.")
+          arg
+    | (_, UTLengthDescription (_, unit)) as arg ->
+        binary_operator
+          (Range.dummy "zero-of-unary-minus", UTLengthDescription(0.0, unit))
+          (op, "-'")
+          arg
+    | arg ->
+        binary_operator
+          (Range.dummy "zero-of-unary-minus", UTIntegerConstant(0))
+          (op, "-")
+          arg
+
 
   let make_standard sttknd endknd main =
     let rng = make_range sttknd endknd in (rng, main)
@@ -748,10 +765,7 @@ nxop:
     { binary_operator utastL (rng, "mod") utastR }
   | tok=EXACT_MINUS; utast2=nxapp
     {
-      binary_operator
-       (Range.dummy "zero-of-unary-minus", UTIntegerConstant(0))
-       (tok, "-")
-       utast2
+      make_uminus tok utast2
     }
   | tok=LNOT; utast2=nxapp
     {

--- a/test/parsing/nx.saty
+++ b/test/parsing/nx.saty
@@ -35,3 +35,5 @@ let op-test =
     F a * b,
     A * b
   )
+
+let uminus = (-1, - 42, -1.0, - 3.14, -1mm, - 2.71828cm, -x, - x)

--- a/test/parsing/parser.expected
+++ b/test/parsing/parser.expected
@@ -60,7 +60,24 @@
                                 ((* a) (not b)); ((* a) F(b));
                                 ((* a) B(U:())); ((* (not a)) b);
                                 ((* F(a)) b); ((* A(U:())) b)]),
-                           UTFinishHeaderFile))
+                           (UTLetNonRecIn (None,
+                              ((Range.Normal ("nx.saty", 39, 4, 39, 10)),
+                               (UTPVariable "uminus")),
+                              (UTTuple
+                                 [((- (UTIntegerConstant 0)) (UTIntegerConstant
+                                                                1));
+                                   ((- (UTIntegerConstant 0)) (UTIntegerConstant
+                                                                 42));
+                                   ((-. (UTFloatConstant 0.)) (UTFloatConstant
+                                                                 1.));
+                                   ((-. (UTFloatConstant 0.)) (UTFloatConstant
+                                                                 3.14));
+                                   L:-1.000000mm;
+                                   ((-' L:0.000000cm) L:2.718280cm);
+                                   ((- (UTIntegerConstant 0)) x);
+                                   ((- (UTIntegerConstant 0)) x)]),
+                              UTFinishHeaderFile))
+                           ))
                         ))
                      ))
                   ))


### PR DESCRIPTION
This PR supports negation on float/length literals, such as `-1.0`, `- 3.14`, `- 2.71828cm`, etc.