### PR TITLE
Add `\lnot` to math.satyh

### DIFF
--- a/lib-satysfi/dist/packages/math.satyh
+++ b/lib-satysfi/dist/packages/math.satyh
@@ -812,7 +812,7 @@ end = struct
   let-math \bigcap = bigop `⋂`
   let-math \bigcup = bigop `⋃`
 
-  let-math \lnot = rel `¬`
+  let-math \lnot = ord `¬`
   let-math \land = rel `∧`
   let-math \lor  = rel `∨`
 

--- a/lib-satysfi/dist/packages/math.satyh
+++ b/lib-satysfi/dist/packages/math.satyh
@@ -213,6 +213,7 @@ module Math : sig
   direct \bigcap : [] math-cmd
   direct \bigcup : [] math-cmd
 
+  direct \lnot : [] math-cmd
   direct \land : [] math-cmd
   direct \lor : [] math-cmd
 
@@ -811,6 +812,7 @@ end = struct
   let-math \bigcap = bigop `⋂`
   let-math \bigcup = bigop `⋃`
 
+  let-math \lnot = rel `¬`
   let-math \land = rel `∧`
   let-math \lor  = rel `∨`
 


### PR DESCRIPTION
It seems counter-intuitive to have `\land`, `\lor` and no `\lnot`.