### PR TITLE
Update URLs to Latin Modern fonts

### DIFF
--- a/download-fonts.sh
+++ b/download-fonts.sh
@@ -46,12 +46,12 @@ download_file () {
 
 # Latin Modern
 NAME=lm2.004otf
-download_file "$NAME.zip" "http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
+download_file "$NAME.zip" "https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip"
 unzip -o "$CACHE/$NAME.zip" "*.otf" -d lib-satysfi/dist/fonts/
 
 # Latin Modern Math
 NAME=latinmodern-math-1959
-download_file "$NAME.zip" "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
+download_file "$NAME.zip" "https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip"
 unzip -o "$CACHE/$NAME.zip" "*.otf" -d "$CACHE/"
 cp "$CACHE"/latinmodern-math-1959/otf/latinmodern-math.otf lib-satysfi/dist/fonts/
 


### PR DESCRIPTION
Related to #411.

> It seems that download-fonts.sh is designated to use HTTP when it installs math fonts from GUST, while those items can be downloaded with not HTTP but HTTPS at least with my curl and httpie.

In this PR, `http://www.gust.org.pl/**` in `download-fonts.sh` is replaced with `https://www.gust.org.pl/**`.

Before:
```
$ ./download-fonts.sh
[download-fonts.sh] Using shasum.
shasum: lm2.004otf.zip.sha1: No such file or directory
[download-fonts.sh] downloading 'lm2.004otf.zip' ....
--2023-07-12 16:19:53--  http://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip
Resolving www.gust.org.pl (www.gust.org.pl)... 158.75.62.7
Connecting to www.gust.org.pl (www.gust.org.pl)|158.75.62.7|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2023-07-12 16:19:54 ERROR 404: Not Found.
```

After:
```
$ ./download-fonts.sh
[download-fonts.sh] Using shasum.
shasum: lm2.004otf.zip.sha1: No such file or directory
[download-fonts.sh] downloading 'lm2.004otf.zip' ....
--2023-07-12 16:20:56--  https://www.gust.org.pl/projects/e-foundry/latin-modern/download/lm2.004otf.zip
Resolving www.gust.org.pl (www.gust.org.pl)... 158.75.62.7
Connecting to www.gust.org.pl (www.gust.org.pl)|158.75.62.7|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 3907819 (3.7M) [application/zip]
Saving to: ‘temp/lm2.004otf.zip’

temp/lm2.004otf.zip                        100%[======================================================================================>]   3.73M  2.29MB/s    in 1.6s    

2023-07-12 16:20:58 (2.29 MB/s) - ‘temp/lm2.004otf.zip’ saved [3907819/3907819]

[download-fonts.sh] finished downloading 'lm2.004otf.zip'..
Archive:  temp/lm2.004otf.zip

--------omitted--------

[download-fonts.sh] downloading 'latinmodern-math-1959.zip' ....
--2023-07-12 16:20:58--  https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip
Resolving www.gust.org.pl (www.gust.org.pl)... 158.75.62.7
Connecting to www.gust.org.pl (www.gust.org.pl)|158.75.62.7|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 576413 (563K) [application/zip]
Saving to: ‘temp/latinmodern-math-1959.zip’

temp/latinmodern-math-1959.zip             100%[======================================================================================>] 562.90K   623KB/s    in 0.9s    

2023-07-12 16:21:00 (623 KB/s) - ‘temp/latinmodern-math-1959.zip’ saved [576413/576413]

[download-fonts.sh] finished downloading 'latinmodern-math-1959.zip'..
Archive:  temp/latinmodern-math-1959.zip
  inflating: temp/latinmodern-math-1959/otf/latinmodern-math.otf  

--------omitted--------

[download-fonts.sh] end..
```