### PR TITLE
friendlier error message for empty files

### DIFF
--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -338,7 +338,8 @@ rule progexpr stack = parse
   | ((("-"? digit+ "." digit*) as flt) (identifier as unitnm))       { LENGTHCONST(get_pos lexbuf, float_of_string flt, unitnm) }
   | ((("-"? "." digit+) as flt) (identifier as unitnm))              { LENGTHCONST(get_pos lexbuf, float_of_string flt, unitnm) }
   | eof {
-      if Stack.length stack = 1 then EOI else
+      let pos = get_pos lexbuf in
+      if Stack.length stack = 1 then EOI(pos) else
         report_error lexbuf "text input ended while reading a program area"
     }
   | _ as c { report_error lexbuf ("illegal token '" ^ (String.make 1 c) ^ "' in a program area") }
@@ -391,7 +392,8 @@ and vertexpr stack = parse
       BHORZGRP(get_pos lexbuf)
     }
   | eof {
-      if Stack.length stack = 1 then EOI else
+      let pos = get_pos lexbuf in
+      if Stack.length stack = 1 then EOI(pos) else
         report_error lexbuf "unexpected end of input while reading a vertical area"
     }
   | _ as c {
@@ -498,7 +500,8 @@ and horzexpr stack = parse
       LITERAL(pos, s, false, omit_post)
     }
   | eof {
-      if Stack.length stack = 1 then EOI else
+      let pos = get_pos lexbuf in
+      if Stack.length stack = 1 then EOI(pos) else
         report_error lexbuf "unexpected end of input while reading an inline text area"
     }
   | str+ {

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -449,7 +449,7 @@
 %token <Range.t * int> ITEM
 %token <Range.t * string> HEADER_REQUIRE HEADER_IMPORT
 %token <Range.t> HEADER_STAGE0 HEADER_STAGE1 HEADER_PERSISTENT0
-%token EOI
+%token <Range.t> EOI
 
 %left  BINOP_BAR
 %left  BINOP_AMP
@@ -515,6 +515,10 @@ optterm_nonempty_list(sep, X):
 main:
   | stage=stage; header=list(headerelem); utast=nxtoplevel { (stage, header, utast) }
   | stage=stage; header=list(headerelem); utast=nxwhl; EOI { (stage, header, utast) }
+  | rng=EOI {
+    raise (ParseErrorDetail(rng, "empty input"))
+  }
+
 ;
 stage:
   |                    { Stage1 }


### PR DESCRIPTION
This PR attempts to fix #270.

Error message will be changed as below (last line):
```console
$ touch e.saty
$ ./satysfi e.saty
 ---- ---- ---- ----
  target file: 'e.pdf'
  dump file: 'e.satysfi-aux' (will be created)
  parsing 'e.saty' ...
! [Syntax Error at Parser] at "e.saty", line 1, characters 0-0:
    empty input
```