### PR TITLE
Small fixes of the package system

### DIFF
--- a/default-registry-commit-hash.txt
+++ b/default-registry-commit-hash.txt
@@ -1,1 +1,1 @@
-5d827e0171ba3cf6c8ac32d22ecfdc1b084619f8	refs/heads/format-1
+39cfbf8be2cac03f079fd4d5e7b1b4ef14ad6c44	refs/heads/format-1

--- a/demo/demo.satysfi-lock-expected
+++ b/demo/demo.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: annot.0.0.1
   location:
     type: global
-    path: ./packages/annot/annot.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/annot/annot.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -11,7 +11,7 @@ locks:
 - name: code.0.0.1
   location:
     type: global
-    path: ./packages/code/code.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/code/code.0.0.1
   dependencies:
   - stdlib.0.0.1
   - font-latin-modern.0.0.1
@@ -20,35 +20,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: footnote-scheme.0.0.1
   location:
     type: global
-    path: ./packages/footnote-scheme/footnote-scheme.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/footnote-scheme/footnote-scheme.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -56,7 +56,7 @@ locks:
 - name: itemize.0.0.1
   location:
     type: global
-    path: ./packages/itemize/itemize.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/itemize/itemize.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -64,7 +64,7 @@ locks:
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -72,7 +72,7 @@ locks:
 - name: proof.0.0.1
   location:
     type: global
-    path: ./packages/proof/proof.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/proof/proof.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -80,7 +80,7 @@ locks:
 - name: std-ja-book.0.0.1
   location:
     type: global
-    path: ./packages/std-ja-book/std-ja-book.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/std-ja-book/std-ja-book.0.0.1
   dependencies:
   - stdlib.0.0.1
   - math.0.0.1
@@ -96,14 +96,14 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib
 - name: tabular.0.0.1
   location:
     type: global
-    path: ./packages/tabular/tabular.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/tabular/tabular.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false

--- a/doc/doc-lang.satysfi-lock-expected
+++ b/doc/doc-lang.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: annot.0.0.1
   location:
     type: global
-    path: ./packages/annot/annot.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/annot/annot.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -11,7 +11,7 @@ locks:
 - name: code.0.0.1
   location:
     type: global
-    path: ./packages/code/code.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/code/code.0.0.1
   dependencies:
   - stdlib.0.0.1
   - font-latin-modern.0.0.1
@@ -20,35 +20,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -56,7 +56,7 @@ locks:
 - name: std-ja.0.0.1
   location:
     type: global
-    path: ./packages/std-ja/std-ja.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/std-ja/std-ja.0.0.1
   dependencies:
   - stdlib.0.0.1
   - math.0.0.1
@@ -71,7 +71,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/doc/doc-primitives.satysfi-lock-expected
+++ b/doc/doc-primitives.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: annot.0.0.1
   location:
     type: global
-    path: ./packages/annot/annot.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/annot/annot.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -11,7 +11,7 @@ locks:
 - name: code.0.0.1
   location:
     type: global
-    path: ./packages/code/code.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/code/code.0.0.1
   dependencies:
   - stdlib.0.0.1
   - font-latin-modern.0.0.1
@@ -20,35 +20,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: footnote-scheme.0.0.1
   location:
     type: global
-    path: ./packages/footnote-scheme/footnote-scheme.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/footnote-scheme/footnote-scheme.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -56,7 +56,7 @@ locks:
 - name: itemize.0.0.1
   location:
     type: global
-    path: ./packages/itemize/itemize.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/itemize/itemize.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -64,7 +64,7 @@ locks:
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -72,7 +72,7 @@ locks:
 - name: std-ja-book.0.0.1
   location:
     type: global
-    path: ./packages/std-ja-book/std-ja-book.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/std-ja-book/std-ja-book.0.0.1
   dependencies:
   - stdlib.0.0.1
   - math.0.0.1
@@ -88,7 +88,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/doc/math1.satysfi-lock-expected
+++ b/doc/math1.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: annot.0.0.1
   location:
     type: global
-    path: ./packages/annot/annot.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/annot/annot.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -11,7 +11,7 @@ locks:
 - name: code.0.0.1
   location:
     type: global
-    path: ./packages/code/code.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/code/code.0.0.1
   dependencies:
   - stdlib.0.0.1
   - font-latin-modern.0.0.1
@@ -20,35 +20,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -56,7 +56,7 @@ locks:
 - name: proof.0.0.1
   location:
     type: global
-    path: ./packages/proof/proof.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/proof/proof.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -64,7 +64,7 @@ locks:
 - name: std-ja.0.0.1
   location:
     type: global
-    path: ./packages/std-ja/std-ja.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/std-ja/std-ja.0.0.1
   dependencies:
   - stdlib.0.0.1
   - math.0.0.1
@@ -79,14 +79,14 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib
 - name: tabular.0.0.1
   location:
     type: global
-    path: ./packages/tabular/tabular.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/tabular/tabular.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false

--- a/lib-satysfi/packages/annot/annot.0.0.1/package.satysfi-lock-expected
+++ b/lib-satysfi/packages/annot/annot.0.0.1/package.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/lib-satysfi/packages/code/code.0.0.1/package.satysfi-lock-expected
+++ b/lib-satysfi/packages/code/code.0.0.1/package.satysfi-lock-expected
@@ -3,14 +3,14 @@ locks:
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/lib-satysfi/packages/footnote-scheme/footnote-scheme.0.0.1/package.satysfi-lock-expected
+++ b/lib-satysfi/packages/footnote-scheme/footnote-scheme.0.0.1/package.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/lib-satysfi/packages/itemize/itemize.0.0.1/package.satysfi-lock-expected
+++ b/lib-satysfi/packages/itemize/itemize.0.0.1/package.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/lib-satysfi/packages/math/math.0.0.1/package.satysfi-lock-expected
+++ b/lib-satysfi/packages/math/math.0.0.1/package.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/lib-satysfi/packages/md-ja/md-ja.0.0.1/package.satysfi-lock-expected
+++ b/lib-satysfi/packages/md-ja/md-ja.0.0.1/package.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: annot.0.0.1
   location:
     type: global
-    path: ./packages/annot/annot.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/annot/annot.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -11,7 +11,7 @@ locks:
 - name: code.0.0.1
   location:
     type: global
-    path: ./packages/code/code.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/code/code.0.0.1
   dependencies:
   - stdlib.0.0.1
   - font-latin-modern.0.0.1
@@ -20,35 +20,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: footnote-scheme.0.0.1
   location:
     type: global
-    path: ./packages/footnote-scheme/footnote-scheme.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/footnote-scheme/footnote-scheme.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -56,7 +56,7 @@ locks:
 - name: itemize.0.0.1
   location:
     type: global
-    path: ./packages/itemize/itemize.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/itemize/itemize.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -64,7 +64,7 @@ locks:
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -72,7 +72,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/lib-satysfi/packages/proof/proof.0.0.1/package.satysfi-lock-expected
+++ b/lib-satysfi/packages/proof/proof.0.0.1/package.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/lib-satysfi/packages/std-ja-book/std-ja-book.0.0.1/package.satysfi-lock-expected
+++ b/lib-satysfi/packages/std-ja-book/std-ja-book.0.0.1/package.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: annot.0.0.1
   location:
     type: global
-    path: ./packages/annot/annot.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/annot/annot.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -11,7 +11,7 @@ locks:
 - name: code.0.0.1
   location:
     type: global
-    path: ./packages/code/code.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/code/code.0.0.1
   dependencies:
   - stdlib.0.0.1
   - font-latin-modern.0.0.1
@@ -20,35 +20,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: footnote-scheme.0.0.1
   location:
     type: global
-    path: ./packages/footnote-scheme/footnote-scheme.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/footnote-scheme/footnote-scheme.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -56,7 +56,7 @@ locks:
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -64,7 +64,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/lib-satysfi/packages/std-ja-report/std-ja-report.0.0.1/package.satysfi-lock-expected
+++ b/lib-satysfi/packages/std-ja-report/std-ja-report.0.0.1/package.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: annot.0.0.1
   location:
     type: global
-    path: ./packages/annot/annot.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/annot/annot.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -11,7 +11,7 @@ locks:
 - name: code.0.0.1
   location:
     type: global
-    path: ./packages/code/code.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/code/code.0.0.1
   dependencies:
   - stdlib.0.0.1
   - font-latin-modern.0.0.1
@@ -20,35 +20,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: footnote-scheme.0.0.1
   location:
     type: global
-    path: ./packages/footnote-scheme/footnote-scheme.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/footnote-scheme/footnote-scheme.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -56,7 +56,7 @@ locks:
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -64,7 +64,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/lib-satysfi/packages/std-ja/std-ja.0.0.1/package.satysfi-lock-expected
+++ b/lib-satysfi/packages/std-ja/std-ja.0.0.1/package.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: annot.0.0.1
   location:
     type: global
-    path: ./packages/annot/annot.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/annot/annot.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -11,7 +11,7 @@ locks:
 - name: code.0.0.1
   location:
     type: global
-    path: ./packages/code/code.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/code/code.0.0.1
   dependencies:
   - stdlib.0.0.1
   - font-latin-modern.0.0.1
@@ -20,35 +20,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -56,7 +56,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/package.satysfi-lock-expected
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/package.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: testing.0.0.1
   location:
     type: global
-    path: ./packages/testing/testing.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/testing/testing.0.0.1
   dependencies: []
   test_only: true
   lock_package_name: testing

--- a/lib-satysfi/packages/tabular/tabular.0.0.1/package.satysfi-lock-expected
+++ b/lib-satysfi/packages/tabular/tabular.0.0.1/package.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/promote-lock-of-packages.sh
+++ b/promote-lock-of-packages.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+for FILE in $(find lib-satysfi -name satysfi.yaml); do
+    DIR="$(dirname "$FILE")"
+    cp "$DIR/package.satysfi-lock" "$DIR/package.satysfi-lock-expected"
+done

--- a/src/frontend/configError.ml
+++ b/src/frontend/configError.ml
@@ -30,6 +30,7 @@ type yaml_error =
       registry_hash_value : registry_hash_value;
     }
   | CannotBeUsedAsAName of YamlDecoder.context * string
+  | UnsupportedConfigFormat of string
   | NotACommand of {
       context : YamlDecoder.context;
       prefix  : char;
@@ -116,6 +117,13 @@ type config_error =
       path     : abs_path;
       expected : string;
       got      : string;
+    }
+  | TarGzipChecksumMismatch of {
+      lock_name : lock_name;
+      url       : string;
+      path      : abs_path;
+      expected  : string;
+      got       : string;
     }
   | FailedToExtractExternalZip of {
       exit_status : int;

--- a/src/frontend/lockFetcher.ml
+++ b/src/frontend/lockFetcher.ml
@@ -54,9 +54,12 @@ let main ~(wget_command : string) ~(tar_command : string) ~(unzip_command : stri
   let ImplSpec{ lock_name; registry_hash_value; container_directory; source } = impl_spec in
   let absdirstr_container = get_abs_path_string container_directory in
   let absdir_lock_root = make_abs_path (Filename.concat absdirstr_container lock_name) in
+  let absdir_lock_cache_of_registry =
+    make_abs_path (Filename.concat (get_abs_path_string absdir_lock_cache) registry_hash_value)
+  in
 
   (* Creates the lock cache directory if non-existent, or does nothing otherwise: *)
-  ShellCommand.mkdir_p absdir_lock_cache;
+  ShellCommand.mkdir_p absdir_lock_cache_of_registry;
 
   (* Creates the directory if non-existent, or does nothing otherwise: *)
   ShellCommand.mkdir_p absdir_lock_root;
@@ -78,7 +81,7 @@ let main ~(wget_command : string) ~(tar_command : string) ~(unzip_command : stri
         let abspath_tarball =
           make_abs_path
             (Filename.concat
-              (Filename.concat (get_abs_path_string absdir_lock_cache) registry_hash_value)
+              (get_abs_path_string absdir_lock_cache_of_registry)
               (Printf.sprintf "%s.tar.gz" lock_name))
         in
         let* () =

--- a/src/frontend/lockFetcher.ml
+++ b/src/frontend/lockFetcher.ml
@@ -124,7 +124,7 @@ let main ~(wget_command : string) ~(tar_command : string) ~(unzip_command : stri
 
                 (* Creates a directory for putting zips: *)
                 let absdir_external =
-                  make_abs_path (Filename.concat (get_abs_path_string absdir_lock_cache) lock_name)
+                  make_abs_path (Filename.concat (get_abs_path_string absdir_lock_cache_of_registry) lock_name)
                 in
                 ShellCommand.mkdir_p absdir_external;
 

--- a/src/frontend/lockFetcher.ml
+++ b/src/frontend/lockFetcher.ml
@@ -51,7 +51,7 @@ let extract_external_zip ~(unzip_command : string) ~(zip : abs_path) ~(output_co
 
 let main ~(wget_command : string) ~(tar_command : string) ~(unzip_command : string) ~cache_directory:(absdir_lock_cache : abs_path) (impl_spec : implementation_spec) : unit ok =
   let open ResultMonad in
-  let ImplSpec{ lock_name; container_directory; source } = impl_spec in
+  let ImplSpec{ lock_name; registry_hash_value; container_directory; source } = impl_spec in
   let absdirstr_container = get_abs_path_string container_directory in
   let absdir_lock_root = make_abs_path (Filename.concat absdirstr_container lock_name) in
 
@@ -77,7 +77,9 @@ let main ~(wget_command : string) ~(tar_command : string) ~(unzip_command : stri
         (* Synchronously fetches a tarball: *)
         let abspath_tarball =
           make_abs_path
-            (Filename.concat (get_abs_path_string absdir_lock_cache) (Printf.sprintf "%s.tar.gz" lock_name))
+            (Filename.concat
+              (Filename.concat (get_abs_path_string absdir_lock_cache) registry_hash_value)
+              (Printf.sprintf "%s.tar.gz" lock_name))
         in
         let* () =
           if Sys.file_exists (get_abs_path_string abspath_tarball) then begin

--- a/src/frontend/logging.ml
+++ b/src/frontend/logging.ml
@@ -128,7 +128,7 @@ let show_package_dependency_before_solving (dependencies_with_flags : (dependenc
 let show_package_dependency_solutions (solutions : package_solution list) =
   Printf.printf "  package dependency solutions:\n";
     solutions |> List.iter (fun solution ->
-      let Lock.{ package_name; locked_version } = solution.lock in
+      let Lock.{ package_name; locked_version; _ } = solution.lock in
       Printf.printf "  - %s %s\n" package_name (SemanticVersion.to_string locked_version)
   )
 

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -1915,7 +1915,7 @@ type solve_input =
 
 
 let make_lock_name (lock : Lock.t) : lock_name =
-  let Lock.{ package_name; locked_version } = lock in
+  let Lock.{ package_name; locked_version; _ } = lock in
   Printf.sprintf "%s.%s" package_name (SemanticVersion.to_string locked_version)
 
 
@@ -1923,8 +1923,10 @@ let convert_solutions_to_lock_config (solutions : package_solution list) : LockC
   let (locked_package_acc, impl_spec_acc) =
     solutions |> List.fold_left (fun (locked_package_acc, impl_spec_acc) solution ->
       let lock_name = make_lock_name solution.lock in
-      let Lock.{ package_name; _ } = solution.lock in
-      let libpathstr_container = Printf.sprintf "./%s/%s/" Constant.packages_directory package_name in
+      let Lock.{ package_name; registry_hash_value; _ } = solution.lock in
+      let libpathstr_container =
+        Printf.sprintf "./%s/%s/%s/" Constant.packages_directory registry_hash_value package_name
+      in
       let libpathstr_lock = Filename.concat libpathstr_container lock_name in
       let lock_location =
         LockConfig.GlobalLocation{
@@ -2133,7 +2135,7 @@ let solve
               |> Result.map_error (fun e -> PackageRegistryFetcherError(e))
           in
 
-          let* PackageRegistryConfig.{ packages } =
+          let* PackageRegistryConfig.{ packages = packages_in_registry } =
             let abspath_registry_config =
               make_abs_path
                 (Filename.concat
@@ -2142,7 +2144,8 @@ let solve
             in
             PackageRegistryConfig.load abspath_registry_config
           in
-          return (registries |> RegistryLocalNameMap.add registry_local_name packages)
+          let registry_spec = { packages_in_registry; registry_hash_value } in
+          return (registries |> RegistryLocalNameMap.add registry_local_name registry_spec)
 
         ) registry_specs (return RegistryLocalNameMap.empty)
       in

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -1951,6 +1951,7 @@ let convert_solutions_to_lock_config (solutions : package_solution list) : LockC
         in
         ImplSpec{
           lock_name           = lock_name;
+          registry_hash_value = registry_hash_value;
           container_directory = abspath_container;
           source              = solution.locked_source;
         }

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -861,6 +861,9 @@ let make_yaml_error_lines : yaml_error -> line list = function
   | CannotBeUsedAsAName(yctx, s) ->
       [ NormalLine(Printf.sprintf "'%s' cannot be used as a name%s" s (show_yaml_context yctx)) ]
 
+  | UnsupportedConfigFormat(format) ->
+      [ NormalLine(Printf.sprintf "unsupported config format '%s'" format) ]
+
   | NotACommand{ context = yctx; prefix = _; string = s } ->
       [ NormalLine(Printf.sprintf "not a command: '%s'%s" s (show_yaml_context yctx)) ]
 
@@ -1222,6 +1225,16 @@ let report_config_error : config_error -> unit = function
   | ExternalZipChecksumMismatch{ url; path; expected; got } ->
       report_error Interface [
         NormalLine("checksum mismatch of an external zip file.");
+        DisplayLine(Printf.sprintf "- fetched from: '%s'" url);
+        DisplayLine(Printf.sprintf "- path: '%s'" (get_abs_path_string path));
+        DisplayLine(Printf.sprintf "- expected: '%s'" expected);
+        DisplayLine(Printf.sprintf "- got: '%s'" got);
+      ]
+
+  | TarGzipChecksumMismatch{ lock_name; url; path; expected; got } ->
+      report_error Interface [
+        NormalLine("checksum mismatch of a tarball.");
+        DisplayLine(Printf.sprintf "- lock name: '%s'" lock_name);
         DisplayLine(Printf.sprintf "- fetched from: '%s'" url);
         DisplayLine(Printf.sprintf "- path: '%s'" (get_abs_path_string path));
         DisplayLine(Printf.sprintf "- expected: '%s'" expected);

--- a/src/frontend/packageSystemBase.ml
+++ b/src/frontend/packageSystemBase.ml
@@ -108,6 +108,7 @@ type dependency_flag =
 type implementation_spec =
   | ImplSpec of {
       lock_name           : lock_name;
+      registry_hash_value : registry_hash_value;
       container_directory : abs_path;
       source              : implementation_source;
     }

--- a/src/frontend/packageSystemBase.ml
+++ b/src/frontend/packageSystemBase.ml
@@ -17,23 +17,6 @@ module PackageNameMap = Map.Make(String)
 
 module PackageNameSet = Set.Make(String)
 
-module Lock = struct
-  type t = {
-    package_name   : package_name;
-    locked_version : SemanticVersion.t;
-  }
-  [@@deriving show { with_path = false }]
-
-  let compare (lock1 : t) (lock2 : t) : int =
-    let { package_name = s1; locked_version = v1 } = lock1 in
-    let { package_name = s2; locked_version = v2 } = lock2 in
-    match String.compare s1 s2 with
-    | 0       -> SemanticVersion.compare v1 v2
-    | nonzero -> nonzero
-end
-
-module LockMap = Map.Make(Lock)
-
 (* The type for names that stand for a package registry.
    Names of this type are supposed to be valid
    within the scope of one package config file. *)
@@ -47,6 +30,23 @@ type registry_hash_value = string
 [@@deriving show { with_path = false }]
 
 module RegistryHashValueMap = Map.Make(String)
+
+module Lock = struct
+  type t = {
+    package_name        : package_name;
+    locked_version      : SemanticVersion.t;
+    registry_hash_value : registry_hash_value;
+  }
+  [@@deriving show { with_path = false }]
+
+  let compare (lock1 : t) (lock2 : t) : int =
+    let { registry_hash_value = h1; package_name = p1; locked_version = v1 } = lock1 in
+    let { registry_hash_value = h2; package_name = p2; locked_version = v2 } = lock2 in
+    List.compare String.compare
+      [ h1; p1; SemanticVersion.to_string v1 ] [ h2; p2; SemanticVersion.to_string v2 ]
+end
+
+module LockMap = Map.Make(Lock)
 
 type package_dependency =
   | PackageDependency of {
@@ -79,8 +79,13 @@ type implementation_record =
       dependencies         : package_dependency_in_registry list;
     }
 
+type registry_spec = {
+  packages_in_registry : (implementation_record list) PackageNameMap.t;
+  registry_hash_value  : registry_hash_value;
+}
+
 type package_context = {
-  registries : ((implementation_record list) PackageNameMap.t) RegistryLocalNameMap.t;
+  registries : registry_spec RegistryLocalNameMap.t;
 }
 
 type package_solution = {

--- a/src/frontend/packageSystemBase.ml
+++ b/src/frontend/packageSystemBase.ml
@@ -66,7 +66,8 @@ type package_dependency_in_registry =
 type implementation_source =
   | NoSource
   | TarGzip of {
-      url : string;
+      url      : string;
+      checksum : string;
     }
 [@@deriving show { with_path = false }]
 

--- a/test/misc/packageConstraintSolverTest.ml
+++ b/test/misc/packageConstraintSolverTest.ml
@@ -5,6 +5,10 @@ module Constant = Main__Constant
 module PackageConstraintSolver = Main__PackageConstraintSolver
 
 
+let registry_hash_value =
+  "c0bebeef4423"
+
+
 let make_version (s_version : string) : SemanticVersion.t =
   match SemanticVersion.parse s_version with
   | Some(semver) -> semver
@@ -38,6 +42,7 @@ let make_impl (s_version : string) (deps : package_dependency_in_registry list) 
 let make_lock (package_name : package_name) (s_version : string) : Lock.t =
   Lock.{
     package_name;
+    registry_hash_value = registry_hash_value;
     locked_version = make_version s_version;
   }
 
@@ -58,7 +63,7 @@ let check package_context dependencies_with_flags expected =
 
 let solve_test_1 () =
   let package_context =
-    let packages =
+    let packages_in_registry =
       PackageNameMap.of_seq @@ List.to_seq [
         ("foo", [
           make_impl "1.0.0" [];
@@ -72,7 +77,8 @@ let solve_test_1 () =
         ]);
       ]
     in
-    { registries = RegistryLocalNameMap.singleton "default" packages }
+    let registry_spec = { packages_in_registry; registry_hash_value } in
+    { registries = RegistryLocalNameMap.singleton "default" registry_spec }
   in
   let dependencies_with_flags =
     [
@@ -97,7 +103,7 @@ let solve_test_1 () =
 
 let solve_test_2 () =
   let package_context =
-    let packages =
+    let packages_in_registry =
       PackageNameMap.of_seq @@ List.to_seq [
         ("foo", [
           make_impl "1.0.0" [];
@@ -111,7 +117,8 @@ let solve_test_2 () =
         ]);
       ]
     in
-    { registries = RegistryLocalNameMap.singleton "default" packages }
+    let registry_spec = { packages_in_registry; registry_hash_value } in
+    { registries = RegistryLocalNameMap.singleton "default" registry_spec }
   in
   let dependencies_with_flags =
     [

--- a/tests/clip.satysfi-lock-expected
+++ b/tests/clip.satysfi-lock-expected
@@ -3,35 +3,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -39,7 +39,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/tests/glue1.satysfi-lock-expected
+++ b/tests/glue1.satysfi-lock-expected
@@ -3,35 +3,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -39,7 +39,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/tests/images/test.satysfi-lock-expected
+++ b/tests/images/test.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: annot.0.0.1
   location:
     type: global
-    path: ./packages/annot/annot.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/annot/annot.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -11,7 +11,7 @@ locks:
 - name: code.0.0.1
   location:
     type: global
-    path: ./packages/code/code.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/code/code.0.0.1
   dependencies:
   - stdlib.0.0.1
   - font-latin-modern.0.0.1
@@ -20,35 +20,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: itemize.0.0.1
   location:
     type: global
-    path: ./packages/itemize/itemize.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/itemize/itemize.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -56,7 +56,7 @@ locks:
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -64,7 +64,7 @@ locks:
 - name: std-ja.0.0.1
   location:
     type: global
-    path: ./packages/std-ja/std-ja.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/std-ja/std-ja.0.0.1
   dependencies:
   - stdlib.0.0.1
   - math.0.0.1
@@ -79,7 +79,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/tests/macro1.satysfi-lock-expected
+++ b/tests/macro1.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: annot.0.0.1
   location:
     type: global
-    path: ./packages/annot/annot.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/annot/annot.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -11,7 +11,7 @@ locks:
 - name: code.0.0.1
   location:
     type: global
-    path: ./packages/code/code.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/code/code.0.0.1
   dependencies:
   - stdlib.0.0.1
   - font-latin-modern.0.0.1
@@ -20,35 +20,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: footnote-scheme.0.0.1
   location:
     type: global
-    path: ./packages/footnote-scheme/footnote-scheme.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/footnote-scheme/footnote-scheme.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -56,7 +56,7 @@ locks:
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -64,7 +64,7 @@ locks:
 - name: std-ja-report.0.0.1
   location:
     type: global
-    path: ./packages/std-ja-report/std-ja-report.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/std-ja-report/std-ja-report.0.0.1
   dependencies:
   - stdlib.0.0.1
   - math.0.0.1
@@ -80,7 +80,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/tests/math-typefaces.satysfi-lock-expected
+++ b/tests/math-typefaces.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: annot.0.0.1
   location:
     type: global
-    path: ./packages/annot/annot.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/annot/annot.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -11,7 +11,7 @@ locks:
 - name: code.0.0.1
   location:
     type: global
-    path: ./packages/code/code.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/code/code.0.0.1
   dependencies:
   - stdlib.0.0.1
   - font-latin-modern.0.0.1
@@ -20,35 +20,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: footnote-scheme.0.0.1
   location:
     type: global
-    path: ./packages/footnote-scheme/footnote-scheme.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/footnote-scheme/footnote-scheme.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -56,7 +56,7 @@ locks:
 - name: itemize.0.0.1
   location:
     type: global
-    path: ./packages/itemize/itemize.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/itemize/itemize.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -64,7 +64,7 @@ locks:
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -72,7 +72,7 @@ locks:
 - name: std-ja-report.0.0.1
   location:
     type: global
-    path: ./packages/std-ja-report/std-ja-report.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/std-ja-report/std-ja-report.0.0.1
   dependencies:
   - stdlib.0.0.1
   - math.0.0.1
@@ -88,7 +88,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/tests/math2.satysfi-lock-expected
+++ b/tests/math2.satysfi-lock-expected
@@ -3,35 +3,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -39,7 +39,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/tests/md/test.satysfi-lock-expected
+++ b/tests/md/test.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: annot.0.0.1
   location:
     type: global
-    path: ./packages/annot/annot.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/annot/annot.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -11,7 +11,7 @@ locks:
 - name: code.0.0.1
   location:
     type: global
-    path: ./packages/code/code.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/code/code.0.0.1
   dependencies:
   - stdlib.0.0.1
   - font-latin-modern.0.0.1
@@ -20,35 +20,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: footnote-scheme.0.0.1
   location:
     type: global
-    path: ./packages/footnote-scheme/footnote-scheme.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/footnote-scheme/footnote-scheme.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -56,7 +56,7 @@ locks:
 - name: itemize.0.0.1
   location:
     type: global
-    path: ./packages/itemize/itemize.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/itemize/itemize.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -64,7 +64,7 @@ locks:
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -72,7 +72,7 @@ locks:
 - name: md-ja.0.0.1
   location:
     type: global
-    path: ./packages/md-ja/md-ja.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/md-ja/md-ja.0.0.1
   dependencies:
   - stdlib.0.0.1
   - math.0.0.1
@@ -89,7 +89,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/tests/refactor1.satysfi-lock-expected
+++ b/tests/refactor1.satysfi-lock-expected
@@ -3,28 +3,28 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -32,7 +32,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib

--- a/tests/refactor2.satysfi-lock-expected
+++ b/tests/refactor2.satysfi-lock-expected
@@ -3,21 +3,21 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math

--- a/tests/refactor3.satysfi-lock-expected
+++ b/tests/refactor3.satysfi-lock-expected
@@ -3,21 +3,21 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math

--- a/tests/refactor5.satysfi-lock-expected
+++ b/tests/refactor5.satysfi-lock-expected
@@ -3,21 +3,21 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math

--- a/tests/staged1.satysfi-lock-expected
+++ b/tests/staged1.satysfi-lock-expected
@@ -3,7 +3,7 @@ locks:
 - name: annot.0.0.1
   location:
     type: global
-    path: ./packages/annot/annot.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/annot/annot.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -11,7 +11,7 @@ locks:
 - name: code.0.0.1
   location:
     type: global
-    path: ./packages/code/code.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/code/code.0.0.1
   dependencies:
   - stdlib.0.0.1
   - font-latin-modern.0.0.1
@@ -20,35 +20,35 @@ locks:
 - name: font-ipa-ex.0.0.1
   location:
     type: global
-    path: ./packages/font-ipa-ex/font-ipa-ex.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-ipa-ex/font-ipa-ex.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-ipa-ex
 - name: font-junicode.0.0.1
   location:
     type: global
-    path: ./packages/font-junicode/font-junicode.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-junicode/font-junicode.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-junicode
 - name: font-latin-modern.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern/font-latin-modern.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern/font-latin-modern.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern
 - name: font-latin-modern-math.0.0.1
   location:
     type: global
-    path: ./packages/font-latin-modern-math/font-latin-modern-math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/font-latin-modern-math/font-latin-modern-math.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: font-latin-modern-math
 - name: math.0.0.1
   location:
     type: global
-    path: ./packages/math/math.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/math/math.0.0.1
   dependencies:
   - stdlib.0.0.1
   test_only: false
@@ -56,7 +56,7 @@ locks:
 - name: std-ja.0.0.1
   location:
     type: global
-    path: ./packages/std-ja/std-ja.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/std-ja/std-ja.0.0.1
   dependencies:
   - stdlib.0.0.1
   - math.0.0.1
@@ -71,7 +71,7 @@ locks:
 - name: stdlib.0.0.1
   location:
     type: global
-    path: ./packages/stdlib/stdlib.0.0.1
+    path: ./packages/d9b4b850ab61a7b68961c6315048b351/stdlib/stdlib.0.0.1
   dependencies: []
   test_only: false
   lock_package_name: stdlib


### PR DESCRIPTION
`satysfi-registry.yaml`:

```diff
+format: "1"
 packages:
 - name: "annot"
   implementations:
   ...
```

Library root:

```
$LIBROOT/packages
└── d9b4b850ab61a7b68961c6315048b351
    ├── annot
    │   └── annot.0.0.1
    │       ├── package.satysfi-lock
    │       ├── package.satysfi-lock-expected
    │       ├── satysfi.yaml
    │       └── src
    │           └── annot.satyh
    ...
```

```
$LIBROOT/cache
└── locks
    ├── d9b4b850ab61a7b68961c6315048b351
    │   ├── annot.0.0.1.tar.gz
    │   ├── code.0.0.1.tar.gz
    ...
```