### PR TITLE
Remove OS-dependent PATH and COMMAND.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,19 @@
-PREFIX=/usr/local
-LIBDIR=$(PREFIX)/share/satysfi
 TARGET=satysfi
-BINDIR=$(PREFIX)/bin
-RM=rm -f
 DUNE=dune
 
 .PHONY: all install lib uninstall clean
 
 all:
 	$(DUNE) build --root .
-	cp _build/install/default/bin/$(TARGET) .
 
 install: $(TARGET)
-	mkdir -p $(BINDIR)
-	install $(TARGET) $(BINDIR)
+	$(DUNE) install
 
 #preliminary:
 #	[ -d .git ] && git submodule update -i || echo "Skip git submodule update -i"
 
 uninstall:
-	rm -rf $(BINDIR)/$(TARGET)
-	rm -rf $(LIBDIR)
+	$(DUNE) uninstall
 
 clean:
 	$(DUNE) clean
-	$(RM) satysfi


### PR DESCRIPTION
- Remove OS-dependent PATH. (e.g. `usr/local/share/satysfi`)
- Remove OS-dependent COMMAND. (e.g. `cp`)

The execution test is changed as follows[^1]:

```
dune exec -- satysfi --version

dune exec -- satysfi demo/demo.saty -o demo/demo.pdf
```

[^1]: https://www.mankier.com/1/dune-exec