### PR TITLE
Support `external_sources` section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,22 +74,15 @@ jobs:
         run: |
           opam install -y .
           if [ "${{ matrix.os }}" == 'macos-latest' ]; then
-            ginstall -d ~/.satysfi
-            ginstall -m 644 lib-satysfi/satysfi-library-root.yaml ~/.satysfi/satysfi-library-root.yaml
+            ./install-libs.sh ~/.satysfi ginstall
           else
-            install -d ~/.satysfi
-            install -m 644 lib-satysfi/satysfi-library-root.yaml ~/.satysfi/satysfi-library-root.yaml
+            ./install-libs.sh ~/.satysfi install
           fi
 
-# It is no longer necessary to install packages and font files beforehand
+# It is no longer necessary to download font files beforehand
 # due to the package system:
 #          if [ -z "$(ls lib-satysfi/dist/fonts)" ]; then
 #            ./download-fonts.sh
-#          fi
-#          if [ "${{ matrix.os }}" == 'macos-latest' ]; then
-#            ./install-libs.sh ~/.satysfi ginstall
-#          else
-#            ./install-libs.sh ~/.satysfi install
 #          fi
 
       - name: Check library packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Cache dist fonts
+      - name: Cache locks
         uses: actions/cache@v2
         env:
-          cache-name: cache-dist-fonts
+          cache-name: cache-locks
         with:
-          path: lib-satysfi/dist/fonts
-          key: ${{ env.cache-name }}-${{ hashFiles('download-fonts.sh') }}
+          path: ~/.satysfi/cache/
+          key: ${{ env.cache-name }}-${{ hashFiles('default-registry-commit-hash.txt') }}
 
       - name: Determine the default OPAM Repo
         id: determine-default-opam-repo
@@ -73,14 +73,17 @@ jobs:
       - name: Install SATySFi
         run: |
           opam install -y .
-          if [ -z "$(ls lib-satysfi/dist/fonts)" ]; then
-            ./download-fonts.sh
-          fi
-          if [ "${{ matrix.os }}" == 'macos-latest' ]; then
-            ./install-libs.sh ~/.satysfi ginstall
-          else
-            ./install-libs.sh ~/.satysfi install
-          fi
+
+# It is no longer necessary to install packages and font files beforehand
+# due to the package system:
+#          if [ -z "$(ls lib-satysfi/dist/fonts)" ]; then
+#            ./download-fonts.sh
+#          fi
+#          if [ "${{ matrix.os }}" == 'macos-latest' ]; then
+#            ./install-libs.sh ~/.satysfi ginstall
+#          else
+#            ./install-libs.sh ~/.satysfi install
+#          fi
 
       - name: Check library packages
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
       - name: Install SATySFi
         run: |
           opam install -y .
+          if [ "${{ matrix.os }}" == 'macos-latest' ]; then
+            ginstall -m 644 lib-satysfi/satysfi-library-root.yaml ~/.satysfi/satysfi-library-root.yaml
+          else
+            install -m 644 lib-satysfi/satysfi-library-root.yaml ~/.satysfi/satysfi-library-root.yaml
+          fi
 
 # It is no longer necessary to install packages and font files beforehand
 # due to the package system:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,10 @@ jobs:
         run: |
           opam install -y .
           if [ "${{ matrix.os }}" == 'macos-latest' ]; then
+            ginstall -d ~/.satysfi
             ginstall -m 644 lib-satysfi/satysfi-library-root.yaml ~/.satysfi/satysfi-library-root.yaml
           else
+            install -d ~/.satysfi
             install -m 644 lib-satysfi/satysfi-library-root.yaml ~/.satysfi/satysfi-library-root.yaml
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ satysfi
 !/tests/images/peppers-rgb.jpg
 *.satysfi-aux
 external/
+temp/tarballs/
 
 # Created by https://www.toptal.com/developers/gitignore/api/ocaml
 # Edit at https://www.toptal.com/developers/gitignore?templates=ocaml

--- a/default-registry-commit-hash.txt
+++ b/default-registry-commit-hash.txt
@@ -1,0 +1,1 @@
+5d827e0171ba3cf6c8ac32d22ecfdc1b084619f8	refs/heads/format-1

--- a/install-libs.sh
+++ b/install-libs.sh
@@ -9,7 +9,10 @@ INSTALL=${2:-install}
 "${INSTALL}" -m 644 lib-satysfi/unidata/*.txt "${LIBDIR}/unidata"
 "${INSTALL}" -d "${LIBDIR}/hyph"
 "${INSTALL}" -m 644 lib-satysfi/hyph/* "${LIBDIR}/hyph"
-"${INSTALL}" -d "${LIBDIR}/packages"
-(cd lib-satysfi && find packages -type f -exec "${INSTALL}" -Dm 644 "{}" "${LIBDIR}/{}" \;)
-"${INSTALL}" -d "${LIBDIR}/registries"
-(cd lib-satysfi && find registries -type f -exec "${INSTALL}" -Dm 644 "{}" "${LIBDIR}/{}" \;)
+
+# It is no longer necessary to install packages beforehand due to the package system:
+#
+# "${INSTALL}" -d "${LIBDIR}/packages"
+# (cd lib-satysfi && find packages -type f -exec "${INSTALL}" -Dm 644 "{}" "${LIBDIR}/{}" \;)
+# "${INSTALL}" -d "${LIBDIR}/registries"
+# (cd lib-satysfi && find registries -type f -exec "${INSTALL}" -Dm 644 "{}" "${LIBDIR}/{}" \;)

--- a/lib-satysfi/packages/font-ipa-ex/font-ipa-ex.0.0.1/satysfi.yaml
+++ b/lib-satysfi/packages/font-ipa-ex/font-ipa-ex.0.0.1/satysfi.yaml
@@ -1,6 +1,16 @@
 language: "^0.1.0"
 name: "font-ipa-ex"
 authors: []
+external_sources:
+  - name: "IPAexfont00401"
+    type: "zip"
+    url: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip"
+    checksum: "57f2631833c1049ea89320971cc74ce5"
+    extractions:
+      - from: "IPAexfont00401/ipaexg.ttf"
+        to: "./fonts/ipaexg.ttf"
+      - from: "IPAexfont00401/ipaexm.ttf"
+        to: "./fonts/ipaexm.ttf"
 contents:
   type: "font"
   main_module: "FontIpaEx"

--- a/lib-satysfi/packages/font-junicode/font-junicode.0.0.1/satysfi.yaml
+++ b/lib-satysfi/packages/font-junicode/font-junicode.0.0.1/satysfi.yaml
@@ -1,6 +1,20 @@
 language: "^0.1.0"
 name: "font-junicode"
 authors: []
+external_sources:
+  - name: "junicode-1.002"
+    type: "zip"
+    url: "http://downloads.sourceforge.net/project/junicode/junicode/junicode-1.002/junicode-1.002.zip"
+    checksum: "b1d6ed8796d8d1eacd733c0d568d939f"
+    extractions:
+      - from: "Junicode.ttf"
+        to: "./fonts/Junicode.ttf"
+      - from: "Junicode-Bold.ttf"
+        to: "./fonts/Junicode-Bold.ttf"
+      - from: "Junicode-Italic.ttf"
+        to: "./fonts/Junicode-Italic.ttf"
+      - from: "Junicode-BoldItalic.ttf"
+        to: "./fonts/Junicode-BoldItalic.ttf"
 contents:
   type: "font"
   main_module: "FontJunicode"

--- a/lib-satysfi/packages/font-latin-modern-math/font-latin-modern-math.0.0.1/satysfi.yaml
+++ b/lib-satysfi/packages/font-latin-modern-math/font-latin-modern-math.0.0.1/satysfi.yaml
@@ -1,6 +1,14 @@
 language: "^0.1.0"
 name: "font-latin-modern-math"
 authors: []
+external_sources:
+  - name: "latinmodern-math-1959"
+    type: "zip"
+    url: "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+    checksum: "bc82f6d4184ec0ea3ba2c0798e6be719"
+    extractions:
+      - from: "latinmodern-math-1959/otf/latinmodern-math.otf"
+        to: "./fonts/latinmodern-math.otf"
 contents:
   type: "font"
   main_module: "FontLatinModernMath"

--- a/lib-satysfi/packages/font-latin-modern/font-latin-modern.0.0.1/satysfi.yaml
+++ b/lib-satysfi/packages/font-latin-modern/font-latin-modern.0.0.1/satysfi.yaml
@@ -1,6 +1,16 @@
 language: "^0.1.0"
 name: "font-latin-modern"
 authors: []
+external_sources:
+  - name: "lm2.004otf"
+    type: "zip"
+    url: "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+    checksum: "0bc81a83fe37416b67b69ab3a6593ef5"
+    extractions:
+      - from: "lmmono10-regular.otf"
+        to: "./fonts/lmmono10-regular.otf"
+      - from: "lmsans10-regular.otf"
+        to: "./fonts/lmsans10-regular.otf"
 contents:
   type: "font"
   main_module: "FontLatinModern"

--- a/make-package-tarballs.sh
+++ b/make-package-tarballs.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TARGET_DIR=temp/tarballs
+
+echo "Deleting copied font files ..."
+for FILE in $(find lib-satysfi -name \*.ttf -or -name \*.otf | grep '^lib-satysfi/packages/'); do
+    rm "$FILE"
+done
+
+mkdir -p "$TARGET_DIR"
+for FILE in $(find lib-satysfi -name satysfi.yaml); do
+    DIR="$(dirname "$FILE")"
+    NAME="$(basename "$DIR")"
+    TARGET="$TARGET_DIR/$NAME.tar.gz"
+    echo "Compressing $DIR to $TARGET ..."
+    tar -czf "$TARGET" "$DIR"
+    echo "Checksum:"
+    md5sum "$TARGET"
+done
+
+echo "Done."

--- a/make-package-tarballs.sh
+++ b/make-package-tarballs.sh
@@ -1,21 +1,25 @@
 #!/bin/sh
 
 TARGET_DIR=temp/tarballs
+REPO_ROOT="$(pwd)/$(dirname "$0")"
 
 echo "Deleting copied font files ..."
 for FILE in $(find lib-satysfi -name \*.ttf -or -name \*.otf | grep '^lib-satysfi/packages/'); do
-    rm "$FILE"
+    rm "${FILE}"
 done
 
-mkdir -p "$TARGET_DIR"
+mkdir -p "${TARGET_DIR}"
 for FILE in $(find lib-satysfi -name satysfi.yaml); do
-    DIR="$(dirname "$FILE")"
-    NAME="$(basename "$DIR")"
-    TARGET="$TARGET_DIR/$NAME.tar.gz"
-    echo "Compressing $DIR to $TARGET ..."
-    tar -czf "$TARGET" "$DIR"
+    VERSIONED_DIR="$(dirname "${FILE}")"
+    PACKAGE_DIR="$(dirname "${VERSIONED_DIR}")"
+    VERSIONED_NAME="$(basename "${VERSIONED_DIR}")"
+
+    ABS_TARGET="${REPO_ROOT}/${TARGET_DIR}/${VERSIONED_NAME}.tar.gz"
+
+    echo "Compressing ${VERSIONED_NAME} at ${PACKAGE_DIR} to ${ABS_TARGET} ..."
+    (cd "${PACKAGE_DIR}" && tar -czf "${ABS_TARGET}" "${VERSIONED_NAME}")
     echo "Checksum:"
-    md5sum "$TARGET"
+    md5sum "${ABS_TARGET}"
 done
 
 echo "Done."

--- a/src/frontend/configError.ml
+++ b/src/frontend/configError.ml
@@ -117,5 +117,9 @@ type config_error =
       expected : string;
       got      : string;
     }
+  | FailedToExtractExternalZip of {
+      exit_status : int;
+      command     : string;
+    }
   | PackageRegistryFetcherError   of PackageRegistryFetcher.error
   | CanonicalRegistryUrlError     of CanonicalRegistryUrl.error

--- a/src/frontend/configError.ml
+++ b/src/frontend/configError.ml
@@ -29,6 +29,7 @@ type yaml_error =
       context             : YamlDecoder.context;
       registry_hash_value : registry_hash_value;
     }
+  | CannotBeUsedAsAName of YamlDecoder.context * string
   | NotACommand of {
       context : YamlDecoder.context;
       prefix  : char;
@@ -95,6 +96,20 @@ type config_error =
   | NoMarkdownConversion          of module_name
   | MoreThanOneMarkdownConversion of module_name
   | MarkdownError                 of MarkdownParser.error
-  | LockFetcherError              of LockFetcher.error
+  | FailedToFetchTarball of {
+      lock_name   : lock_name;
+      exit_status : int;
+      command     : string;
+    }
+  | FailedToExtractTarball of {
+      lock_name   : lock_name;
+      exit_status : int;
+      command     : string;
+    }
+  | FailedToFetchExternalZip of {
+      url         : string;
+      exit_status : int;
+      command     : string;
+    }
   | PackageRegistryFetcherError   of PackageRegistryFetcher.error
   | CanonicalRegistryUrlError     of CanonicalRegistryUrl.error

--- a/src/frontend/configError.ml
+++ b/src/frontend/configError.ml
@@ -111,5 +111,11 @@ type config_error =
       exit_status : int;
       command     : string;
     }
+  | ExternalZipChecksumMismatch of {
+      url      : string;
+      path     : abs_path;
+      expected : string;
+      got      : string;
+    }
   | PackageRegistryFetcherError   of PackageRegistryFetcher.error
   | CanonicalRegistryUrlError     of CanonicalRegistryUrl.error

--- a/src/frontend/configError.ml
+++ b/src/frontend/configError.ml
@@ -121,5 +121,9 @@ type config_error =
       exit_status : int;
       command     : string;
     }
+  | FailedToCopyFile of {
+      exit_status : int;
+      command     : string;
+    }
   | PackageRegistryFetcherError   of PackageRegistryFetcher.error
   | CanonicalRegistryUrlError     of CanonicalRegistryUrl.error

--- a/src/frontend/configUtil.ml
+++ b/src/frontend/configUtil.ml
@@ -72,3 +72,12 @@ let registry_remote_decoder : registry_remote ConfigDecoder.t =
   ~other:(fun tag ->
     failure (fun context -> UnexpectedTag(context, tag))
   )
+
+
+let name_decoder : string ConfigDecoder.t =
+  let open ConfigDecoder in
+  string >>= fun s ->
+  if s |> Core.String.to_list_rev |> List.exists (Char.equal '/') then
+    failure (fun context -> CannotBeUsedAsAName(context, s))
+  else
+    succeed s

--- a/src/frontend/lockFetcher.ml
+++ b/src/frontend/lockFetcher.ml
@@ -117,7 +117,7 @@ let main ~(wget_command : string) ~(tar_command : string) ~(unzip_command : stri
 
                 (* Checks the fetched file by using checksum: *)
                 let* () =
-                  let checksum_got = Digest.file (get_abs_path_string abspath_zip) in
+                  let checksum_got = Digest.to_hex (Digest.file (get_abs_path_string abspath_zip)) in
                   if checksum_got = checksum then
                     return ()
                   else

--- a/src/frontend/lockFetcher.mli
+++ b/src/frontend/lockFetcher.mli
@@ -6,5 +6,6 @@ open ConfigError
 val main :
   wget_command:string ->
   tar_command:string ->
+  unzip_command:string ->
   cache_directory:abs_path ->
   implementation_spec -> (unit, config_error) result

--- a/src/frontend/lockFetcher.mli
+++ b/src/frontend/lockFetcher.mli
@@ -1,21 +1,10 @@
 
 open MyUtil
 open PackageSystemBase
-
-type error =
-  | FailedToFetchTarball of {
-      lock_name   : lock_name;
-      exit_status : int;
-      command     : string;
-    }
-  | FailedToExtractTarball of {
-      lock_name   : lock_name;
-      exit_status : int;
-      command     : string;
-    }
+open ConfigError
 
 val main :
   wget_command:string ->
   tar_command:string ->
   cache_directory:abs_path ->
-  implementation_spec -> (unit, error) result
+  implementation_spec -> (unit, config_error) result

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -1234,6 +1234,12 @@ let report_config_error : config_error -> unit = function
         DisplayLine(command);
       ]
 
+  | FailedToCopyFile{ exit_status; command } ->
+      report_error Interface [
+        NormalLine(Printf.sprintf "failed to copy a file (exit status: %d). command:" exit_status);
+        DisplayLine(command);
+      ]
+
   | PackageRegistryFetcherError(e) ->
       begin
         match e with

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -1228,6 +1228,12 @@ let report_config_error : config_error -> unit = function
         DisplayLine(Printf.sprintf "- got: '%s'" got);
       ]
 
+  | FailedToExtractExternalZip{ exit_status; command } ->
+      report_error Interface [
+        NormalLine(Printf.sprintf "failed to extract a zip file (exit status: %d). command:" exit_status);
+        DisplayLine(command);
+      ]
+
   | PackageRegistryFetcherError(e) ->
       begin
         match e with
@@ -2137,6 +2143,7 @@ let solve
 
             let wget_command = "wget" in (* TODO: make this changeable *)
             let tar_command = "tar" in (* TODO: make this changeable *)
+            let unzip_command = "unzip" in (* TODO: make this changeable *)
             let absdir_lock_cache =
               let absdir_primary_root = get_primary_root_dir () in
               make_abs_path
@@ -2144,7 +2151,8 @@ let solve
             in
             let* () =
               impl_specs |> foldM (fun () impl_spec ->
-                LockFetcher.main ~wget_command ~tar_command ~cache_directory:absdir_lock_cache impl_spec
+                LockFetcher.main
+                  ~wget_command ~tar_command ~unzip_command ~cache_directory:absdir_lock_cache impl_spec
               ) ()
             in
             LockConfig.write abspath_lock_config lock_config;

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -1219,6 +1219,15 @@ let report_config_error : config_error -> unit = function
         DisplayLine(command);
       ]
 
+  | ExternalZipChecksumMismatch{ url; path; expected; got } ->
+      report_error Interface [
+        NormalLine("checksum mismatch of an external zip file.");
+        DisplayLine(Printf.sprintf "- fetched from: '%s'" url);
+        DisplayLine(Printf.sprintf "- path: '%s'" (get_abs_path_string path));
+        DisplayLine(Printf.sprintf "- expected: '%s'" expected);
+        DisplayLine(Printf.sprintf "- got: '%s'" got);
+      ]
+
   | PackageRegistryFetcherError(e) ->
       begin
         match e with

--- a/src/frontend/packageConfig.ml
+++ b/src/frontend/packageConfig.ml
@@ -36,7 +36,7 @@ type package_contents =
 type t = {
   package_name     : package_name;
   package_authors  : string list;
-  external_sources : external_source list;
+  external_sources : (string * external_source) list;
   package_contents : package_contents;
   registry_specs   : registry_remote RegistryLocalNameMap.t;
 }
@@ -219,14 +219,15 @@ let extraction_decoder : extraction ConfigDecoder.t =
   succeed { extracted_from; extracted_to }
 
 
-let external_source_decoder : external_source ConfigDecoder.t =
+let external_source_decoder : (string * external_source) ConfigDecoder.t =
   let open ConfigDecoder in
   branch "type" [
     "zip" ==> begin
+      get "name" name_decoder >>= fun name ->
       get "url" string >>= fun url ->
       get "checksum" string >>= fun checksum ->
       get "extractions" (list extraction_decoder) >>= fun extractions ->
-      succeed @@ ExternalZip{ url; checksum; extractions }
+      succeed (name, ExternalZip{ url; checksum; extractions })
     end;
   ]
   ~other:(fun tag ->

--- a/src/frontend/packageConfig.ml
+++ b/src/frontend/packageConfig.ml
@@ -36,6 +36,7 @@ type package_contents =
 type t = {
   package_name     : package_name;
   package_authors  : string list;
+  external_sources : external_source list;
   package_contents : package_contents;
   registry_specs   : registry_remote RegistryLocalNameMap.t;
 }
@@ -211,12 +212,35 @@ let registry_spec_decoder =
   succeed (registry_local_name, registry_remote)
 
 
+let extraction_decoder : extraction ConfigDecoder.t =
+  let open ConfigDecoder in
+  get "from" string >>= fun extracted_from ->
+  get "to" string >>= fun extracted_to ->
+  succeed { extracted_from; extracted_to }
+
+
+let external_source_decoder : external_source ConfigDecoder.t =
+  let open ConfigDecoder in
+  branch "type" [
+    "zip" ==> begin
+      get "url" string >>= fun url ->
+      get "checksum" string >>= fun checksum ->
+      get "extractions" (list extraction_decoder) >>= fun extractions ->
+      succeed @@ ExternalZip{ url; checksum; extractions }
+    end;
+  ]
+  ~other:(fun tag ->
+    failure (fun context -> UnexpectedTag(context, tag))
+  )
+
+
 let config_decoder : t ConfigDecoder.t =
   let open ConfigDecoder in
   get "language" language_version_checker >>= fun () ->
   get "name" package_name_decoder >>= fun package_name ->
   get "authors" (list string) >>= fun package_authors ->
   get_or_else "registries" (list registry_spec_decoder) [] >>= fun registry_specs ->
+  get_or_else "external_sources" (list external_source_decoder) [] >>= fun external_sources ->
   get "contents" contents_decoder >>= fun package_contents ->
   registry_specs |> List.fold_left (fun res (registry_local_name, registry_remote) ->
     res >>= fun map ->
@@ -228,6 +252,7 @@ let config_decoder : t ConfigDecoder.t =
   succeed @@ {
     package_name;
     package_authors;
+    external_sources;
     package_contents;
     registry_specs;
   }

--- a/src/frontend/packageConfig.mli
+++ b/src/frontend/packageConfig.mli
@@ -32,6 +32,7 @@ type package_contents =
 type t = {
   package_name     : package_name;
   package_authors  : string list;
+  external_sources : external_source list;
   package_contents : package_contents;
   registry_specs   : registry_remote RegistryLocalNameMap.t;
 }

--- a/src/frontend/packageConfig.mli
+++ b/src/frontend/packageConfig.mli
@@ -32,7 +32,7 @@ type package_contents =
 type t = {
   package_name     : package_name;
   package_authors  : string list;
-  external_sources : external_source list;
+  external_sources : (string * external_source) list;
   package_contents : package_contents;
   registry_specs   : registry_remote RegistryLocalNameMap.t;
 }

--- a/src/frontend/packageSystemBase.ml
+++ b/src/frontend/packageSystemBase.ml
@@ -111,3 +111,15 @@ type registry_remote =
       url    : string;
       branch : string;
     }
+
+type extraction = {
+  extracted_from : string;
+  extracted_to   : string;
+}
+
+type external_source =
+  | ExternalZip of {
+      url         : string;
+      checksum    : string;
+      extractions : extraction list;
+    }

--- a/src/frontend/shellCommand.ml
+++ b/src/frontend/shellCommand.ml
@@ -17,6 +17,16 @@ let mkdir_p (absdir : abs_path) : unit =
   Core_unix.mkdir_p (get_abs_path_string absdir)
 
 
+let cp ~(from : abs_path) ~(to_ : abs_path) : run_result =
+  let command =
+    Printf.sprintf "cp \"%s\" \"%s\""
+      (escape_string (get_abs_path_string from))
+      (escape_string (get_abs_path_string to_))
+  in
+  let exit_status = Sys.command command in
+  { exit_status; command }
+
+
 let run_wget
   ~(wget_command : string)
   ~(url : string)
@@ -50,13 +60,13 @@ let run_tar_xzf_strip_components_1
 let run_unzip
   ~(unzip_command : string)
   ~(zip : abs_path)
-  ~(output_dir : abs_path)
+  ~(output_container_dir : abs_path)
 =
   let command =
     Printf.sprintf "\"%s\" -o \"%s\" -d \"%s\""
       (escape_string unzip_command)
       (escape_string (get_abs_path_string zip))
-      (escape_string (get_abs_path_string output_dir))
+      (escape_string (get_abs_path_string output_container_dir))
   in
   let exit_status = Sys.command command in
   { exit_status; command }

--- a/src/frontend/shellCommand.ml
+++ b/src/frontend/shellCommand.ml
@@ -47,6 +47,21 @@ let run_tar_xzf_strip_components_1
   { exit_status; command }
 
 
+let run_unzip
+  ~(unzip_command : string)
+  ~(zip : abs_path)
+  ~(output_dir : abs_path)
+=
+  let command =
+    Printf.sprintf "\"%s\" -o \"%s\" -d \"%s\""
+      (escape_string unzip_command)
+      (escape_string (get_abs_path_string zip))
+      (escape_string (get_abs_path_string output_dir))
+  in
+  let exit_status = Sys.command command in
+  { exit_status; command }
+
+
 let run_git_pull
   ~(git_command : string)
   ~(repo_dir : abs_path)

--- a/src/frontend/shellCommand.mli
+++ b/src/frontend/shellCommand.mli
@@ -8,6 +8,8 @@ type run_result = {
 
 val mkdir_p : abs_path -> unit
 
+val cp : from:abs_path -> to_:abs_path -> run_result
+
 val run_wget :
   wget_command:string ->
   url:string ->
@@ -23,7 +25,7 @@ val run_tar_xzf_strip_components_1 :
 val run_unzip :
   unzip_command:string ->
   zip:abs_path ->
-  output_dir:abs_path ->
+  output_container_dir:abs_path ->
   run_result
 
 val run_git_pull :

--- a/src/frontend/shellCommand.mli
+++ b/src/frontend/shellCommand.mli
@@ -20,6 +20,12 @@ val run_tar_xzf_strip_components_1 :
   output_dir:abs_path ->
   run_result
 
+val run_unzip :
+  unzip_command:string ->
+  zip:abs_path ->
+  output_dir:abs_path ->
+  run_result
+
 val run_git_pull :
   git_command:string ->
   repo_dir:abs_path ->

--- a/update-default-registry-commit-hash-file.sh
+++ b/update-default-registry-commit-hash-file.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+HASH_FILE=default-registry-commit-hash.txt
+REPO_URL=https://github.com/SATySFi/default-registry
+BRANCH=format-1
+
+git ls-remote "${REPO_URL}" "refs/heads/${BRANCH}" > "$HASH_FILE"


### PR DESCRIPTION
`satysfi.yaml`:

```diff
 language: "^0.1.0"
 name: "font-ipa-ex"
 authors: []
+external_sources:
+  - name: "IPAexfont00401"
+    type: "zip"
+    url: "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip"
+    checksum: "57f2631833c1049ea89320971cc74ce5"
+    extractions:
+      - from: "IPAexfont00401/ipaexg.ttf"
+        to: "./fonts/ipaexg.ttf"
+      - from: "IPAexfont00401/ipaexm.ttf"
+        to: "./fonts/ipaexm.ttf"
 contents:
   type: "font"
   main_module: "FontIpaEx"
```