### PR TITLE
Update version to 0.1.0~alpha

### DIFF
--- a/satysfi.opam
+++ b/satysfi.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "satysfi"
-version: "0.0.6"
+version: "0.1.0~alpha"
 maintainer: "gfngfn"
 authors: [
   "gfngfn"


### PR DESCRIPTION
This PR updates the version to `0.1.0~alpha` from `0.0.6` in the `dev-0-1-0` branch.

## Why `0.1.0~alpha`?

It's because of the sorting order:

```
0.0.7 < 0.1 < 0.1.0~alpha < 0.1.0
```

With the order, libraries can exclude dependency on the alpha versions like follows:

Libraries for 0.0.x series has this version constraint:

```
"satysfi" { >= "0.0.z" & < "0.1" }
```

Libraries for 0.1.x series has this version constraint:

```
"satysfi" { >= "0.1.0" & < "0.2" }
```
