### PR TITLE
Try building with oldest dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
-          dune-cache: ${{ matrix.os != 'macos-latest' }}
+          # SATySFi only requires dune >=2.0, which has a problem on caching
+          dune-cache: ${{ matrix.os != 'macos-latest' && ! matrix.oldest-dependencies }}
 
           opam-depext: true
           opam-pin: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
           - 4.10.2
           - 4.11.2
           - 4.12.1
+        oldest-dependencies:
+          - true
+          - false
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -46,8 +49,16 @@ jobs:
             default: ${{ steps.determine-default-opam-repo.outputs.opam-repo-default }}
 
       - name: Install SATySFi dependencies
+        if: ${{ ! matrix.oldest-dependencies }}
         run: |
           opam install . --deps-only --with-doc --verbose
+
+      - name: Install SATySFi dependencies (oldest dependencies)
+        if: matrix.oldest-dependencies
+        run: |
+          OCAML_PACKAGE="ocaml.$(opam show --color=never -f version ocaml)"
+          opam install opam-0install
+          opam install --verbose $(opam exec -- opam-0install --prefer-oldest satysfi "$OCAML_PACKAGE")
 
       - name: Build SATySFi
         run: opam exec -- make all


### PR DESCRIPTION
This PR improves the CI with building wit the oldest dependencies as possible.  This helps to detect wrong lower version boundaries.

Question: May I update the required Dune version to enable the caching for the oldest-dep check?