### PR TITLE
Fix spacing of binary operator at the beggining of math equation (issue #332)

### DIFF
--- a/src/frontend/math.ml
+++ b/src/frontend/math.ml
@@ -257,6 +257,7 @@ let normalize_math_kind mkprev mknext mkraw =
         | MathRelation
         | MathOpen
         | MathPunct
+        | MathEnd
             -> true
         | _ -> false
       in


### PR DESCRIPTION
This change fix spacing of a binary operator at the beggining of math equation, treating a binary operator at the beggining of a equation as a MathOrd symbol.

The change involves only one line addition in `src/frontend/math.ml`.

More detailed explanation is in issue #332.