### PR TITLE
Enable more warnings for 0.1.0 branch

### DIFF
--- a/src/backend/crossRef.ml
+++ b/src/backend/crossRef.ml
@@ -4,8 +4,6 @@ open MyUtil
 module YS = Yojson.Safe
 module MYU = MyYojsonUtil
 
-exception InvalidYOJSON of abs_path * string
-
 
 module CrossRefHashTable = Hashtbl.Make
   (struct

--- a/src/backend/crossRef.ml
+++ b/src/backend/crossRef.ml
@@ -25,7 +25,7 @@ let main_hash_table = CrossRefHashTable.create 32
   (* temporary; initial size *)
 
 
-let read_assoc (abspath : abs_path) (assoc : (string * YS.json) list) : unit =
+let read_assoc (assoc : (string * YS.json) list) : unit =
   assoc |> List.iter (fun (key, vjson) ->
     let value = vjson |> YS.Util.to_string in
     CrossRefHashTable.add main_hash_table key value
@@ -37,7 +37,7 @@ let read_dump_file (abspath : abs_path) : unit =
     let json = YS.from_file (get_abs_path_string abspath) in
       (* -- may raise 'Sys_error', or 'Yojson.Json_error' -- *)
     let assoc = json |> YS.Util.to_assoc in
-    read_assoc abspath assoc
+    read_assoc assoc
   with
   | Yojson.Json_error(msg) -> MYU.syntax_error (get_abs_path_string abspath) msg
 

--- a/src/backend/flowGraph.ml
+++ b/src/backend/flowGraph.ml
@@ -1,5 +1,5 @@
 
-let print_for_debug msg =
+let[@ocaml.warning "-27"] print_for_debug msg =
 (*
   print_endline msg;
 *)

--- a/src/backend/fontFormat.ml
+++ b/src/backend/fontFormat.ml
@@ -2075,7 +2075,6 @@ let find_kerning (dcdr : decoder) (gidprev : glyph_id) (gid : glyph_id) : per_mi
 module MathInfoMap = Map.Make
   (struct
     type t = original_glyph_id
-    let equal = (=)
     let compare = Stdlib.compare
   end)
 

--- a/src/backend/fontFormat.ml
+++ b/src/backend/fontFormat.ml
@@ -1156,6 +1156,7 @@ type 'a resource =
   | Data           of 'a
   | EmbeddedStream of int
 
+(*
 type predefined_encoding =
   | StandardEncoding
   | MacRomanEncoding
@@ -1163,10 +1164,12 @@ type predefined_encoding =
 
 type differences = (string * int) list
 
+(* for module Type1Scheme_ etc. *)
 type encoding =
   | ImplicitEncoding
   | PredefinedEncoding of predefined_encoding
   | CustomEncoding     of predefined_encoding * differences
+*)
 
 type cmap =
   | PredefinedCMap of string
@@ -1174,7 +1177,10 @@ type cmap =
   | CMapFile       of cmap_resource
 *)
 
+(*
+(* for module Type3 *)
 type matrix = float * float * float * float
+*)
 
 type font_stretch =
   | UltraCondensedStretch | ExtraCondensedStretch | CondensedStretch | SemiCondensedStetch

--- a/src/backend/fontFormat.ml
+++ b/src/backend/fontFormat.ml
@@ -13,8 +13,6 @@ type per_mille =
 
 type metrics = per_mille * per_mille * per_mille
 
-type indirect = int
-
 exception FailToLoadFontOwingToSystem of abs_path * string
 exception BrokenFont                  of abs_path * string
 exception CannotFindUnicodeCmap       of abs_path

--- a/src/backend/fontFormat.ml
+++ b/src/backend/fontFormat.ml
@@ -926,7 +926,7 @@ module KerningTable
       let htC = HtClass.create 1024 (* arbitrary constant *) in
       begin
         lst |> List.iter (fun (cls1, pairposlst) ->
-          pairposlst |> List.iter (fun (cls2, valrcd1, valrcd2) ->
+          pairposlst |> List.iter (fun (cls2, valrcd1, _valrcd2) ->
             match valrcd1.Otfm.x_advance with
             | None      -> ()
             | Some(0)   -> ()
@@ -996,7 +996,7 @@ let get_kerning_table srcpath (d : Otfm.decoder) =
         pickup featurelst (fun gf -> Otfm.gpos_feature_tag gf = "kern") `Missing_feature >>= fun feature ->
         () |> Otfm.gpos feature
           ~pair1:(fun () (gid1, pairposlst) ->
-            pairposlst |> List.iter (fun (gid2, valrcd1, valrcd2) ->
+            pairposlst |> List.iter (fun (gid2, valrcd1, _valrcd2) ->
               match valrcd1.Otfm.x_advance with
               | None      -> ()
               | Some(xa1) -> kerntbl |> KerningTable.add gid1 gid2 xa1
@@ -1044,7 +1044,7 @@ let per_mille (dcdr : decoder) (w : design_units) : per_mille =
   per_mille_raw dcdr.units_per_em w
 
 
-let get_original_gid (dcdr : decoder) (gid : glyph_id) : original_glyph_id =
+let get_original_gid (_dcdr : decoder) (gid : glyph_id) : original_glyph_id =
   let SubsetGlyphID(gidorg, _) = gid in
   gidorg
 
@@ -1097,9 +1097,9 @@ let get_glyph_advance_width (dcdr : decoder) (gidorgkey : original_glyph_id) : p
     )
   in
     match hmtxres with
-    | Error(e)             -> broken dcdr.file_path e (Printf.sprintf "get_glyph_advance_width (gid = %d)" gidorgkey)
-    | Ok(None)             -> PerMille(0)
-    | Ok(Some((adv, lsb))) -> per_mille dcdr adv
+    | Error(e)              -> broken dcdr.file_path e (Printf.sprintf "get_glyph_advance_width (gid = %d)" gidorgkey)
+    | Ok(None)              -> PerMille(0)
+    | Ok(Some((adv, _lsb))) -> per_mille dcdr adv
 
 
 let get_bbox (dcdr : decoder) (gidorg : original_glyph_id) : bbox =
@@ -1669,7 +1669,7 @@ type cid_font =
   | CIDFontType2 of CIDFontType2.font
 
 
-let pdfobject_of_cmap pdf cmap =
+let pdfobject_of_cmap _pdf cmap =
   match cmap with
   | PredefinedCMap(cmapname) -> Pdf.Name("/" ^ cmapname)
 (*
@@ -1710,8 +1710,7 @@ module ToUnicodeCMap
         "endcmap CMapName currentdict/CMap defineresource pop end end"
       in
       let buf = Buffer.create ((15 + (6 + 512) * 64 + 10) * 1024) in
-      Array.iteri (fun i ht ->
-        let ht = touccmap.(i) in
+      Array.iter (fun ht ->
         let num = GSHt.length ht in
         if num <= 0 then
           ()
@@ -2005,15 +2004,15 @@ let cid_font_type_2 cidty2font fontname cmap =
 let get_font (dcdr : decoder) (fontreg : font_registration) (fontname : string) : font =
   let cmap = PredefinedCMap("Identity-H") in
   match fontreg with
-  | CIDFontType0Registration(cidsysinfo, embedW) ->
+  | CIDFontType0Registration(cidsysinfo, _embedW) ->
       let cidty0font = CIDFontType0.of_decoder dcdr cidsysinfo in
       (cid_font_type_0 cidty0font fontname cmap)
 
-  | CIDFontType2TTRegistration(cidsysinfo, embedW) ->
+  | CIDFontType2TTRegistration(cidsysinfo, _embedW) ->
       let cidty2font = CIDFontType2.of_decoder dcdr cidsysinfo true in
       (cid_font_type_2 cidty2font fontname cmap)
 
-  | CIDFontType2OTRegistration(cidsysinfo, embedW) ->
+  | CIDFontType2OTRegistration(cidsysinfo, _embedW) ->
       let cidty2font = CIDFontType2.of_decoder dcdr cidsysinfo true (* temporary *) in
       (cid_font_type_2 cidty2font fontname cmap)
 
@@ -2243,7 +2242,7 @@ let get_math_script_variant (md : math_decoder) (gid : glyph_id) : glyph_id =
       in
       let res = Otfm.gsub feature_ssty ~single:f_single ~alt:f_alt None in
       match res with
-      | Error(oerr)          -> gid  (* temporary; maybe should emit an error *)
+      | Error(_oerr)         -> gid  (* temporary; maybe should emit an error *)
       | Ok(None)             -> gid
       | Ok(Some(gidorgssty)) -> intern_gid dcdr gidorgssty
 

--- a/src/backend/fontFormat.ml
+++ b/src/backend/fontFormat.ml
@@ -336,14 +336,14 @@ let per_mille_raw (units_per_em : int) (w : design_units) : per_mille =
 module GSet = Set.Make
   (struct
     type t = original_glyph_id
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end)
 
 
 module GMap = Map.Make
   (struct
     type t = original_glyph_id
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end)
 
 
@@ -2073,7 +2073,7 @@ module MathInfoMap = Map.Make
   (struct
     type t = original_glyph_id
     let equal = (=)
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end)
 
 

--- a/src/backend/fontFormat.ml
+++ b/src/backend/fontFormat.ml
@@ -1492,7 +1492,8 @@ let get_postscript_name (dcdr : decoder) =
   | Ok(Some(x)) -> x
 
 
-type embedding =
+(* -w -unused-constructor *)
+type[@ocaml.warning "-37"] embedding =
   | FontFile
   | FontFile2
   | FontFile3 of string
@@ -1631,7 +1632,8 @@ module CIDFontType0
   end
 
 
-type cid_to_gid_map =
+(* -w -unused-constructor *)
+type[@ocaml.warning "-37"] cid_to_gid_map =
   | CIDToGIDIdentity
   | CIDToGIDStream   of (string resource) ref  (* temporary *)
 

--- a/src/backend/fontFormat.ml
+++ b/src/backend/fontFormat.ml
@@ -2152,7 +2152,6 @@ let assoc_to_map f gidassoc =
 
 
 let make_math_decoder_from_decoder (abspath : abs_path) ((dcdr, font) : decoder * font) =
-  let open OptionMonad in
   let d = dcdr.main in
   match Otfm.math d with
   | Error(oerr) ->

--- a/src/backend/graphicBase.ml
+++ b/src/backend/graphicBase.ml
@@ -1,5 +1,4 @@
 
-open MyUtil
 open LengthInterface
 
 

--- a/src/backend/graphicD.ml
+++ b/src/backend/graphicD.ml
@@ -1,3 +1,5 @@
+(* -unused-value-declaration *)
+[@@@ocaml.warning "-32"]
 
 open LengthInterface
 open GraphicBase

--- a/src/backend/handlePdf.ml
+++ b/src/backend/handlePdf.ml
@@ -166,7 +166,7 @@ let rec ops_of_evaled_horz_box (fs : 'o op_funcs) (pbinfo : page_break_info) ypo
         let opaccnew = Alist.append opacc ops in
           (xpos +% wid, opaccnew)
 
-    | EvHorzRising{ height = hgt; depth = dpt; rising = lenrising; contents = evhblst } ->
+    | EvHorzRising{ height = _hgt; depth = _dpt; rising = lenrising; contents = evhblst } ->
         let (_, opaccsub) =
           evhblst |> List.fold_left (ops_of_evaled_horz_box fs pbinfo (yposbaseline +% lenrising)) (xpos, opacc)
         in
@@ -180,7 +180,7 @@ let rec ops_of_evaled_horz_box (fs : 'o op_funcs) (pbinfo : page_break_info) ypo
         in
         (xpos +% wid, opaccnew)
 
-    | EvHorzEmbeddedVert{ height = hgt; depth = dpt; contents = evvblst } ->
+    | EvHorzEmbeddedVert{ height = hgt; depth = _dpt; contents = evvblst } ->
         let ((_, _), opaccnew) = ops_of_evaled_vert_box_list fs pbinfo (xpos, yposbaseline +% hgt) opacc evvblst in
         (xpos +% wid, opaccnew)
 
@@ -203,7 +203,7 @@ let rec ops_of_evaled_horz_box (fs : 'o op_funcs) (pbinfo : page_break_info) ypo
 
     | EvHorzInlineTabular{
         height        = hgt;
-        depth         = dpt;
+        depth         = _dpt;
         rows          = evtabular;
         column_widths = widlst;
         row_heights   = lenlst;
@@ -268,7 +268,7 @@ and ops_of_evaled_tabular (fs : 'o op_funcs) (pbinfo : page_break_info) point ev
               in
               (opaccnew, (xpos +% wid, ypos))
 
-          | EvMultiCell(ratios, (_, _, widsingle, widcell, hgt, dpt), evhblst) ->
+          | EvMultiCell(ratios, (_, _, widsingle, _widcell, hgt, dpt), evhblst) ->
               let yposbaseline = ypos -% hgt in
               let ops_warning =
                 warn_ratios fs pbinfo (xpos, yposbaseline) hgt dpt ratios
@@ -456,7 +456,7 @@ let add_column_to_page
   Page(paper, pagecontsch, Alist.cat opacc opacccolumn, pbinfo)
 
 
-let write_page (Page(paper, pagecontsch, opaccpage, pbinfo) : page) (pagepartsf : page_parts_scheme_func) ((PDF(pdf, pageacc, flnm)) : t) : t =
+let write_page (Page(paper, _pagecontsch, opaccpage, pbinfo) : page) (pagepartsf : page_parts_scheme_func) ((PDF(pdf, pageacc, flnm)) : t) : t =
 
   let paper_height = get_paper_height paper in
 

--- a/src/backend/horzBox.ml
+++ b/src/backend/horzBox.ml
@@ -541,16 +541,16 @@ let get_metrics_of_evaled_horz_box ((wid, evhbmain) : evaled_horz_box) : length 
     | EvHorzHookPageBreak(_, _) ->
         (Length.zero, Length.zero)
 
-    | EvHorzInlineImage{ height } ->
+    | EvHorzInlineImage{ height; _ } ->
         (height, Length.zero)
 
-    | EvHorzString{ height; depth }
-    | EvHorzMathGlyph{ height; depth }
-    | EvHorzRising{ height; depth }
-    | EvHorzFrame{ height; depth }
-    | EvHorzEmbeddedVert{ height; depth }
-    | EvHorzInlineGraphics{ height; depth }
-    | EvHorzInlineTabular{ height; depth } ->
+    | EvHorzString{ height; depth; _ }
+    | EvHorzMathGlyph{ height; depth; _ }
+    | EvHorzRising{ height; depth; _ }
+    | EvHorzFrame{ height; depth; _ }
+    | EvHorzEmbeddedVert{ height; depth; _ }
+    | EvHorzInlineGraphics{ height; depth; _ }
+    | EvHorzInlineTabular{ height; depth; _ } ->
         (height, depth)
   in
   (wid, hgt, dpt)
@@ -577,11 +577,11 @@ let get_metrics_of_intermediate_horz_box_list (imhblst : intermediate_horz_box l
       | ImHorzFootnote(_) ->
           (Length.zero, Length.zero, Length.zero)
 
-      | ImHorzRising{ width; height; depth }
-      | ImHorzFrame{ width; height; depth }
-      | ImHorzInlineTabular{ width; height; depth }
-      | ImHorzEmbeddedVert{ width; height; depth }
-      | ImHorzInlineGraphics{ width; height; depth } ->
+      | ImHorzRising{ width; height; depth; _ }
+      | ImHorzFrame{ width; height; depth; _ }
+      | ImHorzInlineTabular{ width; height; depth; _ }
+      | ImHorzEmbeddedVert{ width; height; depth; _ }
+      | ImHorzInlineGraphics{ width; height; depth; _ } ->
           (width, height, depth)
     in
     (wid +% w, Length.max hgt h, Length.min dpt d)
@@ -591,15 +591,15 @@ let get_metrics_of_intermediate_horz_box_list (imhblst : intermediate_horz_box l
 let rec extract_string (hblst : horz_box list) : string =
   let extract_one hb =
     match hb with
-    | HorzPure(PHCInnerString{ chars = uchs })  -> string_of_uchlst uchs
-    | HorzPure(PHCInnerMathGlyph(_))            -> ""
-    | HorzPure(PHGRising{ contents = hbs })     -> extract_string hbs
-    | HorzPure(PHGFixedFrame{ contents = hbs }) -> extract_string hbs
-    | HorzPure(PHGInnerFrame{ contents = hbs }) -> extract_string hbs
-    | HorzPure(PHGOuterFrame{ contents = hbs }) -> extract_string hbs
-    | HorzDiscretionary{ no_break = hbs0 }      -> extract_string hbs0
-    | HorzFrameBreakable{ contents = hbs }      -> extract_string hbs
-    | HorzScriptGuard{ contents = hbs }         -> extract_string hbs
-    | _                                         -> ""
+    | HorzPure(PHCInnerString{ chars = uchs; _ })  -> string_of_uchlst uchs
+    | HorzPure(PHCInnerMathGlyph(_))               -> ""
+    | HorzPure(PHGRising{ contents = hbs; _ })     -> extract_string hbs
+    | HorzPure(PHGFixedFrame{ contents = hbs; _ }) -> extract_string hbs
+    | HorzPure(PHGInnerFrame{ contents = hbs; _ }) -> extract_string hbs
+    | HorzPure(PHGOuterFrame{ contents = hbs; _ }) -> extract_string hbs
+    | HorzDiscretionary{ no_break = hbs0; _ }      -> extract_string hbs0
+    | HorzFrameBreakable{ contents = hbs; _ }      -> extract_string hbs
+    | HorzScriptGuard{ contents = hbs; _ }         -> extract_string hbs
+    | _                                            -> ""
   in
   String.concat "" (List.map extract_one hblst)

--- a/src/backend/horzBox.ml
+++ b/src/backend/horzBox.ml
@@ -589,7 +589,7 @@ let get_metrics_of_intermediate_horz_box_list (imhblst : intermediate_horz_box l
 
 
 let rec extract_string (hblst : horz_box list) : string =
-  let rec extract_one hb =
+  let extract_one hb =
     match hb with
     | HorzPure(PHCInnerString{ chars = uchs })  -> string_of_uchlst uchs
     | HorzPure(PHCInnerMathGlyph(_))            -> ""

--- a/src/backend/imageInfo.ml
+++ b/src/backend/imageInfo.ml
@@ -21,7 +21,7 @@ let add_image abspath =
 
 let get_xobject_dictionary pdfmain : Pdf.pdfobject =
   let keyval =
-    [] |> ImageHashTable.fold (fun _ (tag, bbox, imgvalue) acc ->
+    [] |> ImageHashTable.fold (fun _ (tag, _bbox, imgvalue) acc ->
       match imgvalue with
       | ImageHashTable.PDFImage(pdfext, page) ->
           let irxobj = LoadPdf.make_xobject pdfmain pdfext page in

--- a/src/backend/length.mli
+++ b/src/backend/length.mli
@@ -1,3 +1,5 @@
+(* -unused-value-declaration *)
+[@@@ocaml.warning "-32"]
 
 type t  [@@deriving show]
 

--- a/src/backend/lineBreak.ml
+++ b/src/backend/lineBreak.ml
@@ -378,9 +378,9 @@ and convert_list_for_line_breaking_pure (hblst : horz_box list) : lb_pure_box li
     | HorzFrameBreakable{
         paddings              = pads;
         decoration_standalone = decoS;
-        decoration_head       = decoH;
-        decoration_middle     = decoM;
-        decoration_tail       = decoT;
+        decoration_head       = _decoH;
+        decoration_middle     = _decoM;
+        decoration_tail       = _decoT;
         contents              = hbs0;
       } :: tail ->
         let lphbs0 = convert_list_for_line_breaking_pure hbs0 in
@@ -492,7 +492,7 @@ and normalize_chunks_pure (lbpelst : lb_pure_either list) : lb_pure_box list =
               aux (Alist.extend (Alist.append lphbacc lphblst) lphb) None lbpetail
         end
 
-    | PScriptGuard(scriptL, scriptR, lphblstG) :: lbpetail  ->
+    | PScriptGuard(scriptL, _scriptR, lphblstG) :: lbpetail  ->
         begin
           match chunkaccopt with
           | None ->
@@ -1148,7 +1148,7 @@ let main ((breakability_top, paragraph_margin_top) : breakability * length) ((br
         let wmap = wmap |> WidthMap.add_width_all widinfo in
         aux NormalState iterdepth wmap tail
 
-    | LBFrameBreakable{ paddings = pads; contents = lhbs_sub } :: tail ->
+    | LBFrameBreakable{ paddings = _pads; contents = lhbs_sub } :: tail ->
         let wmap_sub = aux NormalState (iterdepth + 1) wmap lhbs_sub in
         aux NormalState iterdepth wmap_sub tail
 

--- a/src/backend/lineBreak.ml
+++ b/src/backend/lineBreak.ml
@@ -28,16 +28,16 @@ let ( ~@ ) = int_of_float
 
 let get_metrics (lphb : lb_pure_box) : metrics =
   match lphb with
-  | LBAtom{ metrics }                         -> metrics
-  | LBRising{ metrics }                       -> metrics
-  | LBOuterFrame{ metrics }                   -> metrics
-  | LBFixedFrame{ width; height; depth }      -> (natural width, height, depth)
-  | LBEmbeddedVert{ width; height; depth }    -> (natural width, height, depth)
-  | LBFixedGraphics{ width; height; depth }   -> (natural width, height, depth)
-  | LBFixedTabular{ width; height; depth }    -> (natural width, height, depth)
-  | LBFixedImage{ width; height}              -> (natural width, height, Length.zero)
+  | LBAtom{ metrics; _ }                       -> metrics
+  | LBRising{ metrics; _ }                     -> metrics
+  | LBOuterFrame{ metrics; _ }                 -> metrics
+  | LBFixedFrame{ width; height; depth; _ }    -> (natural width, height, depth)
+  | LBEmbeddedVert{ width; height; depth; _ }  -> (natural width, height, depth)
+  | LBFixedGraphics{ width; height; depth; _ } -> (natural width, height, depth)
+  | LBFixedTabular{ width; height; depth; _ }  -> (natural width, height, depth)
+  | LBFixedImage{ width; height; _ }           -> (natural width, height, Length.zero)
 
-  | LBOuterFilGraphics{ height; depth } ->
+  | LBOuterFilGraphics{ height; depth; _ } ->
       let widinfo =
         {
           natural     = Length.zero;
@@ -362,7 +362,7 @@ and convert_list_for_line_breaking_pure (hblst : horz_box list) : lb_pure_box li
     match hblst with
     | [] -> Alist.to_list lbpeacc
 
-    | HorzDiscretionary{ no_break = hbs0 } :: tail ->
+    | HorzDiscretionary{ no_break = hbs0; _ } :: tail ->
         let lphbs0 = aux Alist.empty hbs0 in
         aux (Alist.append lbpeacc lphbs0) tail
 
@@ -610,14 +610,14 @@ let rec determine_widths (widreqopt : length option) (lphblst : lb_pure_box list
   let get_intermediate_total_width imhblst =
     imhblst |> List.fold_left (fun wacc imhb ->
       match imhb with
-      | ImHorz(w, _)                  -> wacc +% w
-      | ImHorzRising{ width }         -> wacc +% width
-      | ImHorzFrame{ width }          -> wacc +% width
-      | ImHorzInlineTabular{ width }  -> wacc +% width
-      | ImHorzInlineGraphics{ width } -> wacc +% width
-      | ImHorzEmbeddedVert{ width }   -> wacc +% width
-      | ImHorzHookPageBreak(_)        -> wacc
-      | ImHorzFootnote(_)             -> wacc
+      | ImHorz(w, _)                     -> wacc +% w
+      | ImHorzRising{ width; _ }         -> wacc +% width
+      | ImHorzFrame{ width; _ }          -> wacc +% width
+      | ImHorzInlineTabular{ width; _ }  -> wacc +% width
+      | ImHorzInlineGraphics{ width; _ } -> wacc +% width
+      | ImHorzEmbeddedVert{ width; _ }   -> wacc +% width
+      | ImHorzHookPageBreak(_)           -> wacc
+      | ImHorzFootnote(_)                -> wacc
     ) Length.zero
   in
 
@@ -834,7 +834,7 @@ let break_into_lines (lbinfo : line_break_info) (path : DiscretionaryID.t list) 
      -- *)
   let rec cut (acclines : line_either Alist.t) (accline : lb_pure_box Alist.t) (lhblst : lb_box list) : line_either Alist.t =
     match lhblst with
-    | LBDiscretionary{ id = dscrid; no_break = lphbs0; pre = lphbs1; post = lphbs2 } :: tail ->
+    | LBDiscretionary{ id = dscrid; no_break = lphbs0; pre = lphbs1; post = lphbs2; _ } :: tail ->
         if List.mem dscrid path then
           let accline_sub = Alist.append accline lphbs1 in
           let accline_fresh = Alist.of_list lphbs2 in
@@ -843,7 +843,7 @@ let break_into_lines (lbinfo : line_break_info) (path : DiscretionaryID.t list) 
           let accline = Alist.append accline lphbs0 in
           cut acclines accline tail
 
-    | LBDiscretionaryList{ no_break = lphbs0; candidates } :: tail ->
+    | LBDiscretionaryList{ no_break = lphbs0; candidates; _ } :: tail ->
         begin
           match candidates |> List.find_opt (fun (dscrid, _, _) -> List.mem dscrid path) with
           | None ->
@@ -1130,7 +1130,7 @@ let main ((breakability_top, paragraph_margin_top) : breakability * length) ((br
         in
         aux NormalState iterdepth wmap tail
 
-    | LBEmbeddedVertBreakable{ id = dscrid } :: tail ->
+    | LBEmbeddedVertBreakable{ id = dscrid; _ } :: tail ->
         begin
           match state with
           | ImmediateAfterEmbeddedVert(dscrid_last) ->
@@ -1148,7 +1148,7 @@ let main ((breakability_top, paragraph_margin_top) : breakability * length) ((br
         let wmap = wmap |> WidthMap.add_width_all widinfo in
         aux NormalState iterdepth wmap tail
 
-    | LBFrameBreakable{ paddings = _pads; contents = lhbs_sub } :: tail ->
+    | LBFrameBreakable{ paddings = _pads; contents = lhbs_sub; _ } :: tail ->
         let wmap_sub = aux NormalState (iterdepth + 1) wmap lhbs_sub in
         aux NormalState iterdepth wmap_sub tail
 
@@ -1219,10 +1219,10 @@ let get_leftmost_script (hblst : horz_box list) : CharBasis.script option =
     | [] ->
         None
 
-    | HorzScriptGuard{ left = scriptL } :: _ ->
+    | HorzScriptGuard{ left = scriptL; _ } :: _ ->
         Some(scriptL)
 
-    | HorzDiscretionary{ no_break = hbs0 } :: tail ->
+    | HorzDiscretionary{ no_break = hbs0; _ } :: tail ->
         begin
           match hbs0 with
           | [] -> aux tail
@@ -1246,7 +1246,7 @@ let get_leftmost_script (hblst : horz_box list) : CharBasis.script option =
           | PHCInnerMathGlyph(_) ->
               Some(CharBasis.Latin)
 
-          | PHGRising{ contents = hbs0 } ->
+          | PHGRising{ contents = hbs0; _ } ->
               begin
                 match hbs0 with
                 | [] -> aux tail
@@ -1273,10 +1273,10 @@ let get_rightmost_script (hblst : horz_box list) : CharBasis.script option =
     | [] ->
         None
 
-    | HorzScriptGuard{ right = scriptR } :: _ ->
+    | HorzScriptGuard{ right = scriptR; _ } :: _ ->
         Some(scriptR)
 
-    | HorzDiscretionary{ no_break = hbs0 } :: revtail ->
+    | HorzDiscretionary{ no_break = hbs0; _ } :: revtail ->
         begin
           match hbs0 with
           | [] -> aux revtail
@@ -1300,7 +1300,7 @@ let get_rightmost_script (hblst : horz_box list) : CharBasis.script option =
           | PHCInnerMathGlyph(_) ->
               Some(CharBasis.Latin)
 
-          | PHGRising{ contents = hbs0 } ->
+          | PHGRising{ contents = hbs0; _ } ->
               begin
                 match hbs0 with
                 | [] -> aux revtail

--- a/src/backend/loadHyph.ml
+++ b/src/backend/loadHyph.ml
@@ -198,7 +198,7 @@ let lookup_patterns (lmin : int) (rmin : int) (patlst : pattern list) (uchseglst
   let len = List.length uchseglst in
   let clst = uchseglst |> List.map (fun uchseg -> (uchseg, ref 0)) in
   let () =
-    patlst |> List.iter (fun (beginning, pairlst, final) ->
+    patlst |> List.iter (fun (beginning, pairlst, _final) ->
       match beginning with
       | TopOfWord               -> match_prefix None pairlst clst
       | ArbitraryBeginning(num) -> match_every num pairlst clst

--- a/src/backend/loadHyph.ml
+++ b/src/backend/loadHyph.ml
@@ -168,7 +168,7 @@ let match_prefix (opt : (number ref * number) option) (pairlst : (Uchar.t * numb
     aux accinit pairlst clst
 
 
-let rec match_every (numbeginning : number) pairlst clst =
+let match_every (numbeginning : number) pairlst clst =
   let rec aux (refoptprev : (number ref) option) pairlst clst =
   match clst with
   | [] ->

--- a/src/backend/loadJpeg.ml
+++ b/src/backend/loadJpeg.ml
@@ -1,6 +1,4 @@
 
-open MyUtil
-
 
 type file_path = string
 

--- a/src/backend/loadPdf.ml
+++ b/src/backend/loadPdf.ml
@@ -12,7 +12,7 @@ module IRSet = MutableSet.Make
   end)
 
 
-let rec collect_direct_objects (pdfmain : Pdf.t) (pdfext : Pdf.t) (pdfobj : Pdf.pdfobject) : Pdf.pdfobject =
+let collect_direct_objects (pdfmain : Pdf.t) (pdfext : Pdf.t) (pdfobj : Pdf.pdfobject) : Pdf.pdfobject =
 
   let irset = IRSet.create 32 in
 

--- a/src/backend/namedDest.ml
+++ b/src/backend/namedDest.ml
@@ -1,5 +1,4 @@
 
-open LengthInterface
 open Length
 
 

--- a/src/backend/outline.ml
+++ b/src/backend/outline.ml
@@ -1,8 +1,4 @@
 
-open MyUtil
-open LengthInterface
-open Length
-
 
 let registered_outline : (int * string * string * bool) list ref = ref []
 

--- a/src/backend/pageBreak.ml
+++ b/src/backend/pageBreak.ml
@@ -684,7 +684,7 @@ let solidify (vblst : vert_box list) : intermediate_vert_box list =
       | PBVertSkip(debug_margins, len)     -> ImVertFixedEmpty(debug_margins, len)
       | PBClearPage                        -> ImVertFixedEmpty(Fixed, Length.zero)
 
-      | PBVertFrame(_, pads, decoS, decoH, decoM, decoT, wid, pbvblstsub) ->
+      | PBVertFrame(_, pads, decoS, _decoH, _decoM, _decoT, wid, pbvblstsub) ->
           let imvblstsub = aux pbvblstsub in
           ImVertFrame(pads, decoS, wid, imvblstsub)
 

--- a/src/backend/pageInfo.ml
+++ b/src/backend/pageInfo.ml
@@ -38,7 +38,7 @@ let rec embed_page_info (pbinfo : page_break_info) (imhblst : intermediate_horz_
           row_heights;
           rule_graphics;
         } ->
-          let (evrowlst, footnotelst) = embed_page_info_to_tabular pbinfo imtabular in
+          let (evrowlst, _footnotelst) = embed_page_info_to_tabular pbinfo imtabular in
           ext (width, EvHorzInlineTabular{
             height;
             depth;

--- a/src/backend/setDefaultFont.ml
+++ b/src/backend/setDefaultFont.ml
@@ -13,7 +13,7 @@ type font_abbrev = string
 type script      = string
 
 
-let read_single_assoc key_script script assoc =
+let read_single_assoc assoc =
     let abbrev = assoc |> MYU.find "font-name" |> YS.Util.to_string in
     let ratio = assoc |> MYU.find "ratio" |> YS.Util.to_float in
     let rising = assoc |> MYU.find "rising" |> YS.Util.to_float in
@@ -23,7 +23,7 @@ let read_single_assoc key_script script assoc =
 let read_assoc (assoc : MYU.assoc) =
   List.fold_left (fun mapacc (key_script, script) ->
     let singleassoc = assoc |> MYU.find key_script |> MYU.make_assoc in
-    let triple = read_single_assoc key_script script singleassoc in
+    let triple = read_single_assoc singleassoc in
     mapacc |> ScriptSchemeMap.add script triple
   ) ScriptSchemeMap.empty [
     ("han-ideographic", HanIdeographic);

--- a/src/backend/setDefaultFont.ml
+++ b/src/backend/setDefaultFont.ml
@@ -6,11 +6,7 @@ module YS = Yojson.SafePos
 module MYU = MyYojsonUtil
 
 
-type dir_path    = string
-type file_path   = string
-type key         = string
 type font_abbrev = string
-type script      = string
 
 
 let read_single_assoc assoc =

--- a/src/backend/tabular.ml
+++ b/src/backend/tabular.ml
@@ -31,7 +31,7 @@ let determine_row_metrics (restprev : rest_row) (row : row) : rest_row * length 
           | EmptyCell ->
               aux (Alist.extend restacc None) hgtmax dptmin rtail ctail
 
-          | MultiCell(numrow, numcol, pads, hblst) ->
+          | MultiCell(numrow, _numcol, pads, hblst) ->
               let (_, hgt, dpt) = LineBreak.get_natural_metrics hblst in
               let len = (hgt +% pads.paddingT) +% ((Length.negate dpt) +% pads.paddingB) in
                 (* needs reconsideration *)
@@ -46,7 +46,7 @@ let determine_row_metrics (restprev : rest_row) (row : row) : rest_row * length 
               aux (Alist.extend restacc restelem) hgtmax dptmin rtail ctail
         end
 
-    | ((Some((numrow, len)) as rsome) :: rtail, cell :: ctail) ->
+    | ((Some((numrow, _len)) as rsome) :: rtail, cell :: ctail) ->
         begin
           match cell with
           | NormalCell(_)
@@ -101,7 +101,7 @@ let determine_column_width (restprev : rest_column) (col : column) : rest_column
           | EmptyCell ->
               aux (Alist.extend restacc None) widmax rtail ctail
 
-          | MultiCell(numrow, numcol, pads, hblst) ->
+          | MultiCell(_numrow, numcol, pads, hblst) ->
               let (widraw, _, _) = LineBreak.get_natural_metrics hblst in
               let wid = pads.paddingL +% widraw +% pads.paddingR in
               let widmaxnew =
@@ -267,7 +267,7 @@ let solidify_tabular (vmetrlst : (length * length) list) (widlst : length list) 
                   [ HorzPure(PHSFixedEmpty{ width = pads.paddingR }) ];
                 ]
               in
-              let (imhbs, ratios, hgt, dpt) = LineBreak.fit hblstwithpads wid in
+              let (imhbs, ratios, _hgt, _dpt) = LineBreak.fit hblstwithpads wid in
                 ImNormalCell(ratios, (wid, hgtnmlcell, dptnmlcell), imhbs)
                 (* temporary; should return information about vertical psitioning *)
 

--- a/src/chardecoder/charBasis.ml
+++ b/src/chardecoder/charBasis.ml
@@ -21,14 +21,14 @@ type script =
 module ScriptSchemeMap = Map.Make
   (struct
     type t = script
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end)
 
 
 module ScriptSpaceMap = Map.Make
   (struct
     type t = script * script
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end)
 
 

--- a/src/chardecoder/convertText.ml
+++ b/src/chardecoder/convertText.ml
@@ -5,9 +5,6 @@ open CharBasis
 open LineBreakBox
 
 
-type chunk_info = context_main * script * line_break_class
-
-
 let to_chunks (ctx : context_main) (uchs : Uchar.t list) (alw_last : break_opportunity) : break_opportunity * line_break_chunk list =
   let (alw_first, tris) = LineBreakDataMap.append_break_opportunity uchs alw_last in
   let scrs = ScriptDataMap.divide_by_script ctx tris in

--- a/src/chardecoder/convertText.ml
+++ b/src/chardecoder/convertText.ml
@@ -371,7 +371,7 @@ let chunks_to_boxes_pure (script_before : script) (chunklst : line_break_chunk l
           | AccNone ->
               Alist.to_list lphbacc
 
-          | AccSome(infoprev, alw) ->
+          | AccSome(infoprev, _alw) ->
               let (ctx, _, _) = infoprev in
               let info_after = (ctx, script_after, XX) in
               let autospace = space_between_chunks_pure infoprev info_after in
@@ -404,7 +404,7 @@ let chunks_to_boxes_pure (script_before : script) (chunklst : line_break_chunk l
                 | AccNone ->
                     (opt, lphblstmain)
 
-                | AccSome((infoprev, alw)) ->
+                | AccSome((infoprev, _alw)) ->
                     let autospace = space_between_chunks_pure infoprev (ctx, script, lbcfirst) in
                     (opt, List.append autospace lphblstmain)
               end
@@ -425,7 +425,7 @@ let chunks_to_boxes_pure (script_before : script) (chunklst : line_break_chunk l
                 | AccNone ->
                     (opt, lphblstmain)
 
-                | AccSome((infoprev, alw)) ->
+                | AccSome((infoprev, _alw)) ->
                     let autospace = space_between_chunks_pure infoprev (ctx, script, lbc) in
                     (opt, List.append autospace lphblstmain)
               end

--- a/src/chardecoder/convertText.ml
+++ b/src/chardecoder/convertText.ml
@@ -1,5 +1,4 @@
 
-open MyUtil
 open LengthInterface
 open HorzBox
 open CharBasis

--- a/src/chardecoder/scriptDataMap.ml
+++ b/src/chardecoder/scriptDataMap.ml
@@ -94,7 +94,7 @@ let divide_by_script (ctx : context_main) (trilst : line_break_element list) : L
               Alist.to_list (Alist.extend resacc chunk)
         end
 
-    | (uch, SP, alw) :: tritail ->
+    | (_uch, SP, alw) :: tritail ->
         let chunkspace =
           match alw with
           | AllowBreak   -> Space

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name main)
  (public_name satysfi)
- (flags (-w -3 -bin-annot -thread -safe-string))
+ (flags (:standard -bin-annot -thread -safe-string))
  (libraries str
             batteries
             camlimages

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name main)
  (public_name satysfi)
- (flags (:standard -bin-annot -thread -safe-string))
+ (flags (:standard -w -32 -bin-annot -thread -safe-string))
  (libraries str
             batteries
             camlimages

--- a/src/frontend/bytecomp/bytecomp.ml
+++ b/src/frontend/bytecomp/bytecomp.ml
@@ -16,9 +16,9 @@ let compile_and_exec_0 (env : environment) (ast : abstract_tree) : syntactic_val
 
 let compile_environment (env : environment) : unit =
   let (binds, _) = env in
-  binds |> EvalVarIDMap.iter (fun evid loc ->
+  binds |> EvalVarIDMap.iter (fun _evid loc ->
     match !loc with
-    | PrimitiveClosure(parbr, env1, arity, astf) ->
+    | PrimitiveClosure(parbr, _env1, arity, astf) ->
         begin
           match compile_and_exec_0 env (Function(LabelMap.empty, parbr)) with
           | (CompiledClosure(varloc_labmap, _, _, framesize, body, env1), _) ->

--- a/src/frontend/bytecomp/bytecomp.ml
+++ b/src/frontend/bytecomp/bytecomp.ml
@@ -1,6 +1,4 @@
 
-open MyUtil
-open LengthInterface
 open SyntaxBase
 open Types
 open EvalUtil

--- a/src/frontend/bytecomp/compiler.ml
+++ b/src/frontend/bytecomp/compiler.ml
@@ -1,8 +1,5 @@
 
-open MyUtil
-open LengthInterface
 open Types
-open EvalUtil
 
 
 let report_bug_compiler msg =

--- a/src/frontend/bytecomp/compiler.ml
+++ b/src/frontend/bytecomp/compiler.ml
@@ -67,7 +67,7 @@ and compile_input_horz_content (ihlst : ir_input_horz_element list) =
   compiled_ihlist
 
 
-and compile_code_input_horz (irihlst : (ir input_horz_element_scheme) list) =
+and compile_code_input_horz (_irihlst : (ir input_horz_element_scheme) list) =
   failwith "TODO: compile_code_input_horz"
 (*
   irihlst |> List.map (function
@@ -106,7 +106,7 @@ and compile_input_vert_content (ivlst : ir_input_vert_element list) =
   compiled_ivlist
 
 
-and compile_code_input_vert (irivlst : (ir input_vert_element_scheme) list) =
+and compile_code_input_vert (_irivlst : (ir input_vert_element_scheme) list) =
   failwith "TODO: compile_code_input_vert"
 (*
   irivlst |> List.map (function
@@ -156,7 +156,7 @@ and compile (ir : ir) (cont : instruction list) =
       OpClosureInputVert(compile_input_vert_content ivlst) :: cont
     (* -- lazy evaluation; evaluates embedded variables only -- *)
 
-  | IRInputMath(ims) ->
+  | IRInputMath(_ims) ->
       failwith "TODO: IRInputMath"
 
   (* -- fundamentals -- *)
@@ -187,11 +187,11 @@ and compile (ir : ir) (cont : instruction list) =
       else
         OpClosure(varloc_labmap, List.length irpatlst, framesize, optcode) :: cont
 
-  | IRApply(arity, ircallee, irargs) ->
+  | IRApply(_arity, ircallee, irargs) ->
       let n = List.length irargs in
       compile ircallee @@ (compile_list irargs @@ OpForward(n) :: emit_appop n cont false)
 
-  | IRApplyPrimitive(op, arity, irargs) ->
+  | IRApplyPrimitive(op, _arity, irargs) ->
       compile_list irargs (op :: cont)
 
   | IRApplyOptional(ircallee, iroptarg) ->
@@ -261,7 +261,7 @@ and compile (ir : ir) (cont : instruction list) =
   | IRCodeInputVert(ivlst) ->
       OpCodeMakeInputVert(compile_code_input_vert ivlst) :: cont
 
-  | IRCodeInputMath(ims) ->
+  | IRCodeInputMath(_ims) ->
       failwith "TODO: IRCodeInputMath"
 
   | IRCodePatternMatch(rng, ir, irpatbrs) ->

--- a/src/frontend/bytecomp/ir.cppo.ml
+++ b/src/frontend/bytecomp/ir.cppo.ml
@@ -1,6 +1,5 @@
 
 open MyUtil
-open LengthInterface
 open SyntaxBase
 open Types
 

--- a/src/frontend/bytecomp/ir.cppo.ml
+++ b/src/frontend/bytecomp/ir.cppo.ml
@@ -35,7 +35,7 @@ let map_with_env (type a) (type b) (f : frame -> a -> b * frame) (env : frame) (
   iter env lst Alist.empty
 
 
-let rec transform_0_input_horz_content (env : frame) (ihlst : input_horz_element list) : ir_input_horz_element list * frame =
+let rec transform_0_input_horz_content (_env : frame) (_ihlst : input_horz_element list) : ir_input_horz_element list * frame =
   failwith "TODO: transform_0_input_horz_content"
 (*
   ihlst @|> env @|> map_with_env (fun env elem ->
@@ -60,7 +60,7 @@ let rec transform_0_input_horz_content (env : frame) (ihlst : input_horz_element
   )
 *)
 
-and transform_1_input_horz_content (env : frame) (ihlst : input_horz_element list) : (ir input_horz_element_scheme) list * frame =
+and transform_1_input_horz_content (_env : frame) (_ihlst : input_horz_element list) : (ir input_horz_element_scheme) list * frame =
   failwith "TODO: transform_1_input_horz_content"
 (*
   ihlst @|> env @|> map_with_env (fun env elem ->
@@ -86,7 +86,7 @@ and transform_1_input_horz_content (env : frame) (ihlst : input_horz_element lis
 *)
 
 
-and transform_0_input_vert_content (env : frame) (ivlst : input_vert_element list) : ir_input_vert_element list * frame =
+and transform_0_input_vert_content (_env : frame) (_ivlst : input_vert_element list) : ir_input_vert_element list * frame =
   failwith "TODO: transform_0_input_vert_content"
 (*
   ivlst @|> env @|> map_with_env (fun env elem ->
@@ -102,7 +102,7 @@ and transform_0_input_vert_content (env : frame) (ivlst : input_vert_element lis
 *)
 
 
-and transform_1_input_vert_content (env : frame) (ivlst : input_vert_element list) : (ir input_vert_element_scheme) list * frame =
+and transform_1_input_vert_content (_env : frame) (_ivlst : input_vert_element list) : (ir input_vert_element_scheme) list * frame =
   failwith "TODO: transform_1_input_vert_content"
 (*
   ivlst @|> env @|> map_with_env (fun env elem ->
@@ -118,11 +118,11 @@ and transform_1_input_vert_content (env : frame) (ivlst : input_vert_element lis
 *)
 
 
-and transform_0_input_math_content (env : frame) (ims : input_math_element list) : ir_input_math_element list * frame =
+and transform_0_input_math_content (_env : frame) (_ims : input_math_element list) : ir_input_math_element list * frame =
   failwith "TODO: transform_0_input_math_content"
 
 
-and transform_1_input_math_content (env : frame) (ims : input_math_element list) : (ir input_math_element_scheme) list * frame =
+and transform_1_input_math_content (_env : frame) (_ims : input_math_element list) : (ir input_math_element_scheme) list * frame =
   failwith "TODO: transform_1_input_math_content"
 
 
@@ -494,7 +494,7 @@ and transform_1 (env : frame) (ast : abstract_tree) : ir * frame =
       let (ir2, env) = transform_1 env ast2 in
       (IRCodeLetNonRecIn(irpat, ir1, ir2), env)
 
-  | ContentOf(rng, evid) ->
+  | ContentOf(_rng, evid) ->
       begin
         match find_in_environment env evid with
         | Some(var) -> (IRSymbolOf(var), env)
@@ -518,7 +518,7 @@ and transform_1 (env : frame) (ast : abstract_tree) : ir * frame =
   | Function(_, PatternBranchWhen(_, _, _)) ->
       assert false
 
-  | Apply(ast_labmap, ast1, ast2) ->
+  | Apply(_ast_labmap, _ast1, _ast2) ->
       failwith "TODO (enhance): Ir, Apply"
 (*
       code2 env (fun cv1 cv2 -> CdApply(cv1, cv2)) ast1 ast2
@@ -568,7 +568,7 @@ and transform_1 (env : frame) (ast : abstract_tree) : ir * frame =
   | Lift(_) ->
       report_bug_ir "transform_1: Lift at stage 1"
 
-  | ASTCodeSymbol(symb) ->
+  | ASTCodeSymbol(_symb) ->
       report_bug_ir "transform_1: ASTCodeSymbol at stage 1"
 
 #include "__ir_1.gen.ml"

--- a/src/frontend/bytecomp/vm.cppo.ml
+++ b/src/frontend/bytecomp/vm.cppo.ml
@@ -1,10 +1,8 @@
 
-open MyUtil
 open LengthInterface
 open GraphicBase
 open SyntaxBase
 open Types
-open TypeConv
 open EvalUtil
 
 

--- a/src/frontend/bytecomp/vm.cppo.ml
+++ b/src/frontend/bytecomp/vm.cppo.ml
@@ -137,7 +137,7 @@ and exec_input_vert_content env ivlst =
     CompiledInputVertClosure(imivlst, env)
 
 
-and exec_code_input_horz env irihlst =
+and exec_code_input_horz _env _irihlst =
   failwith "TODO: exec_code_input_horz"
 (*
   irihlst |> List.map (function
@@ -165,7 +165,7 @@ and exec_code_input_horz env irihlst =
 *)
 
 
-and exec_code_input_vert env irivlst =
+and exec_code_input_vert _env _irivlst =
   failwith "TODO: exec_code_input_vert"
 (*
   irivlst |> List.map (function
@@ -200,7 +200,7 @@ and exec_text_mode_intermediate_input_vert (env : vmenv) (valuetctx : syntactic_
 
 
 and exec_text_mode_intermediate_input_horz (env : vmenv) (valuetctx : syntactic_value) (imihlst : compiled_intermediate_input_horz_element list) : syntactic_value =
-  let (tctx, ctxsub) = get_text_mode_context valuetctx in
+  let (tctx, _ctxsub) = get_text_mode_context valuetctx in
     begin
       let rec normalize imihlst =
         imihlst |> List.fold_left (fun acc imih ->
@@ -216,13 +216,13 @@ and exec_text_mode_intermediate_input_horz (env : vmenv) (valuetctx : syntactic_
                   | _                                           -> (Alist.extend acc (CompiledNomInputHorzText(s2)))
                 end
 
-            | CompiledImInputHorzEmbeddedMath(mathcode) ->
+            | CompiledImInputHorzEmbeddedMath(_mathcode) ->
                 failwith "TODO: (VM) math; remains to be supported."
 (*
                 let nmih = CompiledNomInputHorzThunk(List.append mathcode [OpPush(valuetctx); OpForward(1); OpPush(valuemcmd); OpApplyT(2)]) in
                   Alist.extend acc nmih
 *)
-            | CompiledImInputHorzEmbeddedCodeText(s) ->
+            | CompiledImInputHorzEmbeddedCodeText(_s) ->
                 failwith "TODO: (VM) code text; remains to be supported."
 
             | CompiledImInputHorzContent(imihlst, envsub) ->
@@ -261,7 +261,7 @@ and exec_text_mode_intermediate_input_horz (env : vmenv) (valuetctx : syntactic_
     end
 
 
-and exec_pdf_mode_intermediate_input_math (env : vmenv) (ictx : input_context) (imivlst : compiled_intermediate_input_math_element list) : syntactic_value =
+and exec_pdf_mode_intermediate_input_math (_env : vmenv) (_ictx : input_context) (_imivlst : compiled_intermediate_input_math_element list) : syntactic_value =
   failwith "TODO: exec_pdf_mode_intermediate_input_math"
 
 
@@ -365,7 +365,7 @@ and exec_pdf_mode_intermediate_input_horz (env : vmenv) (ictx : input_context) (
     end
 
 
-and exec_application (env : vmenv) ~msg (vf : syntactic_value) (vargs : syntactic_value list) : syntactic_value =
+and exec_application (env : vmenv) ~msg:_ (vf : syntactic_value) (vargs : syntactic_value list) : syntactic_value =
   let len = List.length vargs in
     if len = 0 then
       vf
@@ -564,7 +564,7 @@ and exec_op (op : instruction) (stack : stack) (env : vmenv) (code : instruction
 
       end
 
-  | OpApply(n) ->
+  | OpApply(_n) ->
       failwith "TODO (enhance): Vm, OpApply"
 (*
       begin
@@ -619,7 +619,7 @@ and exec_op (op : instruction) (stack : stack) (env : vmenv) (code : instruction
       end
 *)
 
-  | OpApplyT(n) ->
+  | OpApplyT(_n) ->
       failwith "TODO (enhance): Vm, OpApplyT"
 (*
       begin
@@ -718,7 +718,7 @@ and exec_op (op : instruction) (stack : stack) (env : vmenv) (code : instruction
       end
 *)
 
-  | OpBindGlobal(loc, evid, refs) ->
+  | OpBindGlobal(loc, _evid, _refs) ->
       begin
         match stack with
         | (v, _) :: stack ->
@@ -730,7 +730,7 @@ and exec_op (op : instruction) (stack : stack) (env : vmenv) (code : instruction
         | _ -> report_bug_vm "invalid argument for OpBindGlobal"
       end
 
-  | OpBindLocal(lv, offset, evid, refs) ->
+  | OpBindLocal(lv, offset, evid, _refs) ->
       begin
             begin
               match stack with
@@ -750,8 +750,8 @@ and exec_op (op : instruction) (stack : stack) (env : vmenv) (code : instruction
               binds |> List.iter (fun (var, code) ->
                 let recfunc = exec_value [] env code [] in
                   match var with
-                  | GlobalVar(loc, evid, refs) -> loc := recfunc
-                  | LocalVar(lv, offset, evid, refs) -> local_set_value env lv offset recfunc
+                  | GlobalVar(loc, _evid, _refs) -> loc := recfunc
+                  | LocalVar(lv, offset, _evid, _refs) -> local_set_value env lv offset recfunc
               );
               exec stack env code dump
             end
@@ -792,7 +792,7 @@ and exec_op (op : instruction) (stack : stack) (env : vmenv) (code : instruction
         | _ -> report_bug_vm "invalid argument for OpBranchIfNot"
       end
 
-  | OpLoadGlobal(loc, evid, refs) ->
+  | OpLoadGlobal(loc, _evid, _refs) ->
       begin
             begin
               let v = !loc in
@@ -801,7 +801,7 @@ and exec_op (op : instruction) (stack : stack) (env : vmenv) (code : instruction
 
       end
 
-  | OpLoadLocal(lv, offset, evid, refs) ->
+  | OpLoadLocal(lv, offset, _evid, _refs) ->
       begin
             begin
               let v = local_get_value env lv offset in
@@ -979,7 +979,7 @@ and exec_op (op : instruction) (stack : stack) (env : vmenv) (code : instruction
       let imivclos = exec_input_vert_content env imivlst in
       exec (make_entry imivclos :: stack) env code dump
 
-  | OpBindLocationGlobal(loc, evid) ->
+  | OpBindLocationGlobal(loc, _evid) ->
       begin
         match stack with
         | (valueini, _) :: stack ->
@@ -992,7 +992,7 @@ and exec_op (op : instruction) (stack : stack) (env : vmenv) (code : instruction
         | _ -> report_bug_vm "invalid argument for OpBindLocationGlobal"
       end
 
-  | OpBindLocationLocal(lv, offset, evid) ->
+  | OpBindLocationLocal(lv, offset, _evid) ->
       begin
         match stack with
         | (valueini, _) :: stack ->
@@ -1005,7 +1005,7 @@ and exec_op (op : instruction) (stack : stack) (env : vmenv) (code : instruction
         | _ -> report_bug_vm "invalid argument for OpBindLocationLocal"
       end
 
-  | OpUpdateGlobal(loc, evid) ->
+  | OpUpdateGlobal(loc, _evid) ->
       begin
         match stack with
         | (valuenew, _) :: stack ->
@@ -1024,7 +1024,7 @@ and exec_op (op : instruction) (stack : stack) (env : vmenv) (code : instruction
         | _ -> report_bug_vm "invalid argument for OpUpdateGlobal"
       end
 
-  | OpUpdateLocal(lv, offset, evid) ->
+  | OpUpdateLocal(lv, offset, _evid) ->
       begin
         match stack with
         | (valuenew, _) :: stack ->

--- a/src/frontend/display.ml
+++ b/src/frontend/display.ml
@@ -369,7 +369,7 @@ and rvf_mono (dispmap : DisplayMap.t) (rv : mono_row_variable) : string =
       dispmap |> DisplayMap.find_bound_row_id (MustBeBoundRowID.to_bound_id mbbrid)
 
 
-let rec tvf_poly (dispmap : DisplayMap.t) (plev : paren_level) (ptv : poly_type_variable) : string =
+let tvf_poly (dispmap : DisplayMap.t) (plev : paren_level) (ptv : poly_type_variable) : string =
   match ptv with
   | PolyFree(tvuref) -> tvf_mono_updatable dispmap plev !tvuref
   | PolyBound(bid)   -> dispmap |> DisplayMap.find_bound_id bid

--- a/src/frontend/display.ml
+++ b/src/frontend/display.ml
@@ -1,7 +1,6 @@
 
 open SyntaxBase
 open Types
-open StaticEnv
 
 
 let collect_ids_scheme (fid_ht : unit FreeIDHashTable.t) (frid_ht : LabelSet.t FreeRowIDHashTable.t) (bid_ht : unit BoundIDHashTable.t) (brid_ht : LabelSet.t BoundRowIDHashTable.t) =

--- a/src/frontend/display.ml
+++ b/src/frontend/display.ml
@@ -47,10 +47,10 @@ let collect_ids_scheme (fid_ht : unit FreeIDHashTable.t) (frid_ht : LabelSet.t F
           match tv with
           | Updatable({contents = MonoLink(ty)})  -> aux_mono ty
           | Updatable({contents = MonoFree(fid)}) -> aux_free_id fid
-          | MustBeBound(mbbid)                    -> ()
+          | MustBeBound(_mbbid)                   -> ()
         end
 
-    | DataType(tys, tyid) ->
+    | DataType(tys, _tyid) ->
         tys |> List.iter aux_mono
 
     | RecordType(row) ->
@@ -90,7 +90,7 @@ let collect_ids_scheme (fid_ht : unit FreeIDHashTable.t) (frid_ht : LabelSet.t F
     | RecordType(prow) ->
         aux_poly_row prow
 
-    | DataType(ptys, tyid) ->
+    | DataType(ptys, _tyid) ->
         ptys |> List.iter aux_poly
 
     | HorzCommandType(pcmdargtys) -> pcmdargtys |> List.iter aux_poly_cmd_arg
@@ -104,7 +104,7 @@ let collect_ids_scheme (fid_ht : unit FreeIDHashTable.t) (frid_ht : LabelSet.t F
     | RowCons(_rlabel, ty, row)                         -> aux_mono ty; aux_mono_row row
     | RowVar(UpdatableRow{contents = MonoORLink(row)})  -> aux_mono_row row
     | RowVar(UpdatableRow{contents = MonoORFree(frid)}) -> aux_free_row_id frid
-    | RowVar(MustBeBoundRow(mbbrid))                    -> ()
+    | RowVar(MustBeBoundRow(_mbbrid))                   -> ()
     | RowEmpty                                          -> ()
 
   and aux_poly_row : poly_row -> unit = function

--- a/src/frontend/display.mli
+++ b/src/frontend/display.mli
@@ -1,5 +1,4 @@
 open Types
-open StaticEnv
 
 val show_mono_type : mono_type -> string
 

--- a/src/frontend/evalUtil.ml
+++ b/src/frontend/evalUtil.ml
@@ -418,7 +418,7 @@ let get_math_boxes (value : syntactic_value) : math_box list =
 let get_bool value : bool =
   match value with
   | BaseConstant(BCBool(bc)) -> bc
-  | other                    -> report_bug_value "get_bool" value
+  | _                        -> report_bug_value "get_bool" value
 
 
 let get_int (value : syntactic_value) : int =

--- a/src/frontend/evalVarID.ml
+++ b/src/frontend/evalVarID.ml
@@ -25,7 +25,7 @@ let equal evid1 evid2 =
 
 
 let compare evid1 evid2 =
-  Pervasives.compare evid1.number evid2.number
+  Stdlib.compare evid1.number evid2.number
 
 
 let show_direct evid =

--- a/src/frontend/evaluator.cppo.ml
+++ b/src/frontend/evaluator.cppo.ml
@@ -409,14 +409,14 @@ and interpret_0 (env : environment) (ast : abstract_tree) : syntactic_value =
   | Persistent(_) ->
       report_bug_ast "Persistent(_) at stage 0" ast
 
-  | Lift(ast1) ->
+  | Lift(_ast1) ->
       failwith "TODO: Lift"
 (*
       let value1 = interpret_0 env ast1 in
       CodeValue(CdPersistent(value1))
 *)
 
-  | ASTCodeSymbol(symb) ->
+  | ASTCodeSymbol(_symb) ->
       report_bug_ast "ASTCodeSymbol(_) at stage 0" ast
 
 #include "__evaluator_0.gen.ml"
@@ -1125,7 +1125,7 @@ and add_letrec_bindings_to_environment (env : environment) (recbinds : letrec_bi
       add_to_environment env evid loc
     ) env
   in
-  tris |> List.iter (fun (evid, loc, patbr) ->
+  tris |> List.iter (fun (_evid, loc, patbr) ->
     loc := Closure(LabelMap.empty, patbr, env)
   );
   env
@@ -1141,7 +1141,7 @@ and interpret_letrec_bindings_1 (env : environment) (recbinds : letrec_binding l
     ) (env, Alist.empty)
   in
   let cdrecbinds =
-    zippedacc |> Alist.to_list |> List.map (fun (symb, LetRecBinding(evid, patbr)) ->
+    zippedacc |> Alist.to_list |> List.map (fun (symb, LetRecBinding(_evid, patbr)) ->
       let cdpatbr = interpret_1_pattern_branch env patbr in
       CdLetRecBinding(symb, cdpatbr)
     )

--- a/src/frontend/evaluator.cppo.ml
+++ b/src/frontend/evaluator.cppo.ml
@@ -741,7 +741,7 @@ and read_text_mode_vert_text (value_tctx : syntactic_value) (ivvs : input_vert_v
 
   let loc_tctx = ref value_tctx in
 
-  let rec interpret_commands (ivvs : input_vert_value_element list) =
+  let interpret_commands (ivvs : input_vert_value_element list) =
     ivvs |> List.map (function
     | InputVertValueCommandClosure(vclosure) ->
         let
@@ -770,7 +770,7 @@ and read_text_mode_horz_text (value_tctx : syntactic_value) (ihvs : input_horz_v
   let loc_tctx = ref value_tctx in
 
   (* Merges adjacent `InputHorzValueText`s into single `NomInputHorzText`. *)
-  let rec normalize (ihvs : input_horz_value_element list) =
+  let normalize (ihvs : input_horz_value_element list) =
     ihvs |> List.fold_left (fun acc ihv ->
       match ihv with
       | InputHorzValueCommandClosure(hclosure) ->
@@ -808,7 +808,7 @@ and read_text_mode_horz_text (value_tctx : syntactic_value) (ihvs : input_horz_v
     ) Alist.empty |> Alist.to_list
   in
 
-  let rec interpret_commands (nmihs : nom_input_horz_element list) : string =
+  let interpret_commands (nmihs : nom_input_horz_element list) : string =
     nmihs |> List.map (fun nmih ->
       match nmih with
       | NomInputHorzCommandClosure(hclosure) ->
@@ -931,7 +931,7 @@ and read_pdf_mode_vert_text (value_ctx : syntactic_value) (ivvs : input_vert_val
 
   let loc_ctx = ref value_ctx in
 
-  let rec interpret_commands (ivvs : input_vert_value_element list) =
+  let interpret_commands (ivvs : input_vert_value_element list) =
     ivvs |> List.map (function
     | InputVertValueCommandClosure(vclosure) ->
         let
@@ -959,7 +959,7 @@ and read_pdf_mode_horz_text (ictx : input_context) (ihvs : input_horz_value_elem
   let value_mcmd = make_math_command_func ctxsub.math_command in
   let loc_ctx = ref (Context(ictx)) in
 
-  let rec normalize (imihs : input_horz_value_element list) =
+  let normalize (imihs : input_horz_value_element list) =
     imihs |> List.fold_left (fun acc imih ->
       match imih with
       | InputHorzValueCommandClosure(hclosure) ->
@@ -996,7 +996,7 @@ and read_pdf_mode_horz_text (ictx : input_context) (ihvs : input_horz_value_elem
     ) Alist.empty |> Alist.to_list
   in
 
-  let rec interpret_commands (nmihs : nom_input_horz_element list) : HorzBox.horz_box list =
+  let interpret_commands (nmihs : nom_input_horz_element list) : HorzBox.horz_box list =
     nmihs |> List.map (fun nmih ->
       match nmih with
       | NomInputHorzCommandClosure(hclosure) ->

--- a/src/frontend/exhchecker.ml
+++ b/src/frontend/exhchecker.ml
@@ -111,7 +111,7 @@ let rec string_of_instance ins =
   | IListCons(car, cdr) ->
       (string_of_instance car) ^ "::" ^ (string_of_instance cdr)
 
-  | IConstructor(nm, iins, (_, BaseType(UnitType))) -> nm
+  | IConstructor(nm, _iins, (_, BaseType(UnitType))) -> nm
 
   | IConstructor(nm, IWildCard, (_, ProductType(tys))) ->
       nm ^ "(" ^ (String.concat ", " (repeat (tys |> TupleList.to_list |> List.length) "_")) ^ ")"
@@ -147,7 +147,7 @@ let rec normalize_pat pat =
   | _                    -> pat
 
 
-let expand_mat mat i epat ty =
+let expand_mat mat i epat _ty =
   let rec inner_append a b acc =
     match (a, b) with
     | (x :: xs, y :: ys) -> inner_append xs ys (List.append x y :: acc)
@@ -191,7 +191,7 @@ let rec fold_left3 f a b c d =
 let get_specialized_mat mat patinfo ele tylst =
   let iter fst mat =
     let (nmat, ninfo, nomatch) =
-      List.fold_left (fun (cols, info, no_match) col ->
+      List.fold_left (fun (cols, _info, no_match) col ->
         let (newcol, newinfo, no_m) =
           fold_left3 (fun (col, info, no_m) p q i ->
             let needs_append =
@@ -219,8 +219,8 @@ let get_specialized_mat mat patinfo ele tylst =
                 -> false
             in
               match (needs_append, i) with
-              | (true, (n, PatternBranch(_, _)))        -> (q :: col, i :: info, false)
-              | (true, (n, PatternBranchWhen(_, _, _))) -> (q :: col, i :: info, no_m)
+              | (true, (_, PatternBranch(_, _)))        -> (q :: col, i :: info, false)
+              | (true, (_, PatternBranchWhen(_, _, _))) -> (q :: col, i :: info, no_m)
               | (false, _)                              -> (col, info, no_m)
 
           ) ([], [], true) fst col patinfo
@@ -248,7 +248,7 @@ let get_specialized_mat mat patinfo ele tylst =
     | _ ->
         begin
           match mat with
-          | x :: xs ->
+          | x :: _ ->
               let (nmat, ninfo, nomatch) = iter x mat in
                 (List.tl nmat, ninfo, List.tl tylst, NoExpand, nomatch)
 
@@ -280,7 +280,7 @@ let make_string_sig col =
   ) [EWildCard] col)
 
 
-let make_variant_sig (pre : pre) (tyenv : Typeenv.t) (tyargs : mono_type list) (tyid : TypeID.t) =
+let make_variant_sig (_pre : pre) (tyenv : Typeenv.t) (tyargs : mono_type list) (tyid : TypeID.t) =
   let ctors = tyenv |> Typeenv.enumerate_constructors tyid in
   ctors |> List.map (fun (ctornm, tyscheme) ->
     let (bids, pty_body) = tyscheme in

--- a/src/frontend/exhchecker.ml
+++ b/src/frontend/exhchecker.ml
@@ -155,7 +155,7 @@ let expand_mat mat i epat ty =
     | ([], y::ys)        -> inner_append [] ys (y :: acc)
     | ([], [])           -> List.rev acc
   in
-  let rec sub epat pat =
+  let sub epat pat =
     match (epat, pat) with
     | (ExpandListCons, PListCons(h, t))->
         [[h]; [t]]
@@ -188,8 +188,8 @@ let rec fold_left3 f a b c d =
   | _                           -> a
 
 
-let rec get_specialized_mat mat patinfo ele tylst =
-  let rec iter fst mat =
+let get_specialized_mat mat patinfo ele tylst =
+  let iter fst mat =
     let (nmat, ninfo, nomatch) =
       List.fold_left (fun (cols, info, no_match) col ->
         let (newcol, newinfo, no_m) =

--- a/src/frontend/exhchecker.ml
+++ b/src/frontend/exhchecker.ml
@@ -34,7 +34,7 @@ and expand_type =
 
 module ElementSet = Set.Make(struct
   type t = type_element
-  let compare = Pervasives.compare
+  let compare = Stdlib.compare
 end)
 
 

--- a/src/frontend/files.ml
+++ b/src/frontend/files.ml
@@ -1,4 +1,3 @@
-open Types
 
 (* string -> string *)
 let string_of_file_in file_name_in =

--- a/src/frontend/fontInfo.ml
+++ b/src/frontend/fontInfo.ml
@@ -3,7 +3,6 @@ open MyUtil
 open LengthInterface
 open HorzBox
 open CharBasis
-open Types
 
 
 exception InvalidFontAbbrev     of font_abbrev

--- a/src/frontend/fontInfo.mli
+++ b/src/frontend/fontInfo.mli
@@ -3,7 +3,6 @@ open MyUtil
 open LengthInterface
 open HorzBox
 open CharBasis
-open Types
 
 exception InvalidFontAbbrev     of font_abbrev
 exception InvalidMathFontAbbrev of math_font_abbrev

--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -60,7 +60,7 @@
     lexbuf.lex_curr_p <- { lcp with pos_bol = lcp.pos_cnum + amt; }
 
 
-  let rec increment_line_for_each_break (lexbuf : Lexing.lexbuf) (str : string) : unit =
+  let increment_line_for_each_break (lexbuf : Lexing.lexbuf) (str : string) : unit =
     let len = String.length str in
     let rec aux num has_break tail_spaces prev =
       if num >= len then

--- a/src/frontend/loadMDSetting.ml
+++ b/src/frontend/loadMDSetting.ml
@@ -53,7 +53,7 @@ let get_command pair (k : string) (assoc : MYU.assoc) =
   get_command_main pair rng s
 
 
-let make_code_name_map pair ((pos, _) as json : json) : DecodeMD.command DecodeMD.CodeNameMap.t =
+let make_code_name_map pair (json : json) : DecodeMD.command DecodeMD.CodeNameMap.t =
   let open DecodeMD in
   let pairs = json |> YS.Util.to_list in
   pairs |> List.fold_left (fun accmap json ->

--- a/src/frontend/loadMDSetting.ml
+++ b/src/frontend/loadMDSetting.ml
@@ -5,8 +5,6 @@ module MYU = MyYojsonUtil
 module YS = Yojson.SafePos
 type json = YS.json
 
-type file_path = string
-
 exception MultipleCodeNameDesignation of Range.t * string
 exception NotAnInlineCommand          of Range.t * string
 exception NotABlockCommand            of Range.t * string

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -50,7 +50,6 @@ type frozen_environment = location EvalVarIDMap.t * (syntactic_value StoreIDHash
 
 
 let freeze_environment (env : environment) : frozen_environment =
-  let open MyUtil in
   let (valenv, stenvref) = env in
   let stmap =
     StoreIDMap.empty |> StoreIDHashTable.fold (fun stid value stmap ->

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -189,7 +189,7 @@ let eval_document_file (env : environment) (ast : abstract_tree) (abspath_out : 
     aux 1
 
 
-let preprocess_and_evaluate (env : environment) (libs : (abs_path * binding list) list) (ast_doc : abstract_tree) (abspath_in : abs_path) (abspath_out : abs_path) (abspath_dump : abs_path) =
+let preprocess_and_evaluate (env : environment) (libs : (abs_path * binding list) list) (ast_doc : abstract_tree) (_abspath_in : abs_path) (abspath_out : abs_path) (abspath_dump : abs_path) =
 
   (* Performs preprecessing:
        each evaluation called in `preprocess` is run by the naive interpreter
@@ -364,14 +364,14 @@ let error_log_environment suspended =
         NormalLine("candidate paths:");
       ] (pathcands |> List.map (fun abspath -> DisplayLine(get_abs_path_string abspath))))
 
-  | NotADocumentFile(abspath_in, tyenv, ty) ->
+  | NotADocumentFile(abspath_in, _tyenv, ty) ->
       let fname = convert_abs_path_to_show abspath_in in
       report_error Typechecker [
         NormalLine(Printf.sprintf "file '%s' is not a document file; it is of type" fname);
         DisplayLine(Display.show_mono_type ty);
       ]
 
-  | NotAStringFile(abspath_in, tyenv, ty) ->
+  | NotAStringFile(abspath_in, _tyenv, ty) ->
       let fname = convert_abs_path_to_show abspath_in in
       report_error Typechecker [
         NormalLine(Printf.sprintf "file '%s' is not a file for generating text; it is of type" fname);

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -226,7 +226,8 @@ let convert_abs_path_to_show (abspath : abs_path) : string =
     Filename.basename abspathstr
 
 
-type line =
+(* -w -unused-constructor *)
+type[@ocaml.warning "-37"] line =
   | NormalLine        of string
   | DisplayLine       of string
   | NormalLineOption  of string option

--- a/src/frontend/math.ml
+++ b/src/frontend/math.ml
@@ -421,72 +421,72 @@ let make_right_paren_kern hR dR mkernsR =
 let get_left_kern lmmain hgt dpt =
   let nokernf = no_left_kern hgt dpt in
   match lmmain with
-  | LowMathAtom{ atom } ->
+  | LowMathAtom{ atom; _ } ->
       atom.atom_left_kern
 
   | LowMathList(lm) ->
       lm.low_left_kern
 
-  | LowMathGroup{ left } ->
+  | LowMathGroup{ left; _ } ->
       nokernf left
 
-  | LowMathSubscript{ base = lm }
-  | LowMathSuperscript{ base = lm }
-  | LowMathSubSuperscript{ base = lm }
-  | LowMathUpperLimit{ base = lm }
-  | LowMathLowerLimit{ base = lm } ->
+  | LowMathSubscript{ base = lm; _ }
+  | LowMathSuperscript{ base = lm; _ }
+  | LowMathSubSuperscript{ base = lm; _ }
+  | LowMathUpperLimit{ base = lm; _ }
+  | LowMathLowerLimit{ base = lm; _ } ->
       lm.low_left_kern
 
   | LowMathFraction(_)
   | LowMathRadical(_) ->
       nokernf MathInner
 
-  | LowMathParen{ left }
-  | LowMathParenWithMiddle{ left } ->
+  | LowMathParen{ left; _ }
+  | LowMathParenWithMiddle{ left; _ } ->
       make_left_paren_kern left.lp_height left.lp_depth left.lp_math_kern_scheme
 
 
 let get_right_kern lmmain hgt dpt =
   let nokernf = no_right_kern hgt dpt in
   match lmmain with
-  | LowMathAtom{ atom } ->
+  | LowMathAtom{ atom; _ } ->
       atom.atom_right_kern
 
   | LowMathList(lm) ->
       lm.low_right_kern
 
-  | LowMathGroup{ right } ->
+  | LowMathGroup{ right; _ } ->
       nokernf right
 
-  | LowMathSubscript{ base = lm }
-  | LowMathSuperscript{ base = lm }
-  | LowMathSubSuperscript{ base = lm } ->
+  | LowMathSubscript{ base = lm; _ }
+  | LowMathSuperscript{ base = lm; _ }
+  | LowMathSubSuperscript{ base = lm; _ } ->
       nokernf lm.low_right_kern.right_math_kind
 
-  | LowMathUpperLimit{ base = lm }
-  | LowMathLowerLimit{ base = lm } ->
+  | LowMathUpperLimit{ base = lm; _ }
+  | LowMathLowerLimit{ base = lm; _ } ->
       lm.low_right_kern
 
   | LowMathFraction(_)
   | LowMathRadical(_) ->
       nokernf MathInner
 
-  | LowMathParen{ right }
-  | LowMathParenWithMiddle{ right } ->
+  | LowMathParen{ right; _ }
+  | LowMathParenWithMiddle{ right; _ } ->
       make_right_paren_kern right.lp_height right.lp_depth right.lp_math_kern_scheme
 
 
 let rec get_left_math_kind : math_box -> math_kind = function
-  | MathBoxAtom{ kind } ->
+  | MathBoxAtom{ kind; _ } ->
       kind
 
-  | MathBoxGroup{ left } ->
+  | MathBoxGroup{ left; _ } ->
       left
 
-  | MathBoxSuperscript{ base }
-  | MathBoxSubscript{ base }
-  | MathBoxLowerLimit{ base }
-  | MathBoxUpperLimit{ base } ->
+  | MathBoxSuperscript{ base; _ }
+  | MathBoxSubscript{ base; _ }
+  | MathBoxLowerLimit{ base; _ }
+  | MathBoxUpperLimit{ base; _ } ->
       begin
         match base with
         | []         -> MathEnd
@@ -503,16 +503,16 @@ let rec get_left_math_kind : math_box -> math_kind = function
 
 
 let rec get_right_math_kind : math_box -> math_kind = function
-  | MathBoxAtom{ kind } ->
+  | MathBoxAtom{ kind; _ } ->
       kind
 
-  | MathBoxGroup{ right } ->
+  | MathBoxGroup{ right; _ } ->
       right
 
-  | MathBoxSuperscript{ base }
-  | MathBoxSubscript{ base }
-  | MathBoxLowerLimit{ base }
-  | MathBoxUpperLimit{ base } ->
+  | MathBoxSuperscript{ base; _ }
+  | MathBoxSubscript{ base; _ }
+  | MathBoxLowerLimit{ base; _ }
+  | MathBoxUpperLimit{ base; _ } ->
       begin
         match List.rev base with
         | []         -> MathEnd
@@ -685,13 +685,13 @@ let convert_math_char (ictx : input_context) ~(kern : (math_char_kern_func * mat
 
 let get_height_and_depth_of_low_math_atom (lma : low_math_atom) : length * length =
   match lma.atom_main with
-  | LowMathAtomGlyph{ height; depth }        -> (height, depth)
-  | LowMathAtomEmbeddedHorz{ height; depth } -> (height, depth)
+  | LowMathAtomGlyph{ height; depth; _ }        -> (height, depth)
+  | LowMathAtomEmbeddedHorz{ height; depth; _ } -> (height, depth)
 
 
 let check_subscript (mlstB : math_box list) =
   match List.rev mlstB with
-  | MathBoxSubscript{ base = mlstBB; sub = mlstT } :: mtailrev ->
+  | MathBoxSubscript{ base = mlstBB; sub = mlstT; _ } :: mtailrev ->
     (* If the last element of the base contents has a subscript *)
       let mlstBnew = List.rev_append mtailrev mlstBB in
       Some((mlstT, mlstBnew))
@@ -960,7 +960,7 @@ let horz_of_low_math_element (lme : low_math_atom_main) : horz_box list =
   | LowMathAtomGlyph{ info; width; height; depth; output } ->
       [ HorzPure(PHCInnerMathGlyph{ info; width; height; depth; output }) ]
 
-  | LowMathAtomEmbeddedHorz{ content = hbs } ->
+  | LowMathAtomEmbeddedHorz{ content = hbs; _ } ->
       hbs
 
 
@@ -989,7 +989,7 @@ let get_space_correction = function
   | LowMathList(lm) ->
       ItalicsCorrection(lm.low_right_kern.italics_correction)
 
-  | LowMathAtom{ atom } ->
+  | LowMathAtom{ atom; _ } ->
       ItalicsCorrection(atom.atom_right_kern.italics_correction)
 
   | LowMathSubscript(_)

--- a/src/frontend/math.ml
+++ b/src/frontend/math.ml
@@ -52,7 +52,8 @@ type low_paren = {
 
 type low_radical = horz_box list
 
-type low_math_main =
+(* -w -unused-constructor *)
+type[@ocaml.warning "-37"] low_math_main =
   | LowMathList of low_math
 
   | LowMathAtom of {

--- a/src/frontend/math.ml
+++ b/src/frontend/math.ml
@@ -540,7 +540,7 @@ let superscript_baseline_height ictx h_base d_sup =
 
 
 (* -- calculates the base correction height and the superscript correction height -- *)
-let superscript_correction_heights ictx h_supbl h_base d_sup =
+let superscript_correction_heights _ictx h_supbl h_base d_sup =
   let l_base = h_supbl +% d_sup in
   let l_sup = h_base -% h_supbl in
     (l_base, l_sup)
@@ -557,7 +557,7 @@ let subscript_baseline_depth ictx d_base h_sub =
     d_subbl
 
 
-let subscript_correction_heights ictx d_subbl d_base h_sub =
+let subscript_correction_heights _ictx d_subbl d_base h_sub =
   let l_base = h_sub +% d_base in
   let l_sub = d_base -% d_subbl in
     (l_base, l_sub)
@@ -703,7 +703,7 @@ let check_subscript (mlstB : math_box list) =
 let convert_math_element (mk : math_kind) (ma : math_box_atom) : low_math_atom =
   match ma with
   | MathEmbeddedHorz(hbs) ->
-      let (wid, hgt, dpt) = LineBreak.get_natural_metrics hbs in
+      let (_wid, hgt, dpt) = LineBreak.get_natural_metrics hbs in
       let lma = LowMathAtomEmbeddedHorz{ content = hbs; height = hgt; depth = dpt } in
       {
         atom_main       = lma;
@@ -867,7 +867,7 @@ and convert_to_low_single ~prev:(mk_prev : math_kind) ~next:(mk_next : math_kind
       let h_rad = h_bar +% t_bar in
       begin
         match mlstD_opt with
-        | Some(mlstD) ->
+        | Some(_mlstD) ->
             failwith "TODO: unsupported; MathRadicalWithDegree"
 
         | None ->

--- a/src/frontend/math.ml
+++ b/src/frontend/math.ml
@@ -689,7 +689,7 @@ let get_height_and_depth_of_low_math_atom (lma : low_math_atom) : length * lengt
   | LowMathAtomEmbeddedHorz{ height; depth } -> (height, depth)
 
 
-let rec check_subscript (mlstB : math_box list) =
+let check_subscript (mlstB : math_box list) =
   match List.rev mlstB with
   | MathBoxSubscript{ base = mlstBB; sub = mlstT } :: mtailrev ->
     (* If the last element of the base contents has a subscript *)

--- a/src/frontend/math.ml
+++ b/src/frontend/math.ml
@@ -1005,7 +1005,7 @@ let rec horz_of_low_math (ictx : input_context) ~prev:(mk_first : math_kind) ~ne
   let rec aux (hbacc : horz_box Alist.t) (mk_prev : math_kind) (corr : space_correction) lmmainlst =
     match lmmainlst with
     | [] ->
-        let hb_space_opt = space_between_math_kinds ictx mk_prev corr mk_last in
+        let hb_space_opt = space_between_math_kinds ictx ~prev:mk_prev corr mk_last in
         begin
           match hb_space_opt with
           | None           -> Alist.to_list hbacc
@@ -1031,7 +1031,7 @@ let rec horz_of_low_math (ictx : input_context) ~prev:(mk_first : math_kind) ~ne
               (hblstpure, hbspaceopt, mk)
 
           | LowMathGroup{ left = mkL; right = mkR; inner = lmC } ->
-              let hblstC = horz_of_low_math ictx MathEnd MathClose lmC in
+              let hblstC = horz_of_low_math ictx ~prev:MathEnd ~next:MathClose lmC in
               let hbspaceopt = space_between_math_kinds ictx ~prev:mk_prev corr mkL in
               (hblstC, hbspaceopt, mkR)
 
@@ -1044,8 +1044,8 @@ let rec horz_of_low_math (ictx : input_context) ~prev:(mk_first : math_kind) ~ne
               let rkB = lmB.low_right_kern in
               let d_sup = lmS.low_depth in
               let lkS = lmS.low_left_kern in
-              let hblstB = horz_of_low_math ictx MathEnd MathEnd lmB in
-              let hblstS = horz_of_low_math (Context.enter_script ictx) MathEnd MathEnd lmS in
+              let hblstB = horz_of_low_math ictx ~prev:MathEnd ~next:MathEnd lmB in
+              let hblstS = horz_of_low_math (Context.enter_script ictx) ~prev:MathEnd ~next:MathEnd lmS in
               let h_base = rkB.last_height in
               let (l_base, l_sup) = superscript_correction_heights ictx h_supbl h_base d_sup in
               let l_kernbase = MathKernScheme.calculate ictx rkB.kernTR l_base in
@@ -1068,8 +1068,8 @@ let rec horz_of_low_math (ictx : input_context) ~prev:(mk_first : math_kind) ~ne
               let rkB = lmB.low_right_kern in
               let h_sub = lmS.low_height in
               let lkS = lmS.low_left_kern in
-              let hblstB = horz_of_low_math ictx MathEnd MathEnd lmB in
-              let hblstS = horz_of_low_math (Context.enter_script ictx) MathEnd MathEnd lmS in
+              let hblstB = horz_of_low_math ictx ~prev:MathEnd ~next:MathEnd lmB in
+              let hblstS = horz_of_low_math (Context.enter_script ictx) ~prev:MathEnd ~next:MathEnd lmS in
               let d_base = rkB.last_depth in
               let (l_base, l_sub) = subscript_correction_heights ictx d_subbl d_base h_sub in
               let l_kernbase = MathKernScheme.calculate ictx rkB.kernBR l_base in
@@ -1101,9 +1101,9 @@ let rec horz_of_low_math (ictx : input_context) ~prev:(mk_first : math_kind) ~ne
               let d_sup = lmS.low_depth in
               let lkS = lmS.low_left_kern in
               let h_sub = lmT.low_height in
-              let hblstB = horz_of_low_math ictx MathEnd MathEnd lmB in
-              let hblstS = horz_of_low_math (Context.enter_script ictx) MathEnd MathEnd lmS in
-              let hblstT = horz_of_low_math (Context.enter_script ictx) MathEnd MathEnd lmT in
+              let hblstB = horz_of_low_math ictx ~prev:MathEnd ~next:MathEnd lmB in
+              let hblstS = horz_of_low_math (Context.enter_script ictx) ~prev:MathEnd ~next:MathEnd lmS in
+              let hblstT = horz_of_low_math (Context.enter_script ictx) ~prev:MathEnd ~next:MathEnd lmT in
               let h_base = rkB.last_height in
               let d_base = rkB.last_depth in
 
@@ -1145,8 +1145,8 @@ let rec horz_of_low_math (ictx : input_context) ~prev:(mk_first : math_kind) ~ne
               numerator                  = lmN;
               denominator                = lmD;
             } ->
-              let hblstN = horz_of_low_math ictx MathEnd MathEnd lmN in
-              let hblstD = horz_of_low_math ictx MathEnd MathEnd lmD in
+              let hblstN = horz_of_low_math ictx ~prev:MathEnd ~next:MathEnd lmN in
+              let hblstD = horz_of_low_math ictx ~prev:MathEnd ~next:MathEnd lmD in
               let (w_numer, _, _) = LineBreak.get_natural_metrics hblstN in
               let (w_denom, _, _) = LineBreak.get_natural_metrics hblstD in
               let (hblstNret, hblstDret, w_frac) =
@@ -1174,7 +1174,7 @@ let rec horz_of_low_math (ictx : input_context) ~prev:(mk_first : math_kind) ~ne
               bar_thickness = t_bar;
               inner         = lmC;
             } ->
-              let hblstC = horz_of_low_math ictx MathEnd MathEnd lmC in
+              let hblstC = horz_of_low_math ictx ~prev:MathEnd ~next:MathEnd lmC in
               let (w_cont, _, _) = LineBreak.get_natural_metrics hblstC in
               let graphics (xpos, ypos) =
                 GraphicD.make_fill (Context.color ictx)
@@ -1196,7 +1196,7 @@ let rec horz_of_low_math (ictx : input_context) ~prev:(mk_first : math_kind) ~ne
           | LowMathParen{ left = lpL; right = lpR; inner = lmE } ->
               let hblstparenL = lpL.lp_main in
               let hblstparenR = lpR.lp_main in
-              let hblstE = horz_of_low_math ictx MathOpen MathClose lmE in
+              let hblstE = horz_of_low_math ictx ~prev:MathOpen ~next:MathClose lmE in
               let hblstsub = List.concat [hblstparenL; hblstE; hblstparenR] in
               let hbspaceopt = space_between_math_kinds ictx ~prev:mk_prev corr MathOpen in
               (hblstsub, hbspaceopt, MathClose)
@@ -1225,9 +1225,9 @@ let rec horz_of_low_math (ictx : input_context) ~prev:(mk_first : math_kind) ~ne
           | LowMathUpperLimit{ upper_baseline_height = h_upbl; base = lmB; upper = lmU } ->
               let lkB = lmB.low_left_kern in
               let rkB = lmB.low_right_kern in
-              let hblstB = horz_of_low_math ictx MathEnd MathEnd lmB in
+              let hblstB = horz_of_low_math ictx ~prev:MathEnd ~next:MathEnd lmB in
                 (* needs reconsideration *)
-              let hblstU = horz_of_low_math (Context.enter_script ictx) MathEnd MathEnd lmU in
+              let hblstU = horz_of_low_math (Context.enter_script ictx) ~prev:MathEnd ~next:MathEnd lmU in
               let (w_base, _, _) = LineBreak.get_natural_metrics hblstB in
               let (w_up, _, _) = LineBreak.get_natural_metrics hblstU in
               let hblstsub =
@@ -1249,9 +1249,9 @@ let rec horz_of_low_math (ictx : input_context) ~prev:(mk_first : math_kind) ~ne
           | LowMathLowerLimit{ lower_baseline_depth = d_lowbl; base = lmB; lower = lmL } ->
               let lkB = lmB.low_left_kern in
               let rkB = lmB.low_right_kern in
-              let hblstB = horz_of_low_math ictx MathEnd MathEnd lmB in
+              let hblstB = horz_of_low_math ictx ~prev:MathEnd ~next:MathEnd lmB in
                 (* needs reconsideration *)
-              let hblstL = horz_of_low_math (Context.enter_script ictx) MathEnd MathEnd lmL in
+              let hblstL = horz_of_low_math (Context.enter_script ictx) ~prev:MathEnd ~next:MathEnd lmL in
               let (w_base, _, _) = LineBreak.get_natural_metrics hblstB in
               let (w_low, _, _) = LineBreak.get_natural_metrics hblstL in
               let hblstsub =
@@ -1283,7 +1283,7 @@ let rec horz_of_low_math (ictx : input_context) ~prev:(mk_first : math_kind) ~ne
 
 let main (ictx : input_context) (ms : math_box list) : horz_box list =
   let lms = convert_to_low ~prev:MathEnd ~next:MathEnd ms in
-  horz_of_low_math ictx MathEnd MathEnd lms
+  horz_of_low_math ictx ~prev:MathEnd ~next:MathEnd lms
 
 
 let space_between_maths (ictx : input_context) (mathlst1 : math_box list) (mathlst2 : math_box list) : horz_box option =
@@ -1291,13 +1291,13 @@ let space_between_maths (ictx : input_context) (mathlst1 : math_box list) (mathl
   | (math1R :: _, math2L :: _) ->
       let mk1R = get_right_math_kind math1R in
       let mk2L = get_left_math_kind math2L in
-      let lm1 = convert_to_low MathEnd mk2L mathlst1 in
+      let lm1 = convert_to_low ~prev:MathEnd ~next:mk2L mathlst1 in
       let corr =
         match lm1.low_main with
         | lmmain :: _ -> get_space_correction lmmain
         | []          -> NoSpace
       in
-      space_between_math_kinds ictx mk1R corr mk2L
+      space_between_math_kinds ictx ~prev:mk1R corr mk2L
 
   | _ ->
       None

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -1092,7 +1092,7 @@ inline_elem_cmd:
       }
 
   | imacro_raw=BACKSLASH_MACRO; macargsraw=macroargs {
-      let (rng_cs, csnm) = imacro_raw in
+      let (rng_cs, _csnm) = imacro_raw in
       let imacro = (rng_cs, [], imacro_raw) in
       let (rng_last, macroargs) = macargsraw in
       make_standard (Tok rng_cs) (Tok rng_last) (UTInputHorzMacro(imacro, macroargs))
@@ -1120,7 +1120,7 @@ inline_elem_text:
   | ichars=nonempty_list(inline_char)
       {
         let rng = make_range_from_list ichars in
-        let text = String.concat "" (ichars |> List.map (fun (r, t) -> t)) in
+        let text = String.concat "" (ichars |> List.map (fun (_, t) -> t)) in
         (rng, UTInputHorzText(text))
       }
 ;

--- a/src/frontend/primitives.cppo.ml
+++ b/src/frontend/primitives.cppo.ml
@@ -285,14 +285,14 @@ let ( !- ) evid = ContentOf(Range.dummy "temporary", evid)
 
 let dr = Range.dummy "dummy:lambda"
 
-let rec lambda1 astf env =
+let lambda1 astf env =
   let evid1 = EvalVarID.fresh (dr, "(dummy:lambda1-1)") in
     lamenv env evid1 1 (astf (!- evid1))
       (fun lst -> match lst with
                   | [a1] -> astf a1
                   | _ -> failwith "internal error")
 
-let rec lambda2 astf env =
+let lambda2 astf env =
   let evid1 = EvalVarID.fresh (dr, "(dummy:lambda2-1)") in
   let evid2 = EvalVarID.fresh (dr, "(dummy:lambda2-2)") in
     lamenv env evid1 2 (lam evid2 (astf (!- evid1) (!- evid2)))
@@ -300,7 +300,7 @@ let rec lambda2 astf env =
                   | [a1;a2] -> astf a1 a2
                   | _ -> failwith "internal error")
 
-let rec lambda3 astf env =
+let lambda3 astf env =
   let evid1 = EvalVarID.fresh (dr, "(dummy:lambda3-1)") in
   let evid2 = EvalVarID.fresh (dr, "(dummy:lambda3-2)") in
   let evid3 = EvalVarID.fresh (dr, "(dummy:lambda3-3)") in
@@ -309,7 +309,7 @@ let rec lambda3 astf env =
                   | [a1;a2;a3] -> astf a1 a2 a3
                   | _ -> failwith "internal error")
 
-let rec lambda4 astf env =
+let lambda4 astf env =
   let evid1 = EvalVarID.fresh (dr, "(dummy:lambda4-1)") in
   let evid2 = EvalVarID.fresh (dr, "(dummy:lambda4-2)") in
   let evid3 = EvalVarID.fresh (dr, "(dummy:lambda4-3)") in
@@ -319,7 +319,7 @@ let rec lambda4 astf env =
                   | [a1;a2;a3;a4] -> astf a1 a2 a3 a4
                   | _ -> failwith "internal error")
 
-let rec lambda5 astf env =
+let lambda5 astf env =
   let evid1 = EvalVarID.fresh (dr, "(dummy:lambda5-1)") in
   let evid2 = EvalVarID.fresh (dr, "(dummy:lambda5-2)") in
   let evid3 = EvalVarID.fresh (dr, "(dummy:lambda5-3)") in
@@ -330,7 +330,7 @@ let rec lambda5 astf env =
                   | [a1;a2;a3;a4;a5] -> astf a1 a2 a3 a4 a5
                   | _ -> failwith "internal error")
 
-let rec lambda6 astf env =
+let lambda6 astf env =
   let evid1 = EvalVarID.fresh (dr, "(dummy:lambda6-1)") in
   let evid2 = EvalVarID.fresh (dr, "(dummy:lambda6-2)") in
   let evid3 = EvalVarID.fresh (dr, "(dummy:lambda6-3)") in
@@ -342,7 +342,7 @@ let rec lambda6 astf env =
                   | [a1;a2;a3;a4;a5;a6] -> astf a1 a2 a3 a4 a5 a6
                   | _ -> failwith "internal error")
 
-let rec lambda7 astf env =
+let lambda7 astf env =
   let evid1 = EvalVarID.fresh (dr, "(dummy:lambda7-1)") in
   let evid2 = EvalVarID.fresh (dr, "(dummy:lambda7-2)") in
   let evid3 = EvalVarID.fresh (dr, "(dummy:lambda7-3)") in

--- a/src/frontend/staticEnv.ml
+++ b/src/frontend/staticEnv.ml
@@ -1,5 +1,4 @@
 
-open MyUtil
 open Types
 
 

--- a/src/frontend/storeID.ml
+++ b/src/frontend/storeID.ml
@@ -11,7 +11,7 @@ let min_id_in_document = ref 0
 let equal = (=)
 
 
-let compare = Pervasives.compare
+let compare = Stdlib.compare
 
 
 let hash = Hashtbl.hash

--- a/src/frontend/syntaxBase.ml
+++ b/src/frontend/syntaxBase.ml
@@ -1,5 +1,5 @@
 
-let pp_set fold pp_elem ppf set =
+let pp_set fold _pp_elem ppf set =
   Format.fprintf ppf "@[<hv1>{";
   fold (fun k is_first ->
     begin

--- a/src/frontend/typeConv.ml
+++ b/src/frontend/typeConv.ml
@@ -28,8 +28,8 @@ let rec erase_range_of_type (ty : mono_type) : mono_type =
           | Updatable(tvref) ->
               begin
                 match !tvref with
-                | MonoFree(fid) -> (rng, tymain)
-                | MonoLink(ty)  -> erase_range_of_type ty
+                | MonoFree(_fid) -> (rng, tymain)
+                | MonoLink(ty)   -> erase_range_of_type ty
               end
 
         | MustBeBound(_) ->

--- a/src/frontend/typechecker.ml
+++ b/src/frontend/typechecker.ml
@@ -1,5 +1,4 @@
 
-open MyUtil
 open SyntaxBase
 open Types
 open StaticEnv

--- a/src/frontend/typechecker.ml
+++ b/src/frontend/typechecker.ml
@@ -2300,7 +2300,8 @@ and substitute_concrete (subst : substitution) (modsig : signature) : signature 
         {
           opaques = quant;
           domain  = modsig1;
-          codomain = absmodsig2
+          codomain = absmodsig2;
+          _
         } = fsig
       in
       let modsig1 = modsig1 |> substitute_concrete subst in
@@ -2454,6 +2455,7 @@ and subtype_concrete_with_concrete (rng : Range.t) (modsig1 : signature) (modsig
           opaques  = quant1;
           domain   = modsigdom1;
           codomain = absmodsigcod1;
+          _
         } = fsig1
       in
       let
@@ -2461,6 +2463,7 @@ and subtype_concrete_with_concrete (rng : Range.t) (modsig1 : signature) (modsig
           opaques  = _quant2;
           domain   = modsigdom2;
           codomain = absmodsigcod2;
+          _
         } = fsig2
       in
       let subst = subtype_concrete_with_abstract rng modsigdom2 (quant1, modsigdom1) in
@@ -2934,7 +2937,7 @@ and copy_contents (modsig1 : signature) (modsig2 : signature) : signature =
 
   | (ConcFunctor(fsig1), ConcFunctor(fsig2)) ->
       let { opaques = _quant_dom1; domain = modsig_dom1; codomain = absmodsig_cod1; closure = closure } = fsig1 in
-      let { opaques = _quant_dom2; domain = modsig_dom2; codomain = absmodsig_cod2 } = fsig2 in
+      let { opaques = _quant_dom2; domain = modsig_dom2; codomain = absmodsig_cod2; _ } = fsig2 in
       let modsig_dom2_new = copy_contents modsig_dom1 modsig_dom2 in
       let absmodsig_cod2_new =
         let (_, modsig_cod1) = absmodsig_cod1 in

--- a/src/frontend/typechecker.ml
+++ b/src/frontend/typechecker.ml
@@ -359,7 +359,7 @@ let flatten_type (ty : mono_type) : mono_command_argument_type list * mono_type 
     | RowCons((_, label), ty, row)                     -> aux_row (tylabmap |> LabelMap.add label ty) row
   in
   let rec aux acc ty =
-    let (rng, tymain) = ty in
+    let (_rng, tymain) = ty in
       match tymain with
       | TypeVariable(Updatable{contents = MonoLink(tysub)}) ->
           aux acc tysub
@@ -574,7 +574,7 @@ let rec unify_sub ((rng1, tymain1) as ty1 : mono_type) ((rng2, tymain2) as ty2 :
               zipped |> List.iter (fun (cmdargty1, cmdargty2) ->
                 let CommandArgType(ty_labmap1, ty1) = cmdargty1 in
                 let CommandArgType(ty_labmap2, ty2) = cmdargty2 in
-                LabelMap.merge (fun label tyopt1 tyopt2 ->
+                LabelMap.merge (fun _label tyopt1 tyopt2 ->
                   match (tyopt1, tyopt2) with
                   | (Some(ty1), Some(ty2)) -> Some(unify ty1 ty2)
                   | (_, None) | (None, _)  -> raise InternalContradictionError
@@ -663,7 +663,7 @@ and unify_list (tys1 : mono_type list) (tys2 : mono_type list) : unit =
 
 and solve_row_disjointness (row : mono_row) (labset : LabelSet.t) : unit =
   match row with
-  | RowCons((rng, label), ty, rowsub) ->
+  | RowCons((_rng, label), _ty, rowsub) ->
       if labset |> LabelSet.mem label then
         raise InternalContradictionError
           (* TODO (error): should report error about label *)
@@ -1250,7 +1250,7 @@ let rec typecheck
       (IfThenElse(eB, e1, e2), ty1)
 
   | UTLetIn(UTMutable(ident, utastI), utastA) ->
-      let (tyenvI, evid, eI, tyI) = make_type_environment_by_let_mutable pre tyenv ident utastI in
+      let (tyenvI, evid, eI, _tyI) = make_type_environment_by_let_mutable pre tyenv ident utastI in
       let (eA, tyA) = typecheck_iter tyenvI utastA in
       (LetMutableIn(evid, eI, eA), tyA)
 
@@ -1438,7 +1438,7 @@ and typecheck_command_arguments (tycmd : mono_type) (rngcmdapp : Range.t) (pre :
 
 and typecheck_math (pre : pre) (tyenv : Typeenv.t) (utmes : untyped_input_math_element list) : input_math_element list =
 
-  let iter (b, utmes) = typecheck_math pre tyenv utmes in
+  let iter (_b, utmes) = typecheck_math pre tyenv utmes in
 
   utmes |> List.map (fun utme ->
     let (rng, UTInputMathElement{ base = utbase; sub = utsub_opt; sup = utsup_opt }) = utme in
@@ -1478,7 +1478,7 @@ and typecheck_math (pre : pre) (tyenv : Typeenv.t) (utmes : untyped_input_math_e
   )
 
 
-and typecheck_input_vert (rng : Range.t) (pre : pre) (tyenv : Typeenv.t) (utivlst : untyped_input_vert_element list) : input_vert_element list =
+and typecheck_input_vert (_rng : Range.t) (pre : pre) (tyenv : Typeenv.t) (utivlst : untyped_input_vert_element list) : input_vert_element list =
   let rec aux acc utivlst =
     match utivlst with
     | [] ->
@@ -1506,7 +1506,7 @@ and typecheck_input_vert (rng : Range.t) (pre : pre) (tyenv : Typeenv.t) (utivls
               raise_error (InvalidExpressionAsToStaging(rng_app, Stage1))
 
           | Stage1 ->
-              let (rng_all, modidents, cs) = bmacro in
+              let (_rng_all, modidents, cs) = bmacro in
               let (rng_cs, _csnm) = cs in
               let macentry = find_macro tyenv modidents cs in
               let macty = TypeConv.instantiate_macro_type pre.level pre.quantifiability macentry.macro_type in
@@ -1529,7 +1529,7 @@ and typecheck_input_vert (rng : Range.t) (pre : pre) (tyenv : Typeenv.t) (utivls
   aux Alist.empty utivlst
 
 
-and typecheck_input_horz (rng : Range.t) (pre : pre) (tyenv : Typeenv.t) (utihlst : untyped_input_horz_element list) : input_horz_element list =
+and typecheck_input_horz (_rng : Range.t) (pre : pre) (tyenv : Typeenv.t) (utihlst : untyped_input_horz_element list) : input_horz_element list =
   let rec aux acc utihlst =
     match utihlst with
     | [] ->
@@ -1575,7 +1575,7 @@ and typecheck_input_horz (rng : Range.t) (pre : pre) (tyenv : Typeenv.t) (utihls
               raise_error (InvalidExpressionAsToStaging(rng_app, Stage1))
 
           | Stage1 ->
-              let (rng_all, modidents, cs) = hmacro in
+              let (_rng_all, modidents, cs) = hmacro in
               let (rng_cs, _csnm) = cs in
               let macentry = find_macro tyenv modidents cs in
               let macty = TypeConv.instantiate_macro_type pre.level pre.quantifiability macentry.macro_type in
@@ -2006,7 +2006,7 @@ and decode_manual_base_kind (mnbkd : manual_base_kind) : base_kind =
   | _   -> raise_error (UndefinedKindName(rng, kdnm))
 
 
-and decode_manual_kind (pre : pre) (tyenv : Typeenv.t) (mnkd : manual_kind) : kind =
+and decode_manual_kind (_pre : pre) (_tyenv : Typeenv.t) (mnkd : manual_kind) : kind =
   let MKind(mnbkds_dom, mnbkd_cod) = mnkd in
   let kds_dom = mnbkds_dom |> List.map decode_manual_base_kind in
   let TypeKind = decode_manual_base_kind mnbkd_cod in
@@ -2036,7 +2036,7 @@ and decode_manual_macro_parameter_type (pre : pre) (tyenv : Typeenv.t) (mmacpara
 and make_constructor_branch_map (pre : pre) (tyenv : Typeenv.t) (utctorbrs : constructor_branch list) =
   utctorbrs |> List.fold_left (fun ctormap utctorbr ->
     match utctorbr with
-    | UTConstructorBranch((rng, ctornm), mty_opt) ->
+    | UTConstructorBranch((_rng, ctornm), mty_opt) ->
         let ty =
           match mty_opt with
           | Some(mty) -> decode_manual_type pre tyenv mty
@@ -2411,7 +2411,7 @@ and substitute_struct (subst : substitution) (ssig : StructSig.t) : StructSig.t 
       ~v:(fun _x ventry ->
         { ventry with val_type = ventry.val_type |> substitute_poly_type subst }
       )
-      ~a:(fun csnm macentry ->
+      ~a:(fun _csnm macentry ->
         { macentry with macro_type = macentry.macro_type |> substitute_macro_type subst }
       )
       ~c:(fun _ctornm centry ->
@@ -2458,7 +2458,7 @@ and subtype_concrete_with_concrete (rng : Range.t) (modsig1 : signature) (modsig
       in
       let
         {
-          opaques  = quant2;
+          opaques  = _quant2;
           domain   = modsigdom2;
           codomain = absmodsigcod2;
         } = fsig2
@@ -2681,7 +2681,7 @@ and subtype_row_with_equal_domain (internbid : type_intern) (internbrid : row_in
 
 
 and subtype_label_map_with_equal_domain (internbid : type_intern) (internbrid : row_intern) (pty_labmap1 : poly_type_body LabelMap.t) (pty_labmap2 : poly_type_body LabelMap.t) : bool =
-  LabelMap.merge (fun label pty1_opt pty2_opt ->
+  LabelMap.merge (fun _label pty1_opt pty2_opt ->
     match (pty1_opt, pty2_opt) with
     | (Some(pty1), Some(pty2)) -> Some(subtype_poly_type_impl internbid internbrid (Poly(pty1)) (Poly(pty2)))
     | _                        -> Some(false)
@@ -2693,7 +2693,7 @@ and subtype_label_map_with_equal_domain (internbid : type_intern) (internbrid : 
    by referring and updating `internbid` and `internbrid`. *)
 and subtype_label_map_inclusive (internbid : type_intern) (internbrid : row_intern) (pty_labmap1 : poly_type_body LabelMap.t) (pty_labmap2 : poly_type_body LabelMap.t) : (poly_type_body LabelMap.t) option =
   let merged =
-    LabelMap.merge (fun label pty1_opt pty2_opt ->
+    LabelMap.merge (fun _label pty1_opt pty2_opt ->
       match (pty1_opt, pty2_opt) with
       | (Some(pty1), Some(pty2)) -> Some(Ok(subtype_poly_type_impl internbid internbrid (Poly(pty1)) (Poly(pty2))))
       | (None, Some(pty2))       -> Some(Error(pty2))
@@ -2762,7 +2762,7 @@ and subtype_type_scheme (tyscheme1 : type_scheme) (tyscheme2 : type_scheme) : bo
         | _ ->
             false
       in
-      let internbrid (brid1 : BoundRowID.t) (nomprow2 : normalized_poly_row) : bool =
+      let internbrid (_brid1 : BoundRowID.t) (_nomprow2 : normalized_poly_row) : bool =
         false
       in
       subtype_poly_type_impl internbid internbrid pty1 pty2
@@ -2859,7 +2859,7 @@ and poly_type_equal (Poly(pty1) : poly_type) (Poly(pty2) : poly_type) : bool =
 
   and aux_labeled_map ptylabmap1 ptylabmap2 =
     let labmap =
-      LabelMap.merge (fun label pty1_opt pty2_opt ->
+      LabelMap.merge (fun _label pty1_opt pty2_opt ->
         match (pty1_opt, pty2_opt) with
         | (Some(pty1), Some(pty2)) -> Some(aux pty1 pty2)
         | _                        -> Some(false)
@@ -2933,8 +2933,8 @@ and copy_contents (modsig1 : signature) (modsig2 : signature) : signature =
       (ConcStructure(ssig2_new))
 
   | (ConcFunctor(fsig1), ConcFunctor(fsig2)) ->
-      let { opaques = quant_dom1; domain = modsig_dom1; codomain = absmodsig_cod1; closure = closure } = fsig1 in
-      let { opaques = quant_dom2; domain = modsig_dom2; codomain = absmodsig_cod2 } = fsig2 in
+      let { opaques = _quant_dom1; domain = modsig_dom1; codomain = absmodsig_cod1; closure = closure } = fsig1 in
+      let { opaques = _quant_dom2; domain = modsig_dom2; codomain = absmodsig_cod2 } = fsig2 in
       let modsig_dom2_new = copy_contents modsig_dom1 modsig_dom2 in
       let absmodsig_cod2_new =
         let (_, modsig_cod1) = absmodsig_cod1 in
@@ -3086,7 +3086,7 @@ and typecheck_declaration (tyenv : Typeenv.t) (utdecl : untyped_declaration) : S
             (quant, ssig)
       end
 
-  | UTDeclMacro((rng_cs, csnm), (_, mmacty)) ->
+  | UTDeclMacro((_rng_cs, csnm), (_, mmacty)) ->
       let pre_init =
         {
           stage           = Stage0;
@@ -3121,7 +3121,7 @@ and typecheck_binding_list (tyenv : Typeenv.t) (utbinds : untyped_binding list) 
   ((quant, ssig), binds)
 
 
-and get_dependency_on_synonym_types (known_syns : SynonymDependencyGraph.Vertex.t SynonymNameMap.t) (pre : pre) (tyenv : Typeenv.t) (mty : manual_type) : SynonymVertexSet.t =
+and get_dependency_on_synonym_types (known_syns : SynonymDependencyGraph.Vertex.t SynonymNameMap.t) (_pre : pre) (_tyenv : Typeenv.t) (mty : manual_type) : SynonymVertexSet.t =
   let hashset = SynonymVertexHashSet.create 32 in
     (* A hash set is created on every (non-partial) call. *)
   let register_if_needed (tynm : type_name) : unit =
@@ -3149,7 +3149,7 @@ and get_dependency_on_synonym_types (known_syns : SynonymDependencyGraph.Vertex.
     | MRecordType(mfields, _) ->
         aux_row mfields
 
-    | MTypeParam(typaram) ->
+    | MTypeParam(_typaram) ->
         ()
 
     | MHorzCommandType(mcmdargtys) -> mcmdargtys |> List.iter aux_cmd_arg
@@ -3226,7 +3226,7 @@ and bind_types (tyenv : Typeenv.t) (tybinds : untyped_type_binding list) =
   (* Traverse each definition of the synonym types and extract dependencies between them. *)
   let graph =
     synacc |> Alist.to_list |> List.fold_left (fun graph syn ->
-      let ((_, tynm), tyvars, synbind, vertex) = syn in
+      let ((_, _tynm), _tyvars, synbind, vertex) = syn in
       let dependencies = get_dependency_on_synonym_types known_syns pre tyenv synbind in
       let graph =
         graph |> SynonymVertexSet.fold (fun vertex_dep graph ->

--- a/src/frontend/types.cppo.ml
+++ b/src/frontend/types.cppo.ml
@@ -780,7 +780,7 @@ and instruction =
   | OpBranchIfNot of instruction list
       [@printer (fun fmt _ -> Format.fprintf fmt "OpBranchIfNot(...)")]
   | OpLoadGlobal of syntactic_value ref * EvalVarID.t * int
-      [@printer ((fun fmt (r, evid, refs) -> Format.fprintf fmt "OpLoadGlobal(%s)" (EvalVarID.show_direct evid)))]
+      [@printer ((fun fmt (_r, evid, _refs) -> Format.fprintf fmt "OpLoadGlobal(%s)" (EvalVarID.show_direct evid)))]
   | OpLoadLocal of int * int * EvalVarID.t * int
   | OpDereference
       (* !! pdf, no-interp *)

--- a/src/md/decodeMD.ml
+++ b/src/md/decodeMD.ml
@@ -326,7 +326,7 @@ let rec convert_inline_element (cmdrcd : command_record) (ilne : inline_element)
         | None      -> [(dummy_range, UTInputHorzText("\n"))]
       end
 
-  | Url(href, iln, title) ->
+  | Url(href, iln, _title) ->
       let utastarg1 = (dummy_range, UTStringConstant(href)) in
       let utastarg2 = convert_inline cmdrcd iln in
       make_inline_application cmdrcd.url [utastarg1; utastarg2]

--- a/src/myYojsonUtil.ml
+++ b/src/myYojsonUtil.ml
@@ -36,7 +36,7 @@ let make_assoc ((pos, _) as json : json) : assoc =
   (pos, assoc)
 
 
-let find_opt (key : string) ((pos, assoc) : assoc) : json option =
+let find_opt (key : string) ((_pos, assoc) : assoc) : json option =
   assoc |> YojsonMap.find_opt key
 
 

--- a/tools/gencode/vminst.ml
+++ b/tools/gencode/vminst.ml
@@ -369,7 +369,7 @@ make_math_boxes [ MathBoxLowerLimit{ context = ictx; base; lower } ]
         ~is_text_mode_primitive:true
         ~code:{|
 let ma = MathChar{ context = ictx; is_big = false; chars = uchs } in
-make_math_boxes [ HorzBox.(MathBoxAtom{ kind = mathcls; main = ma }) ]
+make_math_boxes [ MathBoxAtom{ kind = mathcls; main = ma } ]
 |}
     ; inst "BackendMathBigChar"
         ~name:"math-big-char"
@@ -385,7 +385,7 @@ make_math_boxes [ HorzBox.(MathBoxAtom{ kind = mathcls; main = ma }) ]
         ~is_text_mode_primitive:true
         ~code:{|
 let ma = MathChar{ context = ictx; is_big = true; chars = uchs } in
-make_math_boxes [ HorzBox.(MathBoxAtom{ kind = mathcls; main = ma }) ]
+make_math_boxes [ MathBoxAtom{ kind = mathcls; main = ma } ]
 |}
     ; inst "BackendMathCharWithKern"
         ~name:"math-char-with-kern"
@@ -406,7 +406,7 @@ make_math_boxes [ HorzBox.(MathBoxAtom{ kind = mathcls; main = ma }) ]
 let left_kern = make_math_char_kern_func (reducef ~msg:"math-char-with-kern 1") value_left_kern in
 let right_kern = make_math_char_kern_func (reducef ~msg:"math-char-with-kern 2") value_right_kern in
 let ma = MathCharWithKern{ context = ictx; is_big = false; chars = uchs; left_kern; right_kern } in
-make_math_boxes [ HorzBox.(MathBoxAtom{ kind = mathcls; main = ma }) ]
+make_math_boxes [ MathBoxAtom{ kind = mathcls; main = ma } ]
 |}
     ; inst "BackendMathBigCharWithKern"
         ~name:"math-big-char-with-kern"
@@ -427,7 +427,7 @@ make_math_boxes [ HorzBox.(MathBoxAtom{ kind = mathcls; main = ma }) ]
 let left_kern = make_math_char_kern_func (reducef ~msg:"math-big-char-with-kern 1") value_left_kern in
 let right_kern = make_math_char_kern_func (reducef ~msg:"math-big-char-with-kern 2") value_right_kern in
 let ma = MathCharWithKern{ context = ictx; is_big = true; chars = uchs; left_kern; right_kern } in
-make_math_boxes [ HorzBox.(MathBoxAtom{ kind = mathcls; main = ma }) ]
+make_math_boxes [ MathBoxAtom{ kind = mathcls; main = ma } ]
 |}
     ; inst "BackendEmbedHorzToMath"
         ~name:"embed-inline-to-math"
@@ -440,7 +440,7 @@ make_math_boxes [ HorzBox.(MathBoxAtom{ kind = mathcls; main = ma }) ]
         ]
         ~is_pdf_mode_primitive:true
         ~code:{|
-make_math_boxes [ HorzBox.(MathBoxAtom{ kind = mathcls; main = MathEmbeddedHorz(hbs) }) ]
+make_math_boxes [ MathBoxAtom{ kind = mathcls; main = MathEmbeddedHorz(hbs) } ]
 |}
     ; inst "BackendSetMathCharClass"
         ~name:"set-math-char-class"
@@ -2716,7 +2716,7 @@ make_float (floor fc1)
         ~is_pdf_mode_primitive:true
         ~is_text_mode_primitive:true
         ~code:{|
-make_length (HorzBox.(len1 +% len2))
+make_length (len1 +% len2)
 |}
     ; inst "LengthMinus"
         ~name:"-'"
@@ -2730,7 +2730,7 @@ make_length (HorzBox.(len1 +% len2))
         ~is_pdf_mode_primitive:true
         ~is_text_mode_primitive:true
         ~code:{|
-make_length (HorzBox.(len1 -% len2))
+make_length (len1 -% len2)
 |}
     ; inst "LengthTimes"
         ~name:"*'"
@@ -2744,7 +2744,7 @@ make_length (HorzBox.(len1 -% len2))
         ~is_pdf_mode_primitive:true
         ~is_text_mode_primitive:true
         ~code:{|
-make_length (HorzBox.(len1 *% flt2))
+make_length (len1 *% flt2)
 |}
     ; inst "LengthDivides"
         ~name:"/'"
@@ -2758,7 +2758,7 @@ make_length (HorzBox.(len1 *% flt2))
         ~is_pdf_mode_primitive:true
         ~is_text_mode_primitive:true
         ~code:{|
-make_float (HorzBox.(len1 /% len2))
+make_float (len1 /% len2)
 |}
     ; inst "LengthLessThan"
         ~name:"<'"
@@ -2772,7 +2772,7 @@ make_float (HorzBox.(len1 /% len2))
         ~is_pdf_mode_primitive:true
         ~is_text_mode_primitive:true
         ~code:{|
-make_bool (HorzBox.(len1 <% len2))
+make_bool (len1 <% len2)
 |}
     ; inst "LengthGreaterThan"
         ~name:">'"
@@ -2786,7 +2786,7 @@ make_bool (HorzBox.(len1 <% len2))
         ~is_pdf_mode_primitive:true
         ~is_text_mode_primitive:true
         ~code:{|
-make_bool (HorzBox.(len2 <% len1))
+make_bool (len2 <% len1)
 |}
     ; inst "PrimitiveSetWordBreakPenalty"
         ~name:"set-word-break-penalty"

--- a/tools/gencode/vminst.ml
+++ b/tools/gencode/vminst.ml
@@ -761,6 +761,8 @@ match value1 with
 | _                    -> report_bug_value "HorzLex" value1
 |}
         ~code:{|
+let _ = ictx in
+let _ = value1 in
 failwith "TODO: HorzLex" (*
 match value1 with
 | CompiledInputHorzClosure(imihlst, envi) -> exec_pdf_mode_intermediate_input_horz envi ictx imihlst
@@ -803,6 +805,8 @@ let mbs = read_pdf_mode_math_text ictx imvs in
 make_math_boxes mbs
 |}
         ~code:{|
+let _ = ictx in
+let _ = value1 in
 failwith "MathLex" (*
 match value1 with
 | CompiledInputMathClosure(imims, envi) -> exec_pdf_mode_intermediate_input_math envi ictx imims
@@ -823,6 +827,7 @@ match value1 with
 read_text_mode_horz_text value_tctx ihvs
 |}
         ~code:{|
+let _ = value_tctx in
 let _ = ihvs in
 failwith "TODO: TextHorzLex" (*
 match value1 with
@@ -844,6 +849,7 @@ match value1 with
 read_text_mode_vert_text value_tctx ivvs
 |}
         ~code:{|
+let _ = value_tctx in
 let _ = ivvs in
 failwith "TODO: TextVertLex" (*
 match value1 with
@@ -865,6 +871,7 @@ match value1 with
 read_text_mode_math_text value_tctx imvs
 |}
         ~code:{|
+let _ = value_tctx in
 let _ = imvs in
 failwith "TODO: TextVertLex"
 |}
@@ -1929,7 +1936,7 @@ make_bool (String.equal str1 str2)
         ~code:{|
 let resstr =
   try BatUTF8.sub str pos wid with
-  | Invalid_argument(s) -> report_dynamic_error "illegal index for string-sub"
+  | Invalid_argument(_) -> report_dynamic_error "illegal index for string-sub"
 in
 make_string resstr
 |}
@@ -1948,7 +1955,7 @@ make_string resstr
         ~code:{|
 let resstr =
   try String.sub str pos wid with
-  | Invalid_argument(s) -> report_dynamic_error "illegal index for string-sub-bytes"
+  | Invalid_argument(_) -> report_dynamic_error "illegal index for string-sub-bytes"
 in
 make_string resstr
 |}
@@ -2427,7 +2434,7 @@ make_bool (not binl)
         ~code:{|
 let bits =
   try numl lsr numr with
-  | Invalid_argument(s) -> report_dynamic_error "Bit offset out of bounds for '>>'"
+  | Invalid_argument(_) -> report_dynamic_error "Bit offset out of bounds for '>>'"
 in
 make_int bits
 |}
@@ -2445,7 +2452,7 @@ make_int bits
         ~code:{|
 let bits =
   try numl lsl numr with
-  | Invalid_argument(s) -> report_dynamic_error "Bit offset out of bounds for '<<'"
+  | Invalid_argument(_) -> report_dynamic_error "Bit offset out of bounds for '<<'"
 in
 make_int bits
 |}


### PR DESCRIPTION
This PR enables more warnings of OCaml compiler while building SATySFi itself.

This PR also includes fixes for warnings. This **does not** aim to improve global code structure, but rewrite code locally to eliminate warnings; simply remove unused code and flags, prefix `_` to unused variables, add missing patterns, ..., etc.

Removing unused value declarations (fixing warning 32) is a future work since it is unclear to me which declarations should be removed.