### PR TITLE
Avoid `camlimages.5.0.5` for an installation issue

### DIFF
--- a/satysfi.opam
+++ b/satysfi.opam
@@ -22,7 +22,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.12.0"}
   "batteries"
-  "camlimages" {>= "5.0.1"}
+  "camlimages" {>= "5.0.1" & < "5.0.5"}
   "camlpdf" {= "2.3.1+satysfi"}
   "core_kernel" {>= "v0.15"}
   "cppo" {build & >= "1.6.4" & < "1.7.0"}


### PR DESCRIPTION
An ad-hoc workaround for the following issue:

- https://github.com/gfngfn/SATySFi/issues/424