### PR TITLE
Fix behavior `clear-page` in multi-column

### DIFF
--- a/lib-satysfi/dist/packages/standalone-multicolumn.satyh
+++ b/lib-satysfi/dist/packages/standalone-multicolumn.satyh
@@ -5,7 +5,7 @@ let-inline ctx \math m =
   embed-math ctx m
 
 let standalone n bt =
-  let multisep = 5pt in
+  let multisep = 20pt in
   let all-text-width = 440pt in
   let one-column-width =
     (all-text-width -' (multisep *' float (n - 1))) *' (1.0 /. float n)

--- a/lib-satysfi/dist/packages/standalone-multicolumn.satyh
+++ b/lib-satysfi/dist/packages/standalone-multicolumn.satyh
@@ -1,0 +1,39 @@
+
+let-block ctx +p it = line-break true true ctx (read-inline ctx it ++ inline-fil)
+
+let-inline ctx \math m =
+  embed-math ctx m
+
+let standalone n bt =
+  let multisep = 5pt in
+  let all-text-width = 440pt in
+  let one-column-width =
+    (all-text-width -' (multisep *' float (n - 1))) *' (1.0 /. float n)
+  in
+  let shifts =
+    let-rec sub m =
+      if n == m then
+        []
+      else
+        ((one-column-width +' multisep) *' float m) :: sub (m + 1)
+    in
+    sub 1
+  in
+  let ctx =
+    get-initial-context one-column-width (command \math)
+      |> set-dominant-narrow-script Latin
+      |> set-dominant-wide-script Kana
+  in
+  let bb = read-block ctx bt in
+  page-break-multicolumn A4Paper shifts (fun () -> block-nil) (fun () -> block-nil)
+    (fun _ -> (|
+      text-origin = (80pt, 100pt);
+      text-height = 630pt;
+    |))
+    (fun _ -> (|
+      header-origin  = (0pt, 0pt);
+      header-content = block-nil;
+      footer-origin  = (0pt, 0pt);
+      footer-content = block-nil;
+    |))
+    bb

--- a/src/backend/horzBox.ml
+++ b/src/backend/horzBox.ml
@@ -343,6 +343,7 @@ and vert_box =
       [@printer (fun fmt _ -> Format.fprintf fmt "Breakable")]
   | VertFrame          of margins * paddings * decoration * decoration * decoration * decoration * length * vert_box list
 (*      [@printer (fun fmt (_, _, _, _, _, imvblst) -> Format.fprintf fmt "%a" (pp_list pp_intermediate_vert_box) imvblst)] *)
+  | VertClearColumn
   | VertClearPage
   | VertHookPageBreak of (page_break_info -> point -> unit)
 

--- a/src/frontend/primitives.cppo.ml
+++ b/src/frontend/primitives.cppo.ml
@@ -593,6 +593,7 @@ let pdf_mode_table =
       ("inline-nil", ~% tIB, (fun _ -> base (BCHorz([])))                               );
       ("omit-skip-after", ~% tIB, (fun _ -> base (BCHorz(HorzBox.([HorzOmitSkipAfter])))));
       ("block-nil" , ~% tBB, (fun _ -> base (BCVert([])))                               );
+      ("clear-column", ~% tBB, (fun _ -> base (BCVert(HorzBox.([VertClearColumn]))))        );
       ("clear-page", ~% tBB, (fun _ -> base (BCVert(HorzBox.([VertClearPage]))))        );
 
 #include "__primitives_pdf_mode.gen.ml"

--- a/tests/multicolumn.saty
+++ b/tests/multicolumn.saty
@@ -1,0 +1,15 @@
+@require: standalone-multicolumn
+
+let-block ctx +clear-page = clear-page
+let-block ctx +clear-column = clear-column
+
+in
+
+standalone 3 '<
+  +p{test}
+  +clear-column;
+  +p{test}
+  +p{test}
+  +clear-page;
+  +p{test}
+>


### PR DESCRIPTION
Issue: `clear-page` breaks *columns* in multi-column format
Expectation: `clear-page` breaks *pages* in multi-column format

This PR fixed this issue:
- Change the behavior of `clear-page` primitive
- Add a new `clear-column` primitive

Demo of column and page breaks in 3 columns format (`tests/multicolumn.saty`):

```
standalone 3 '<
  +p{test}
  +clear-column;
  +p{test}
  +p{test}
  +clear-page;
  +p{test}
>
```

<img width="719" alt="キャプチャ" src="https://user-images.githubusercontent.com/36466996/224233250-4526ad52-4c65-4019-832c-68e069ab7708.png">
