### PR TITLE
Fix math spacing around parentheses

### DIFF
--- a/src/frontend/primitives.cppo.ml
+++ b/src/frontend/primitives.cppo.ml
@@ -501,6 +501,8 @@ let default_math_class_map =
         (uchar_of_char '|', None,                      MathBinary);
         (uchar_of_char '/', None,                      MathOrdinary);
         (uchar_of_char ',', None,                      MathPunct);
+        (uchar_of_char '(', None,                      MathOpen);
+        (uchar_of_char ')', None,                      MathClose);
       ]
 
 


### PR DESCRIPTION
Version 0.0.7 adds arbitrary Unicode character support in math expressions and now it is legal to write literal parentheses characters (`(` and `)`) in math expressions.
However, math-class for parentheses are not properly set now, and math expressions containing these characters cause incorrect spacing.

I know the use of `math-paren` is recommended way to write parentheses and when we use `math-paren`, spacing around parentheses is correct.
But, parentheses are used very often in math expressions, so the use of literal `(` and `)` is more handy.

Although We can use `set-math-char` primitive in our document file to set math-class for these characters to avoid the spacing problem, for often used symbols setting math-class in SATySFi itself seems reasonable.
For example, math-class of binary operators like `+` and relational operators like `=` are set in `src/frontend/primitives.cppo.ml`.

How about supporting literal parentheses characters officially by setting math-class correctly?

This PR sets math-class for parentheses symbols as follows.

- set `(` (U+0028) to have math-class `MathOpen`
- set `)` (U+0029) to have math-class `MathClose`

Here is a demo for spacing around parentheses.

```
@require: stdjareport
@require: list
@require: math

let correct-spacing ctx =
    % list of (cp-form, cp-to, math-class)
    let mkmap =
        [
            (0x0028, 0x0028, MathOpen);  % left paren
            (0x0029, 0x0029, MathClose); % right paren
        ]
    in
    mkmap |> List.fold-left
            (fun ctx (cp-from,cp-to,mk) -> (ctx |> set-math-char cp-from cp-to mk))
            ctx

let-inline ctx \correct-spacing m =
    embed-math (correct-spacing ctx) m

in

document (|
    title = {Awkward spacing around parentheses};
    author = {sankantsu};
|) '<
     +p {
         Default spacing: ${(+1) + (-2) = -1}
     }
     +p {
         Corrected spacing: \correct-spacing(${(+1) + (-2) = -1});
     }
     +p {
         Using `\paren`: ${\paren{+1} + \paren{-2} = -1}
     }
>
```

- before

![before](https://user-images.githubusercontent.com/52688583/183830338-feef3f57-9315-4cfb-b984-b80b267d8ff5.png)

- after

![after](https://user-images.githubusercontent.com/52688583/183830461-a5908b1e-2c62-4378-a59e-fff5e9733886.png)