### PR TITLE
Add OCaml 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
           - 4.12.1
           - 4.13.1
           - 4.14.0
+          - 5.1.1
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION

```
Install system packages required by opam packages
  /opt/hostedtoolcache/opam/2.1.5/x86_64/opam depext satysfi
  # Detecting depexts using vars: arch=x86_64, os=linux, os-distribution=ubuntu, os-family=debian
  [ERROR] No solution for satysfi:   * No agreement on the version of ocaml:
              - (invariant) → ocaml-base-compiler >= 5.1.1 → ocaml = 5.1.1
              - satysfi → camlimages < 5.0.5 → ocaml < 5.0
              You can temporarily relax the switch invariant with `--update-invariant'
            * No agreement on the version of ocaml-base-compiler:
              - (invariant) → ocaml-base-compiler >= 5.1.1
              - satysfi → camlimages < 5.0.5 → ocaml < 4.02.0 → ocaml-base-compiler = 3.07+1
            * Missing dependency:
              - satysfi → camlimages < 5.0.5 → ocaml < 4.02.0 → ocaml-variants >= 3.12.0 → ocaml-beta
              unmet availability conditions: 'enable-ocaml-beta-repository'
```