### PR TITLE
Allow importing submodules in use statement

### DIFF
--- a/demo/demo.saty
+++ b/demo/demo.saty
@@ -20,6 +20,7 @@
   ],
 |)]
 use package open Stdlib
+use package open Stdlib.Pervasives
 use package open Math
 use package open Annot
 use package open Code
@@ -29,7 +30,6 @@ use package Tabular
 use package open StdJaBook
 use open Local of `./local`
 
-let open Pervasives in
 document ?(
   show-toc = true,
 ) (|

--- a/demo/local.satyh
+++ b/demo/local.satyh
@@ -1,15 +1,12 @@
-use package Stdlib
+use package open Stdlib.List
+use package open Stdlib.Color
+use package open Stdlib.HDecoSet
+use package open Stdlib.VDecoSet
 use package Math
 use package Code
 use package StdJaBook
 
 module Local = struct
-
-  %- TODO: remove this by using 'open'
-  module List = Stdlib.List
-  module Color = Stdlib.Color
-  module HDecoSet = Stdlib.HDecoSet
-  module VDecoSet = Stdlib.VDecoSet
 
 
   val inline ctx \gray inner =

--- a/demo/local.satyh
+++ b/demo/local.satyh
@@ -1,7 +1,7 @@
-use package open Stdlib.List
-use package open Stdlib.Color
-use package open Stdlib.HDecoSet
-use package open Stdlib.VDecoSet
+use package Stdlib.List
+use package Stdlib.Color
+use package Stdlib.HDecoSet
+use package Stdlib.VDecoSet
 use package Math
 use package Code
 use package StdJaBook

--- a/doc/doc-lang.saty
+++ b/doc/doc-lang.saty
@@ -16,11 +16,11 @@
   ],
 |)]
 use package open Stdlib
+use package open Stdlib.Pervasives
 use package open StdJa
 use package open Math
 use open LocalMath of `local-math`
 
-let open Pervasives in
 document (|
   title = {\SATySFi;言語仕様},
   author = {Takashi SUWA},

--- a/doc/doc-primitives.saty
+++ b/doc/doc-primitives.saty
@@ -16,14 +16,13 @@
     (| name = `std-ja-book`, registry = `default`, requirement = `^0.0.1` |),
   ],
 |)]
-use package open Stdlib
+use package open Stdlib.Pervasives
 use package open Math
 use package open Itemize
 use package open StdJaBook
 use open Local of `local`
 use open LocalMath of `local-math`
 
-let open Pervasives in
 document ?(
   show-toc = true,
 ) (|

--- a/doc/math1.saty
+++ b/doc/math1.saty
@@ -18,12 +18,11 @@
   ],
 |)]
 use package open Stdlib
+use package open Stdlib.Pervasives
 use package open Math
 use package open Proof
 use package open Tabular
 use package open StdJa
-
-let open Pervasives in
 
 let math ctx \overwrite mf ma mb =
   read-math ctx ${#mf\sqbracket{#ma \mapsto #mb}}

--- a/src/frontend/closedFileDependencyResolver.ml
+++ b/src/frontend/closedFileDependencyResolver.ml
@@ -34,7 +34,7 @@ let main (utlibs : (abs_path * untyped_library_file) list) : ((abs_path * untype
       let (_attrs, header, _) = utlib in
       header |> foldM (fun graph headerelem ->
         match headerelem with
-        | HeaderUse{ module_name = (rng, modnm_sub); _ } ->
+        | HeaderUse{ mod_chain = (_, ((rng, modnm_sub), _)); _ } ->
             begin
               match graph |> SourceModuleDependencyGraph.get_vertex modnm_sub with
               | None ->
@@ -48,8 +48,8 @@ let main (utlibs : (abs_path * untyped_library_file) list) : ((abs_path * untype
         | HeaderUsePackage(_) ->
             return graph
 
-        | HeaderUseOf{ module_name = modident; _ } ->
-            err @@ CannotUseHeaderUseOf(modident)
+        | HeaderUseOf{ mod_chain; _ } ->
+            err @@ CannotUseHeaderUseOf(mod_chain)
 
       ) graph
     ) graph

--- a/src/frontend/configError.ml
+++ b/src/frontend/configError.ml
@@ -53,8 +53,8 @@ type config_error =
   | CannotReadFileOwingToSystem     of string
   | LibraryContainsWholeReturnValue of abs_path
   | DocumentLacksWholeReturnValue   of abs_path
-  | CannotUseHeaderUse              of module_name ranged
-  | CannotUseHeaderUseOf            of module_name ranged
+  | CannotUseHeaderUse              of module_name_chain ranged
+  | CannotUseHeaderUseOf            of module_name_chain ranged
   | FailedToParse                   of parse_error
   | MainModuleNameMismatch of {
       expected : module_name;

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -958,6 +958,12 @@ let report_document_attribute_error : DocumentAttribute.error -> unit = function
       ]
 
 
+let module_name_chain_to_string (((_, modnm0), modidents) : module_name_chain) =
+  let modidents = modidents |> List.map (fun (_, modnm) -> modnm) in
+  let modidents = modnm0 :: modidents in
+  modidents |> String.concat "."
+
+
 let report_config_error (display_config : Logging.config) : config_error -> unit = function
   | NotADocumentFile(abspath_in, ty) ->
       let fname = Logging.show_path display_config abspath_in in
@@ -1029,13 +1035,15 @@ let report_config_error (display_config : Logging.config) : config_error -> unit
         NormalLine(Printf.sprintf "file '%s' is not a document; it lacks a return value." fname);
       ]
 
-  | CannotUseHeaderUse((rng, modnm)) ->
+  | CannotUseHeaderUse((rng, mod_chain)) ->
+      let modnm = module_name_chain_to_string mod_chain in
       report_error Interface [
         NormalLine(Printf.sprintf "at %s:" (Range.to_string rng));
         NormalLine(Printf.sprintf "cannot specify 'use %s' here; use 'use %s of ...' instead." modnm modnm);
       ]
 
-  | CannotUseHeaderUseOf((rng, modnm)) ->
+  | CannotUseHeaderUseOf((rng, mod_chain)) ->
+      let modnm = module_name_chain_to_string mod_chain in
       report_error Interface [
         NormalLine(Printf.sprintf "at %s:" (Range.to_string rng));
         NormalLine(Printf.sprintf "cannot specify 'use %s of ...' here; use 'use %s' instead." modnm modnm);

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -374,15 +374,15 @@ main_lib:
       { (modident, utsig_opt, utbinds) }
 ;
 headerelem:
-  | USE; PACKAGE; opening=optional_open; modident=UPPER
-     { HeaderUsePackage{ opening; module_name = modident } }
-  | USE; opening=optional_open; modident=UPPER
-     { HeaderUse{ opening; module_name = modident } }
-  | USE; opening=optional_open; modident=UPPER; OF; tok=STRING
+  | USE; PACKAGE; opening=optional_open; mod_chain=mod_chain
+     { HeaderUsePackage{ opening; mod_chain } }
+  | USE; opening=optional_open; mod_chain=mod_chain
+     { HeaderUse{ opening; mod_chain } }
+  | USE; opening=optional_open; mod_chain=mod_chain; OF; tok=STRING
      {
        let (_rng, str, pre, post) = tok in
        let s = omit_spaces pre post str in
-       HeaderUseOf{ opening; module_name = modident; path = s }
+       HeaderUseOf{ opening; mod_chain; path = s }
      }
 ;
 optional_open:

--- a/src/frontend/typecheckUtil.ml
+++ b/src/frontend/typecheckUtil.ml
@@ -48,9 +48,8 @@ let find_module (tyenv : Typeenv.t) ((rng, modnm) : module_name ranged) : module
       return mentry
 
 
-let find_module_chain (tyenv : Typeenv.t) ((modident0, modidents) : module_name_chain) : module_entry ok =
+let resolve_module_chain (mentry0 : module_entry) (modidents : (module_name ranged) list) : module_entry ok =
   let open ResultMonad in
-  let* mentry0 = find_module tyenv modident0 in
   modidents |> foldM (fun mentry (rng, modnm) ->
     match mentry.mod_signature with
     | ConcFunctor(fsig) ->
@@ -66,6 +65,12 @@ let find_module_chain (tyenv : Typeenv.t) ((modident0, modidents) : module_name_
               return mentry
         end
   ) mentry0
+
+
+let find_module_chain (tyenv : Typeenv.t) ((modident0, modidents) : module_name_chain) : module_entry ok =
+  let open ResultMonad in
+  let* mentry0 = find_module tyenv modident0 in
+  resolve_module_chain mentry0 modidents
 
 
 let add_to_type_environment_by_signature (ssig : StructSig.t) (tyenv : Typeenv.t) : Typeenv.t =

--- a/src/frontend/types.cppo.ml
+++ b/src/frontend/types.cppo.ml
@@ -50,22 +50,6 @@ type input_position = {
 }
 [@@deriving show { with_path = false }]
 
-type header_element =
-  | HeaderUsePackage of {
-      opening     : bool;
-      module_name : module_name ranged;
-    }
-  | HeaderUse of {
-      opening     : bool;
-      module_name : module_name ranged;
-    }
-  | HeaderUseOf of {
-      opening     : bool;
-      module_name : module_name ranged;
-      path        : string;
-    }
-[@@deriving show { with_path = false }]
-
 type quantifiability = Quantifiable | Unquantifiable
 [@@deriving show]
 
@@ -364,6 +348,22 @@ type untyped_macro_parameter =
 type module_name_chain =
   module_name ranged * (module_name ranged) list
 [@@deriving show { with_path = false; } ]
+
+type header_element =
+  | HeaderUsePackage of {
+      opening   : bool;
+      mod_chain : module_name_chain ranged;
+    }
+  | HeaderUse of {
+      opening   : bool;
+      mod_chain : module_name_chain ranged;
+    }
+  | HeaderUseOf of {
+      opening   : bool;
+      mod_chain : module_name_chain ranged;
+      path      : string;
+    }
+[@@deriving show { with_path = false }]
 
 type untyped_binding =
   untyped_binding_main ranged


### PR DESCRIPTION

Currently, in order to open submodules we need to combine `use Module` and `let open SubModule in`.
To keep consistency and make headers more simple, allow writing `use Module.SubModule` to import submodules directly.
