### PR TITLE
Make CI more fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           ./install-libs.sh ~/.satysfi
 
       - name: Build demo docs
+        if: matrix.os == 'ubuntu-latest' &&  matrix.ocaml-version == '4.12.1'
         run: |
           (cd demo; opam exec -- make)
           (cd doc; opam exec -- make)


### PR DESCRIPTION
- Today the CI is very slow because of cross compile.
- I think, test of `doc/` and `demo/` is not required to be run on every environment.
- I make it run on just one environment.