### PR TITLE
Change the definition of the `paren` type

### DIFF
--- a/doc/paren.satyh
+++ b/doc/paren.satyh
@@ -3,7 +3,10 @@
 
 module LocalParen = struct
 
-  val record-paren-left hgt dpt hgtaxis fontsize color =
+  val record-paren-left hgt dpt ctx =
+    let fontsize = get-font-size ctx in
+    let hgtaxis = fontsize *' get-math-axis-height-ratio ctx in
+    let color = get-text-color ctx in
     let halflen = Math.half-length hgt dpt hgtaxis fontsize in
     let w0 = fontsize *' 0.1 in
     let w1 = fontsize *' 0.075 +' halflen *' 0.01 in
@@ -49,7 +52,10 @@ module LocalParen = struct
     (inline-graphics (w0 +' w1 +' w2 +' w-extra) (hgtaxis +' halflen) (halflen -' hgtaxis) graphics, kerninfo)
 
 
-  val record-paren-right hgt dpt hgtaxis fontsize color =
+  val record-paren-right hgt dpt ctx =
+    let fontsize = get-font-size ctx in
+    let hgtaxis = fontsize *' get-math-axis-height-ratio ctx in
+    let color = get-text-color ctx in
     let halflen = Math.half-length hgt dpt hgtaxis fontsize in
     let w0 = fontsize *' 0.1 in
     let w1 = fontsize *' 0.075 +' halflen *' 0.01 in

--- a/lib-satysfi/dist/packages/math.satyh
+++ b/lib-satysfi/dist/packages/math.satyh
@@ -1050,7 +1050,14 @@ end = struct
     let lenappend = fontsize *' 0.1 in
       Pervasives.length-max minhalflen ((Pervasives.length-max (hgt -' hgtaxis) (hgtaxis +' dpt)) +' lenappend)
 
-  val angle-left thk hgt dpt hgtaxis fontsize color =
+  val extract-spec-from-context ctx =
+    let fontsize = get-font-size ctx in
+    let hgtaxis = fontsize *' get-math-axis-height-ratio ctx in
+    let color = get-text-color ctx in
+    (fontsize, hgtaxis, color)
+
+  val angle-left thk hgt dpt ctx =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
     let halflen = half-length hgt dpt hgtaxis fontsize in
     let widparen = halflen *' 0.375 in
     let wid = widparen +' fontsize *' 0.1 in
@@ -1072,7 +1079,8 @@ end = struct
     in
     (inline-graphics wid (hgtaxis +' halflen) (halflen -' hgtaxis) graphics, kerninfo)
 
-  val angle-right thk hgt dpt hgtaxis fontsize color =
+  val angle-right thk hgt dpt ctx =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
     let halflen = half-length hgt dpt hgtaxis fontsize in
     let widparen = halflen *' 0.375 in
     let wid = widparen +' fontsize *' 0.1 in
@@ -1097,7 +1105,8 @@ end = struct
   val math ctx \angle-bracket m =
     math-paren ctx (angle-left 0.5pt) (angle-right 0.5pt) (read-math ctx m)
 
-  val paren-left hgt dpt hgtaxis fontsize color =
+  val paren-left hgt dpt ctx =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
     let halflen = half-length hgt dpt hgtaxis fontsize in
     let w0 = fontsize *' 0.1 in
     let w1 = fontsize *' 0.075 +' halflen *' 0.01 in
@@ -1131,7 +1140,8 @@ end = struct
     let kerninfo _ = 0pt in
       (inline-graphics (w0 +' w1 +' w2 +' w-extra) (hgtaxis +' halflen) (halflen -' hgtaxis) graphics, kerninfo)
 
-  val paren-right hgt dpt hgtaxis fontsize color =
+  val paren-right hgt dpt ctx =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
     let halflen = half-length hgt dpt hgtaxis fontsize in
     let w0 = fontsize *' 0.1 in
     let w1 = fontsize *' 0.075 +' halflen *' 0.01 in
@@ -1188,7 +1198,8 @@ end = struct
     read-math ctx ${#m1 \paren{#m2}}
 
 
-  val brace-left hgt dpt hgtaxis fontsize color =
+  val brace-left hgt dpt ctx =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
 
     let t0 = fontsize *' 0.0125 in
     let t4 = fontsize *' 0.025 in
@@ -1264,7 +1275,8 @@ end = struct
     (inline-graphics (x4 +' w-extra) (hgtaxis +' halflen) (halflen -' hgtaxis) graphics, kerninfo)
 
 
-  val brace-right hgt dpt hgtaxis fontsize color =
+  val brace-right hgt dpt ctx =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
 
     let t0 = fontsize *' 0.0125 in
     let t4 = fontsize *' 0.025 in
@@ -1340,7 +1352,8 @@ end = struct
     (inline-graphics x4 (hgtaxis +' halflen) (halflen -' hgtaxis) graphics, kerninfo)
 
 
-  val brace-left-long hgt dpt hgtaxis fontsize color =
+  val brace-left-long hgt dpt ctx =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
     let halflen = half-length hgt dpt hgtaxis fontsize in
 
     let t0B = fontsize *' 0.05 in
@@ -1391,7 +1404,8 @@ end = struct
     math-paren ctx brace-left brace-right (read-math ctx m)
 
 
-  val bar-middle hgt dpt hgtaxis fontsize color =
+  val bar-middle hgt dpt ctx =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
     let halflen = half-length hgt dpt hgtaxis fontsize in
     let halfwid = fontsize *' 0.5 in
     let graphics (x, y) =
@@ -1406,7 +1420,8 @@ end = struct
     math-paren-with-middle ctx brace-left brace-right bar-middle [read-math ctx m1, read-math ctx m2]
 
 
-  val slash-middle hgt dpt hgtaxis fontsize color =
+  val slash-middle hgt dpt ctx =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
     let halflen = half-length hgt dpt hgtaxis fontsize in
     let halfwid = halflen *' 0.5 in
     let graphics (x, y) =
@@ -1463,7 +1478,8 @@ end = struct
         |> close-with-line
 
 
-  val bracket-left pathf (hgt : length) (dpt : length) (hgtaxis : length) (fontsize : length) (color : color) =
+  val bracket-left pathf (hgt : length) (dpt : length) (ctx : context) =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
     let halflen = half-length hgt dpt hgtaxis fontsize in
     let (w0, w1, w2, t) = bracket-metrics fontsize halflen in
     let path (xpos, ypos) =
@@ -1477,7 +1493,8 @@ end = struct
     (inline-graphics widparen (hgtaxis +' halflen) (halflen -' hgtaxis) graphics, (fun _ -> 0pt))
 
 
-  val bracket-right pathf hgt dpt hgtaxis fontsize color =
+  val bracket-right pathf (hgt : length) (dpt : length) (ctx : context) =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
     let halflen = half-length hgt dpt hgtaxis fontsize in
     let (w0, w1, w2, t) = bracket-metrics fontsize halflen in
     let widparen = w0 +' w1 +' w2 in
@@ -1509,10 +1526,11 @@ end = struct
     math-paren ctx ceil-left ceil-right (read-math ctx m)
 
 
-  val empty-paren _ _ _ _ _ = (inline-nil, (fun _ -> 0pt))
+  val empty-paren _ _ _ = (inline-nil, (fun _ -> 0pt))
 
 
-  val abs-left hgt dpt hgtaxis fontsize color =
+  val abs-left hgt dpt ctx =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
     let halflen = half-length hgt dpt hgtaxis fontsize in
     let wid = 5.0pt in
     let path (xpos, ypos) =
@@ -1525,7 +1543,8 @@ end = struct
     (inline-graphics wid (hgtaxis +' halflen) (halflen -' hgtaxis) graphics, kerninfo)
 
 
-  val abs-right hgt dpt hgtaxis fontsize color =
+  val abs-right hgt dpt ctx =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
     let halflen = half-length hgt dpt hgtaxis fontsize in
     let wid = 5.0pt in
     let path (xpos, ypos) =
@@ -1542,7 +1561,8 @@ end = struct
     math-paren ctx abs-left abs-right (read-math ctx m)
 
 
-  val norm-left hgt dpt hgtaxis fontsize color =
+  val norm-left hgt dpt ctx =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
     let halflen = half-length hgt dpt hgtaxis fontsize in
     let wid = 7.0pt in
     let path (xpos, ypos) =
@@ -1561,7 +1581,8 @@ end = struct
     (inline-graphics wid (hgtaxis +' halflen) (halflen -' hgtaxis) graphics, kerninfo)
 
 
-  val norm-right hgt dpt hgtaxis fontsize color =
+  val norm-right hgt dpt ctx =
+    let (fontsize, hgtaxis, color) = extract-spec-from-context ctx in
     let halflen = half-length hgt dpt hgtaxis fontsize in
     let wid = 7.0pt in
     let path (xpos, ypos) =

--- a/lib-satysfi/dist/packages/math.satyh
+++ b/lib-satysfi/dist/packages/math.satyh
@@ -1623,7 +1623,7 @@ end = struct
         in
         let ib = tabular celllstlst (fun _ _ -> Gr.empty) in
         let (_, hgt, dpt) = get-natural-metrics ib in
-        let hgtaxis = get-axis-height ctx in
+        let hgtaxis = size *' get-math-axis-height-ratio ctx in
         raise-inline (hgtaxis -' (hgt +' dpt) *' 0.5) ib
       )
     in

--- a/lib-satysfi/dist/packages/pervasives.satyh
+++ b/lib-satysfi/dist/packages/pervasives.satyh
@@ -2,7 +2,7 @@ module Pervasives = struct
 
   type point = length * length
 
-  type paren = length -> length -> length -> length -> color -> inline-boxes * (length -> length)
+  type paren = length -> length -> context -> inline-boxes * (length -> length)
 
 
   val get-natural-width ib =

--- a/lib-satysfi/dist/packages/proof.satyh
+++ b/lib-satysfi/dist/packages/proof.satyh
@@ -66,11 +66,12 @@ end = struct
             ((fun pt -> [Gr.text-rightward pt ib]), wname)
         end
       in
+      let axis-height = get-font-size ctx *' get-math-axis-height-ratio ctx in
       let bar =
           inline-graphics w (thickness +' gap) gap (fun (x, y) -> (
             let grs =
               fill color (Gr.rectangle (x, y) (x +' w, y +' thickness))
-                :: (glnamef (x +' w, y -' (get-axis-height ctx)))
+                :: (glnamef (x +' w, y -' axis-height))
             in
             unite-graphics grs
           ))

--- a/src/backend/horzBox.ml
+++ b/src/backend/horzBox.ml
@@ -415,18 +415,6 @@ and math_variant_value_main =
   | MathVariantToCharWithKern of bool * Uchar.t list * math_char_kern_func * math_char_kern_func
       [@printer (fun fmt _ -> Format.fprintf fmt "<to-char'>")]
 
-and paren = length -> length -> length -> length -> color -> horz_box list * math_kern_func
-  (* --
-     'paren':
-       the type for adjustable parentheses.
-       An adjustable parenthesis takes as arguments
-       (1-2) the height and the depth of the inner contents,
-       (3)   the axis height,
-       (4)   the font size, and
-       (5)   the color for glyphs,
-       and then returns its inline box representation and the function for kerning.
-     -- *)
-
 and radical = length -> length -> length -> length -> color -> horz_box list
   (* --
      'radical':

--- a/src/frontend/math.ml
+++ b/src/frontend/math.ml
@@ -645,12 +645,9 @@ let radical_degree_baseline_height mathctx scriptlev h_rad d_deg =
 *)
 
 
-let make_paren mathctx paren hgt dpt =
-  let fontsize = MathContext.font_size mathctx in
-  let mc = FontInfo.get_math_constants mathctx in
-  let h_bar = fontsize *% mc.FontFormat.axis_height in
-  let (hblst, kernf) = paren hgt dpt h_bar fontsize (MathContext.color mathctx) in
-    (hblst, FontInfo.make_dense_math_kern kernf)
+let make_paren mathctx (paren : paren) (height : length) (depth : length) =
+  let (hbs, kernf) = paren height depth (MathContext.context_for_text mathctx) in
+  (hbs, FontInfo.make_dense_math_kern kernf)
 
 
 let make_radical mathctx radical hgt_bar t_bar dpt =

--- a/src/frontend/primitives.cppo.ml
+++ b/src/frontend/primitives.cppo.ml
@@ -85,7 +85,7 @@ let tIGR = tIGR_raw
 let tIGRO_raw = tLN @-> tPT @-> tGR
 let tIGRO = tIGRO_raw
 
-let tPAREN = tLN @-> tLN @-> tLN @-> tLN @-> tCLR @-> tPROD [tIB; tLN @-> tLN]
+let tPAREN = tLN @-> tLN @-> tCTX @-> tPROD [tIB; tLN @-> tLN]
 
 let tICMD ty = (~! "cmd", HorzCommandType([CommandArgType(LabelMap.empty, ty)]))
 

--- a/src/frontend/types.cppo.ml
+++ b/src/frontend/types.cppo.ml
@@ -1066,15 +1066,15 @@ and math_box =
     }
   | MathBoxParen of {
       context : input_context;
-      left    : HorzBox.paren;
-      right   : HorzBox.paren;
+      left    : paren;
+      right   : paren;
       inner   : math_box list;
     }
   | MathBoxParenWithMiddle of {
       context : input_context;
-      left    : HorzBox.paren;
-      right   : HorzBox.paren;
-      middle  : HorzBox.paren;
+      left    : paren;
+      right   : paren;
+      middle  : paren;
       inner   : (math_box list) list;
     }
   | MathBoxUpperLimit of {
@@ -1087,6 +1087,15 @@ and math_box =
       base    : math_box list;
       lower   : math_box list;
     }
+
+and paren =
+  length -> length -> input_context -> HorzBox.horz_box list * HorzBox.math_kern_func
+    (* The type for adjustable parentheses.
+       An adjustable parenthesis takes as arguments
+       (1) the height of the inner contents,
+       (2) the depth of the inner contents, and
+       (3) the context,
+       and then returns its inline box representation and the function for kerning. *)
 
 and code_value =
   | CdPersistent    of Range.t * EvalVarID.t

--- a/tools/gencode/vminst.ml
+++ b/tools/gencode/vminst.ml
@@ -1298,6 +1298,20 @@ match ctx.script_space_map |> CharBasis.ScriptSpaceMap.find_opt (script1, script
       make_float r2;
     ]))
 |}
+    ; inst "PrimitivieGetMathAxisHeightRatio"
+        ~name:"get-math-axis-height-ratio"
+        ~type_:Type.(tCTX @-> tFL)
+        ~fields:[
+        ]
+        ~params:[
+          param "ictx" ~type_:"context";
+        ]
+        ~is_pdf_mode_primitive:true
+        ~code:{|
+let mctx = MathContext.make ictx in
+let mc = FontInfo.get_math_constants mctx in
+make_float (mc.FontFormat.axis_height)
+|}
     ; inst "PrimitiveSetParagraphMargin"
         ~name:"set-paragraph-margin"
         ~type_:Type.(tLN @-> tLN @-> tCTX @-> tCTX)
@@ -1597,21 +1611,6 @@ CompiledInputHorzClosure([CompiledImInputHorzText(str)], env)
         ~is_text_mode_primitive:true
         ~code:{|
 make_string (HorzBox.extract_string hblst)
-|}
-    ; inst "PrimitiveGetAxisHeight"
-        ~name:"get-axis-height"
-        ~type_:Type.(tCTX @-> tLN)
-        ~fields:[
-        ]
-        ~params:[
-          param "(ctx, _)" ~type_:"context";
-        ]
-        ~is_pdf_mode_primitive:true
-        ~code:{|
-let fontsize = ctx.HorzBox.font_size in
-let mfabbrev = ctx.HorzBox.math_font_abbrev in
-let hgt = FontInfo.get_axis_height mfabbrev fontsize in
-make_length (hgt)
 |}
     ; inst "BackendFixedEmpty"
         ~name:"inline-skip"


### PR DESCRIPTION
## Before

```
type paren = length -> length -> length -> length -> color -> inline-boxes * (length -> length)
```

i.e. the type for functions that take

- the height of the inner formulae,
- the (non-negative) depth of the inner formulae,
- the font size,
- the axis height, and
- the text color

## After

```
type paren = length -> length -> context -> inline-boxes * (length -> length)
```