### PR TITLE
Introduce `local` packages to Saphe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@
 obsolete/*.txt
 old/
 *.png
-satysfi
-saphe
+/satysfi
+/saphe
 *.ttf
 *.otf
 *.ttc

--- a/doc/doc-primitives.saphe.lock.yaml.expected
+++ b/doc/doc-primitives.saphe.lock.yaml.expected
@@ -108,6 +108,8 @@ locks:
     package_name: stdlib
     version: 0.0.1
 dependencies:
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-latin-modern.0.0.1
+  used_as: FontLatinModern
 - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.itemize.0.0.1
   used_as: Itemize
 - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.math.0.0.1

--- a/doc/doc-primitives.saphe.yaml
+++ b/doc/doc-primitives.saphe.yaml
@@ -31,3 +31,8 @@ contents:
           registry: "default"
           name: "std-ja-book"
           requirement: "^0.0.1"
+      - used_as: "FontLatinModern"
+        registered:
+          registry: "default"
+          name: "font-latin-modern"
+          requirement: "^0.0.1"

--- a/src-saphe/configError.ml
+++ b/src-saphe/configError.ml
@@ -151,3 +151,8 @@ type config_error =
   | NotALibraryLocalFixed of {
       dir : abs_path;
     }
+  | LocalFixedDoesNotSupportLanguageVersion of {
+      dir                  : abs_path;
+      language_version     : SemanticVersion.t;
+      language_requirement : SemanticVersion.requirement;
+    }

--- a/src-saphe/configError.ml
+++ b/src-saphe/configError.ml
@@ -148,3 +148,6 @@ type config_error =
       path    : abs_path;
       message : string;
     }
+  | NotALibraryLocalFixed of {
+      dir : abs_path;
+    }

--- a/src-saphe/configUtil.ml
+++ b/src-saphe/configUtil.ml
@@ -61,6 +61,10 @@ let dependency_spec_decoder : parsed_package_dependency_spec ConfigDecoder.t =
         version_requirement;
       }
     end;
+    "local" ==> begin
+      get "path" string >>= fun relative_path ->
+      succeed @@ ParsedLocalFixedDependency{ relative_path }
+    end;
   ]
 
 

--- a/src-saphe/constant.ml
+++ b/src-saphe/constant.ml
@@ -13,9 +13,9 @@ let lock_tarball_name (package_name : package_name) (locked_version : SemanticVe
   Printf.sprintf "%s.%s" package_name (SemanticVersion.to_string locked_version)
 
 
-let lock_directory ~store_root:(absdir_store_root : abs_path) (lock : Lock.t) : abs_path =
-  let Lock.{ package_id; locked_version } = lock in
-  let PackageId.{ registry_hash_value; package_name } = package_id in
+let registered_lock_directory ~store_root:(absdir_store_root : abs_path) (reglock : RegisteredLock.t) : abs_path =
+  let RegisteredLock.{ registered_package_id; locked_version } = reglock in
+  let RegisteredPackageId.{ registry_hash_value; package_name } = registered_package_id in
   append_to_abs_directory absdir_store_root
     (Printf.sprintf "packages/%s/%s/%s"
       registry_hash_value
@@ -23,13 +23,18 @@ let lock_directory ~store_root:(absdir_store_root : abs_path) (lock : Lock.t) : 
       (lock_tarball_name package_name locked_version))
 
 
+let lock_directory ~(store_root : abs_path) (lock : Lock.t) : abs_path =
+  match lock with
+  | Lock.Registered(reglock)         -> registered_lock_directory ~store_root reglock
+  | Lock.LocalFixed{ absolute_path } -> absolute_path
+
 (* Should be in sync with SATySFi *)
 let envelope_config_path ~dir:(absdir_library : abs_path) : abs_path =
   append_to_abs_directory absdir_library "satysfi-envelope.yaml"
 
 
-let lock_envelope_config ~(store_root : abs_path) (lock : Lock.t) : abs_path =
-  envelope_config_path ~dir:(lock_directory ~store_root lock)
+let registered_lock_envelope_config ~(store_root : abs_path) (reglock : RegisteredLock.t) : abs_path =
+  envelope_config_path ~dir:(registered_lock_directory ~store_root reglock)
 
 
 let registry_root_directory_path ~store_root:(absdir_store_root : abs_path) (registry_hash_value : registry_hash_value) : abs_path =

--- a/src-saphe/localFixedPackageCollector.ml
+++ b/src-saphe/localFixedPackageCollector.ml
@@ -1,7 +1,53 @@
 
+open MyUtil
 open PackageSystemBase
+open ConfigError
 
 
-let main (_deps_with_flags : (dependency_flag * package_dependency) list) : (package_dependency list) LocalFixedPackageIdMap.t =
-  LocalFixedPackageIdMap.empty
+type collection = (package_dependency list) LocalFixedPackageIdMap.t
+
+
+let get_dependencies (absdir_package : abs_path) : (package_dependency list, config_error) result =
+  let open ResultMonad in
+  let abspath_package_config = Constant.library_package_config_path ~dir:absdir_package in
+  let*
+    PackageConfig.{
+      language_requirement = _; (* TODO: check that this requirement meets the selected language version *)
+      package_contents;
+      registry_remotes = _; (* TODO: append to the target's `registry_remotes` *)
+      _
+    } = PackageConfig.load abspath_package_config
+  in
+  match package_contents with
+  | PackageConfig.Library{ dependencies; _ } ->
+    (* Ignores `test_dependencies` here. *)
+      return dependencies
+
+  | PackageConfig.Font(_) ->
+      return []
+
+  | PackageConfig.Document(_) ->
+      err @@ NotALibraryLocalFixed{ dir = absdir_package }
+
+
+let rec aux (gained : collection) (deps : package_dependency list) : (collection, config_error) result =
+  let open ResultMonad in
+  deps |> foldM (fun gained dep ->
+    let PackageDependency{ spec; _ } = dep in
+    match spec with
+    | RegisteredDependency(_) ->
+        return gained
+
+    | LocalFixedDependency{ absolute_path } ->
+        if gained |> LocalFixedPackageIdMap.mem absolute_path then
+          return gained
+        else
+          let* deps_sub = get_dependencies absolute_path in
+          let gained = gained |> LocalFixedPackageIdMap.add absolute_path deps_sub in
+          aux gained deps_sub
+  ) gained
+
+
+let main (deps : package_dependency list) : (collection, config_error) result =
+  aux LocalFixedPackageIdMap.empty deps
     (* TODO: construct local_fixed_dependencies by traversing local fixed dependencies *)

--- a/src-saphe/localFixedPackageCollector.ml
+++ b/src-saphe/localFixedPackageCollector.ml
@@ -7,14 +7,14 @@ open ConfigError
 type collection = (package_dependency list) LocalFixedPackageIdMap.t
 
 
-let get_dependencies ~(language_version : SemanticVersion.t) (absdir_package : abs_path) : (package_dependency list, config_error) result =
+let get_dependencies ~(language_version : SemanticVersion.t) (absdir_package : abs_path) : (package_dependency list * registry_remote list, config_error) result =
   let open ResultMonad in
   let abspath_package_config = Constant.library_package_config_path ~dir:absdir_package in
   let*
     PackageConfig.{
       language_requirement;
       package_contents;
-      registry_remotes = _; (* TODO: append to the target's `registry_remotes` *)
+      registry_remotes;
       _
     } = PackageConfig.load abspath_package_config
   in
@@ -31,33 +31,37 @@ let get_dependencies ~(language_version : SemanticVersion.t) (absdir_package : a
   match package_contents with
   | PackageConfig.Library{ dependencies; _ } ->
     (* Ignores `test_dependencies` here, because we do not run the tests of depended packages. *)
-      return dependencies
+      return (dependencies, registry_remotes)
 
   | PackageConfig.Font(_) ->
-      return []
+      return ([], registry_remotes)
 
   | PackageConfig.Document(_) ->
       err @@ NotALibraryLocalFixed{ dir = absdir_package }
 
 
-let rec aux ~(language_version : SemanticVersion.t) (gained : collection) (deps : package_dependency list) : (collection, config_error) result =
+let rec aux ~(language_version : SemanticVersion.t) (gained : collection) (deps : package_dependency list) (registry_remote_acc : registry_remote Alist.t) : (collection * registry_remote Alist.t, config_error) result =
   let open ResultMonad in
-  deps |> foldM (fun gained dep ->
+  deps |> foldM (fun (gained, registry_remote_acc) dep ->
     let PackageDependency{ spec; _ } = dep in
     match spec with
     | RegisteredDependency(_) ->
-        return gained
+        return (gained, registry_remote_acc)
 
     | LocalFixedDependency{ absolute_path } ->
         if gained |> LocalFixedPackageIdMap.mem absolute_path then
-          return gained
+          return (gained, registry_remote_acc)
         else
-          let* deps_sub = get_dependencies ~language_version absolute_path in
+          let* (deps_sub, registry_remotes_sub) = get_dependencies ~language_version absolute_path in
           let gained = gained |> LocalFixedPackageIdMap.add absolute_path deps_sub in
-          aux ~language_version gained deps_sub
-  ) gained
+          let registry_remote_acc = Alist.append registry_remote_acc registry_remotes_sub in
+          aux ~language_version gained deps_sub registry_remote_acc
+  ) (gained, registry_remote_acc)
 
 
-let main ~(language_version : SemanticVersion.t) (deps : package_dependency list) : (collection, config_error) result =
-  aux ~language_version  LocalFixedPackageIdMap.empty deps
-    (* TODO: construct local_fixed_dependencies by traversing local fixed dependencies *)
+let main ~(language_version : SemanticVersion.t) (deps : package_dependency list) : (collection * registry_remote list, config_error) result =
+  let open ResultMonad in
+  let* (gained, registry_remote_acc) =
+    aux ~language_version LocalFixedPackageIdMap.empty deps Alist.empty
+  in
+  return (gained, Alist.to_list registry_remote_acc)

--- a/src-saphe/localFixedPackageCollector.ml
+++ b/src-saphe/localFixedPackageCollector.ml
@@ -1,0 +1,7 @@
+
+open PackageSystemBase
+
+
+let main (_deps_with_flags : (dependency_flag * package_dependency) list) : (package_dependency list) LocalFixedPackageIdMap.t =
+  LocalFixedPackageIdMap.empty
+    (* TODO: construct local_fixed_dependencies by traversing local fixed dependencies *)

--- a/src-saphe/localFixedPackageCollector.ml
+++ b/src-saphe/localFixedPackageCollector.ml
@@ -7,20 +7,30 @@ open ConfigError
 type collection = (package_dependency list) LocalFixedPackageIdMap.t
 
 
-let get_dependencies (absdir_package : abs_path) : (package_dependency list, config_error) result =
+let get_dependencies ~(language_version : SemanticVersion.t) (absdir_package : abs_path) : (package_dependency list, config_error) result =
   let open ResultMonad in
   let abspath_package_config = Constant.library_package_config_path ~dir:absdir_package in
   let*
     PackageConfig.{
-      language_requirement = _; (* TODO: check that this requirement meets the selected language version *)
+      language_requirement;
       package_contents;
       registry_remotes = _; (* TODO: append to the target's `registry_remotes` *)
       _
     } = PackageConfig.load abspath_package_config
   in
+  let* () =
+    if language_version |> SemanticVersion.fulfill language_requirement then
+      return ()
+    else
+      err @@ LocalFixedDoesNotSupportLanguageVersion{
+        dir = absdir_package;
+        language_version;
+        language_requirement;
+      }
+  in
   match package_contents with
   | PackageConfig.Library{ dependencies; _ } ->
-    (* Ignores `test_dependencies` here. *)
+    (* Ignores `test_dependencies` here, because we do not run the tests of depended packages. *)
       return dependencies
 
   | PackageConfig.Font(_) ->
@@ -30,7 +40,7 @@ let get_dependencies (absdir_package : abs_path) : (package_dependency list, con
       err @@ NotALibraryLocalFixed{ dir = absdir_package }
 
 
-let rec aux (gained : collection) (deps : package_dependency list) : (collection, config_error) result =
+let rec aux ~(language_version : SemanticVersion.t) (gained : collection) (deps : package_dependency list) : (collection, config_error) result =
   let open ResultMonad in
   deps |> foldM (fun gained dep ->
     let PackageDependency{ spec; _ } = dep in
@@ -42,12 +52,12 @@ let rec aux (gained : collection) (deps : package_dependency list) : (collection
         if gained |> LocalFixedPackageIdMap.mem absolute_path then
           return gained
         else
-          let* deps_sub = get_dependencies absolute_path in
+          let* deps_sub = get_dependencies ~language_version absolute_path in
           let gained = gained |> LocalFixedPackageIdMap.add absolute_path deps_sub in
-          aux gained deps_sub
+          aux ~language_version gained deps_sub
   ) gained
 
 
-let main (deps : package_dependency list) : (collection, config_error) result =
-  aux LocalFixedPackageIdMap.empty deps
+let main ~(language_version : SemanticVersion.t) (deps : package_dependency list) : (collection, config_error) result =
+  aux ~language_version  LocalFixedPackageIdMap.empty deps
     (* TODO: construct local_fixed_dependencies by traversing local fixed dependencies *)

--- a/src-saphe/logging.ml
+++ b/src-saphe/logging.ml
@@ -8,24 +8,31 @@ let show_package_dependency_before_solving (dependencies_with_flags : (dependenc
   dependencies_with_flags |> List.iter (fun (flag, dep) ->
     let PackageDependency{ used_as; spec } = dep in
     match spec with
-    | RegisteredDependency{ package_id; version_requirement; _ } ->
-        let PackageId.{ package_name; _ } = package_id in
+    | RegisteredDependency{ registered_package_id; version_requirement; _ } ->
+        let RegisteredPackageId.{ package_name; _ } = registered_package_id in
         let s_restr = SemanticVersion.requirement_to_string version_requirement in
         let s_test_only =
           match flag with
           | SourceDependency   -> ""
           | TestOnlyDependency -> ", test_only"
         in
-        Printf.printf "  - %s (%s%s) used as %s\n" package_name s_restr s_test_only used_as;
+        Printf.printf "  - %s (%s%s) used as %s\n" package_name s_restr s_test_only used_as
+
+    | LocalFixedDependency{ absolute_path } ->
+        Printf.printf "  - '%s' used as %s\n" (get_abs_path_string absolute_path) used_as
   )
 
 
 let show_package_dependency_solutions (solutions : package_solution list) =
   Printf.printf "  package dependency solutions:\n";
-    solutions |> List.iter (fun solution ->
-      let Lock.{ package_id; locked_version; _ } = solution.lock in
-      let PackageId.{ package_name; _ } = package_id in
-      Printf.printf "  - %s %s\n" package_name (SemanticVersion.to_string locked_version)
+  solutions |> List.iter (fun solution ->
+    match solution.lock with
+    | Lock.Registered(RegisteredLock.{ registered_package_id; locked_version; _ }) ->
+        let RegisteredPackageId.{ package_name; _ } = registered_package_id in
+        Printf.printf "  - %s %s\n" package_name (SemanticVersion.to_string locked_version)
+
+    | Lock.LocalFixed{ absolute_path } ->
+        Printf.printf "  - %s\n" (get_abs_path_string absolute_path)
   )
 
 

--- a/src-saphe/packageConstraintSolver.ml
+++ b/src-saphe/packageConstraintSolver.ml
@@ -317,12 +317,18 @@ module SolverInput = struct
 
   let conflict_class (impl : impl) : conflict_class list =
     match impl with
-    | DummyImpl | TargetImpl(_) | LocalFixedImpl(_) ->
-        [ "*" ]
+    | DummyImpl ->
+        [ "dummy" ]
+
+    | TargetImpl(_) ->
+        [ "target" ]
+
+    | LocalFixedImpl{ absolute_path; _ } ->
+        [ Printf.sprintf "local/%s" (get_abs_path_string absolute_path) ]
 
     | Impl{ package_name; version; _ } ->
         let compat = SemanticVersion.get_compatibility_unit version in
-        [ Printf.sprintf "%s/%s" package_name compat ]
+        [ Printf.sprintf "registered/%s/%s" package_name compat ]
 
 
   let rejects (_role : Role.t) : (impl * rejection) list * string list =

--- a/src-saphe/packageConstraintSolver.ml
+++ b/src-saphe/packageConstraintSolver.ml
@@ -283,6 +283,7 @@ module SolverInput = struct
 
 
   let meets_restriction (impl : impl) (restr : restriction) : bool =
+    let b = (* TODO: remove this *)
     match impl with
     | DummyImpl ->
         false
@@ -306,6 +307,7 @@ module SolverInput = struct
           | AsIs ->
               false
         end
+    in Format.printf "MEETS: %a |= %a --> %B@," pp_impl impl pp_restriction restr b; b (* TODO: remove this *)
 
 
   (* Unused *)

--- a/src-saphe/packageConstraintSolver.ml
+++ b/src-saphe/packageConstraintSolver.ml
@@ -78,22 +78,12 @@ module SolverInput = struct
     | VersionRequirement of SemanticVersion.requirement
     | AsIs
 
-  let pp_restriction ppf = function
-    | VersionRequirement(SemanticVersion.CompatibleWith(semver)) ->
-        Format.fprintf ppf "~%s" (SemanticVersion.to_string semver)
-
-    | AsIs ->
-        Format.fprintf ppf "AS-IS"
-
   type dependency =
     | Dependency of {
         role        : Role.t;
         used_as     : string;
         restriction : restriction;
       }
-
-  let pp_dependency ppf (Dependency{ role; used_as; restriction }) =
-    Format.fprintf ppf "%a (used as %s, %a)" Role.pp role used_as pp_restriction restriction
 
   type dep_info = {
     dep_role              : Role.t;
@@ -178,14 +168,12 @@ module SolverInput = struct
     { dep_role = role; dep_importance = `Essential; dep_required_commands = [] }
 
 
-  let requires (role : Role.t) (impl : impl) : dependency list * command_name list =
-    let (dependencies, cmds) = (* TODO: remove this *)
+  let requires (_role : Role.t) (impl : impl) : dependency list * command_name list =
     match impl with
     | DummyImpl                        -> ([], [])
     | TargetImpl{ dependencies }       -> (dependencies, [])
     | LocalFixedImpl{ dependencies; _} -> (dependencies, [])
     | Impl{ dependencies; _ }          -> (dependencies, [])
-    in Format.printf "DEPS: (role: %a) %a ->@,@[<v2>  %a@]@," Role.pp role pp_impl impl (Format.pp_print_list pp_dependency) dependencies; (dependencies, cmds) (* TODO: remove this *)
 
 
   (* Unused *)
@@ -256,7 +244,6 @@ module SolverInput = struct
               None
           )
         in
-        Format.printf "IMPLS: %a =@,@[<v2>  %a@]@," Role.pp role (Format.pp_print_list pp_impl) impls; (* TODO: remove this *)
         { replacement = None; impls }
 
     | LocalFixedRole{ absolute_path; context } ->
@@ -267,13 +254,11 @@ module SolverInput = struct
         in
         let dependencies = make_internal_dependency context requires in
         let impl = LocalFixedImpl{ absolute_path; dependencies } in
-        Format.printf "IMPLS: %a = %a@," Role.pp role pp_impl impl; (* TODO: remove this *)
         { replacement = None; impls = [ impl ] }
 
     | TargetRole{ requires; context } ->
         let dependencies = make_internal_dependency context requires in
         let impl = TargetImpl{ dependencies } in
-        Format.printf "IMPLS: %a = %a@," Role.pp role pp_impl impl; (* TODO: remove this *)
         { replacement = None; impls = [ impl ] }
 
 
@@ -283,7 +268,6 @@ module SolverInput = struct
 
 
   let meets_restriction (impl : impl) (restr : restriction) : bool =
-    let b = (* TODO: remove this *)
     match impl with
     | DummyImpl ->
         false
@@ -307,7 +291,6 @@ module SolverInput = struct
           | AsIs ->
               false
         end
-    in Format.printf "MEETS: %a |= %a --> %B@," pp_impl impl pp_restriction restr b; b (* TODO: remove this *)
 
 
   (* Unused *)
@@ -416,14 +399,12 @@ let solve (context : package_context) (dependencies_with_flags : (dependency_fla
   in
   let requires = Alist.to_list dependency_acc in
   let target_role = SolverInput.Role.TargetRole{ requires; context } in
-  Format.printf "@[<v>"; (* TODO: remove this *)
   let output_opt =
     InternalSolver.do_solve ~closest_match:false {
       role    = target_role;
       command = None;
     }
   in
-  Format.printf "@]"; (* TODO: remove this *)
   output_opt |> Option.map (fun output ->
     let open InternalSolver in
 

--- a/src-saphe/packageConstraintSolver.ml
+++ b/src-saphe/packageConstraintSolver.ml
@@ -408,8 +408,6 @@ let solve (context : package_context) (dependencies_with_flags : (dependency_fla
   output_opt |> Option.map (fun output ->
     let open InternalSolver in
 
-    Format.printf "EXPLAIN: %s@," (Output.explain output target_role);
-
     (* Adds vertices to the graph: *)
     let rolemap = output |> Output.to_map in
     let (quad_acc, graph, explicit_vertex_to_used_as, explicit_test_vertex_to_used_as, lock_to_vertex_map) =

--- a/src-saphe/packageSystemBase.ml
+++ b/src-saphe/packageSystemBase.ml
@@ -77,6 +77,10 @@ module PackageId = struct
         -1
 end
 
+module RegisteredPackageIdMap = Map.Make(RegisteredPackageId)
+
+module LocalFixedPackageIdMap = Map.Make(AbsPath)
+
 module PackageIdMap = Map.Make(PackageId)
 
 module PackageIdSet = Set.Make(PackageId)
@@ -169,8 +173,9 @@ type implementation_record =
     }
 
 type package_context = {
-  language_version        : SemanticVersion.t;
-  package_id_to_impl_list : (implementation_record list) PackageIdMap.t;
+  language_version         : SemanticVersion.t;
+  registered_package_impls : (implementation_record list) RegisteredPackageIdMap.t;
+  local_fixed_dependencies : (package_dependency list) LocalFixedPackageIdMap.t;
 }
 
 type locked_dependency = {

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -877,6 +877,7 @@ let solve ~(fpath_in : string) =
           EnvelopeConfig.write abspath_envelope_config { envelope_contents }
             |> Result.map_error (fun message -> FailedToWriteFile{ path = abspath_envelope_config; message })
         in
+        Logging.end_envelope_config_output abspath_envelope_config;
         return (local_fixed_dependencies |> LocalFixedPackageIdMap.add absdir_package deps)
       ) local_fixed_package_map (return LocalFixedPackageIdMap.empty)
     in
@@ -1081,8 +1082,8 @@ let make_envelope_spec ~(store_root : abs_path) (locked_package : LockConfig.loc
     | Lock.Registered(reglock) ->
         get_abs_path_string (Constant.registered_lock_envelope_config ~store_root reglock)
 
-    | LocalFixed{ absolute_path } ->
-        get_abs_path_string absolute_path
+    | Lock.LocalFixed{ absolute_path } ->
+        get_abs_path_string (Constant.envelope_config_path ~dir:absolute_path)
   in
   let envelope_dependencies = lock_dependencies |> List.map make_envelope_dependency in
   {

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -1134,7 +1134,7 @@ let build
         Logging.end_deps_config_output abspath_deps_config;
 
         (* Builds the package by invoking `satysfi`: *)
-        let SatysfiCommand.{ exit_status = _; command = _ } = (* TODO: use `exit_status` *)
+        let SatysfiCommand.{ exit_status; command = _ } =
           SatysfiCommand.(build_package
             ~envelope:abspath_envelope_config
             ~deps:abspath_deps_config
@@ -1142,7 +1142,7 @@ let build
             ~mode:text_mode_formats_str_opt
             ~options)
         in
-        return ()
+        return exit_status
 
     | DocumentBuildInput{
         doc  = abspath_doc;
@@ -1159,7 +1159,7 @@ let build
         Logging.end_deps_config_output abspath_deps_config;
 
         (* Builds the document by invoking `satysfi`: *)
-        let SatysfiCommand.{ exit_status = _; command = _ } = (* TODO: use `exit_status` *)
+        let SatysfiCommand.{ exit_status; command = _ } =
           SatysfiCommand.(build_document
             ~doc:abspath_doc
             ~out:abspath_out
@@ -1169,11 +1169,11 @@ let build
             ~mode:text_mode_formats_str_opt
             ~options)
         in
-        return ()
+        return exit_status
   in
   match res with
-  | Ok(())   -> ()
-  | Error(e) -> report_config_error e; exit 1
+  | Ok(exit_status) -> exit exit_status
+  | Error(e)        -> report_config_error e; exit 1
 
 
 type test_input =
@@ -1225,16 +1225,16 @@ let test
         Logging.end_deps_config_output abspath_deps_config;
 
         (* Builds the package by invoking `satysfi`: *)
-        let SatysfiCommand.{ exit_status = _; command = _ } = (* TODO: use `exit_status` *)
+        let SatysfiCommand.{ exit_status; command = _ } =
           SatysfiCommand.(test_package
             ~envelope:abspath_envelope_config
             ~deps:abspath_deps_config
             ~base_dir:absdir_store_root
             ~mode:text_mode_formats_str_opt)
         in
-        return ()
+        return exit_status
 
   in
   match res with
-  | Ok(())   -> ()
-  | Error(e) -> report_config_error e; exit 1
+  | Ok(exit_status) -> exit exit_status
+  | Error(e)        -> report_config_error e; exit 1

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -837,7 +837,8 @@ let solve ~(fpath_in : string) =
     Logging.show_package_dependency_before_solving dependencies_with_flags;
 
     let local_fixed_dependencies =
-      failwith "TODO: construct local_fixed_dependencies by traversing local fixed dependencies"
+      LocalFixedPackageIdMap.empty
+        (* TODO: construct local_fixed_dependencies by traversing local fixed dependencies *)
     in
 
     (* Arranges the store root config: *)

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -353,6 +353,12 @@ let report_config_error = function
         DisplayLine(message);
       ]
 
+  | NotALibraryLocalFixed{ dir = absdir_package } ->
+      report_error [
+        NormalLine(Printf.sprintf "the following local package is not a library:");
+        DisplayLine(get_abs_path_string absdir_package);
+      ]
+
 
 type solve_input =
   | PackageSolveInput of {
@@ -836,8 +842,8 @@ let solve ~(fpath_in : string) =
 
     Logging.show_package_dependency_before_solving dependencies_with_flags;
 
-    let local_fixed_dependencies =
-      LocalFixedPackageCollector.main dependencies_with_flags
+    let* local_fixed_dependencies =
+      LocalFixedPackageCollector.main (List.map Stdlib.snd dependencies_with_flags)
     in
 
     (* Arranges the store root config: *)

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -837,8 +837,7 @@ let solve ~(fpath_in : string) =
     Logging.show_package_dependency_before_solving dependencies_with_flags;
 
     let local_fixed_dependencies =
-      LocalFixedPackageIdMap.empty
-        (* TODO: construct local_fixed_dependencies by traversing local fixed dependencies *)
+      LocalFixedPackageCollector.main dependencies_with_flags
     in
 
     (* Arranges the store root config: *)

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -359,6 +359,16 @@ let report_config_error = function
         DisplayLine(get_abs_path_string absdir_package);
       ]
 
+  | LocalFixedDoesNotSupportLanguageVersion{ dir = absdir_package; language_version; language_requirement } ->
+      let s_version = SemanticVersion.to_string language_version in
+      let s_req = SemanticVersion.requirement_to_string language_requirement in
+      report_error [
+        NormalLine(Printf.sprintf "the local package");
+        DisplayLine(get_abs_path_string absdir_package);
+        NormalLine(Printf.sprintf "requires the language version to be %s," s_req);
+        NormalLine(Printf.sprintf "but we are using %s." s_version);
+      ]
+
 
 type solve_input =
   | PackageSolveInput of {
@@ -843,7 +853,7 @@ let solve ~(fpath_in : string) =
     Logging.show_package_dependency_before_solving dependencies_with_flags;
 
     let* local_fixed_dependencies =
-      LocalFixedPackageCollector.main (List.map Stdlib.snd dependencies_with_flags)
+      LocalFixedPackageCollector.main ~language_version (List.map Stdlib.snd dependencies_with_flags)
     in
 
     (* Arranges the store root config: *)

--- a/src-util/absPath.ml
+++ b/src-util/absPath.ml
@@ -1,0 +1,102 @@
+
+(* TODO: separate UTF-8-related functions to one module *)
+let decode_utf8 (str_utf8 : string) : Uchar.t list =
+  let decoder = Uutf.decoder ~encoding:`UTF_8 (`String(str_utf8)) in
+  let rec loop (uchacc : Uchar.t Alist.t) =
+    match Uutf.decode decoder with
+    | `Await        -> assert false
+    | `End          -> Alist.to_list uchacc
+    | `Malformed(_) -> assert false
+    | `Uchar(uch)   -> loop (Alist.extend uchacc uch)
+  in
+  loop Alist.empty
+
+
+let encode_utf8 (uchs : Uchar.t list) : string =
+  let buffer = Buffer.create (List.length uchs * 4) in
+  let encoder = Uutf.encoder `UTF_8 (`Buffer(buffer)) in
+  uchs |> List.iter (fun uch -> Uutf.encode encoder (`Uchar(uch)) |> ignore);
+  Uutf.encode encoder `End |> ignore;
+  Buffer.contents buffer
+
+
+(** the type for components each of which stand for a single directory. *)
+type component = string
+[@@deriving show { with_path = false }]
+
+type t = AbsPath of component list
+[@@deriving show { with_path = false }]
+
+type non_normal_component =
+  | Component of component
+  | Current
+  | Parent
+[@@deriving show { with_path = false }]
+
+
+let make_non_normal_components (uchs : Uchar.t list) : non_normal_component =
+  match encode_utf8 uchs with
+  | "" | "." -> Current
+  | ".."     -> Parent
+  | s        -> Component(s)
+
+
+let rec separate_to_non_normal_components (ncompoacc : non_normal_component Alist.t) (uchacc : Uchar.t Alist.t) (uchs : Uchar.t list) : non_normal_component list =
+  match uchs with
+  | [] ->
+      let ncompo_last = make_non_normal_components (Alist.to_list uchacc) in
+      Alist.to_list (Alist.extend ncompoacc ncompo_last)
+
+  | uch_first :: uchs_rest ->
+      if Uchar.equal uch_first (Uchar.of_char '/') then
+        let ncompo = make_non_normal_components (Alist.to_list uchacc) in
+        separate_to_non_normal_components
+          (Alist.extend ncompoacc ncompo)
+          Alist.empty
+          uchs_rest
+      else
+        separate_to_non_normal_components
+          ncompoacc
+          (Alist.extend uchacc uch_first)
+          uchs_rest
+
+
+let normalize (ncompos : non_normal_component list) : (component list) option =
+  let open OptionMonad in
+  let* compoacc =
+    ncompos |> foldM (fun compoacc ncompo ->
+      match ncompo with
+      | Current          -> return compoacc
+      | Parent           -> Alist.chop_last compoacc >>= fun (compoacc, _) -> return compoacc
+      | Component(compo) -> return (Alist.extend compoacc compo)
+    ) Alist.empty
+  in
+  return (Alist.to_list compoacc)
+
+
+let of_string_exn (s : string) : t =
+  let uchs = decode_utf8 s in
+  match uchs with
+  | [] ->
+      assert false
+
+  | uch_first :: uchs_rest ->
+      if Uchar.equal uch_first (Uchar.of_char '/') then
+        let ncompos = separate_to_non_normal_components Alist.empty Alist.empty uchs_rest in
+        Format.printf "%a\n" (Format.pp_print_list ~pp_sep:(fun ppf () -> Format.fprintf ppf "|") pp_non_normal_component) ncompos; (* TODO: remove this *)
+        match normalize ncompos with
+        | None         -> assert false
+        | Some(compos) -> AbsPath(compos)
+      else
+        assert false
+
+
+let to_string (AbsPath(compos) : t) : string =
+  Printf.sprintf "/%s" (String.concat "/" compos)
+
+
+let to_components (AbsPath(compos) : t) = compos
+
+
+let compare (AbsPath(compos1)) (AbsPath(compos2)) =
+  List.compare String.compare compos1 compos2

--- a/src-util/absPath.ml
+++ b/src-util/absPath.ml
@@ -31,7 +31,6 @@ type non_normal_component =
   | Component of component
   | Current
   | Parent
-[@@deriving show { with_path = false }]
 
 
 let make_non_normal_components (uchs : Uchar.t list) : non_normal_component =

--- a/src-util/absPath.ml
+++ b/src-util/absPath.ml
@@ -83,7 +83,6 @@ let of_string_exn (s : string) : t =
   | uch_first :: uchs_rest ->
       if Uchar.equal uch_first (Uchar.of_char '/') then
         let ncompos = separate_to_non_normal_components Alist.empty Alist.empty uchs_rest in
-        Format.printf "%a\n" (Format.pp_print_list ~pp_sep:(fun ppf () -> Format.fprintf ppf "|") pp_non_normal_component) ncompos; (* TODO: remove this *)
         match normalize ncompos with
         | None         -> assert false
         | Some(compos) -> AbsPath(compos)

--- a/src-util/absPath.mli
+++ b/src-util/absPath.mli
@@ -9,3 +9,5 @@ val to_string : t -> string
 val to_components : t -> string list
 
 val compare : t -> t -> int
+
+val make_relative : from:t -> t -> string

--- a/src-util/absPath.mli
+++ b/src-util/absPath.mli
@@ -1,0 +1,11 @@
+
+type t
+[@@deriving show]
+
+val of_string_exn : string -> t
+
+val to_string : t -> string
+
+val to_components : t -> string list
+
+val compare : t -> t -> int

--- a/src-util/myUtil.ml
+++ b/src-util/myUtil.ml
@@ -41,34 +41,27 @@ let ( @|> ) = ( |> )
      ---- *)
 
 
-type abs_path = AbsPath of string
+type abs_path = AbsPath.t
 [@@deriving show { with_path = false }]
 
 type lib_path = LibPath of string
 
 
-let open_in_abs (AbsPath(pathstr)) =
-  Stdlib.open_in pathstr
+let open_in_abs (abspath : abs_path) =
+  Stdlib.open_in (AbsPath.to_string abspath)
 
 
-let basename_abs (AbsPath(pathstr)) =
-  Filename.basename pathstr
+let basename_abs (abspath : abs_path) =
+  Filename.basename (AbsPath.to_string abspath)
 
 
-let make_abs_path pathstr = AbsPath(pathstr)
+let make_abs_path pathstr = AbsPath.of_string_exn pathstr
 
 let make_lib_path pathstr = LibPath(pathstr)
 
-let get_abs_path_string (AbsPath(pathstr)) = pathstr
+let get_abs_path_string = AbsPath.to_string
 
 let get_lib_path_string (LibPath(pathstr)) = pathstr
-
-
-module AbsPath = struct
-  type t = abs_path
-
-  let compare ap1 ap2 = String.compare (get_abs_path_string ap1) (get_abs_path_string ap2)
-end
 
 
 let make_absolute_if_relative ~(origin : string) (s : string) : abs_path =

--- a/src-util/myUtil.ml
+++ b/src-util/myUtil.ml
@@ -80,6 +80,10 @@ let append_to_abs_directory (absdir : abs_path) (filename : string) : abs_path =
   make_abs_path (Filename.concat (get_abs_path_string absdir) filename)
 
 
+let dirname (abspath : abs_path) : abs_path =
+  make_abs_path (Filename.dirname (get_abs_path_string abspath))
+
+
 let read_file (abspath : abs_path) : (string, string) result =
   let open ResultMonad in
   try

--- a/src-util/myUtil.mli
+++ b/src-util/myUtil.mli
@@ -38,6 +38,8 @@ val make_absolute_if_relative : origin:string -> string -> abs_path
 
 val append_to_abs_directory : abs_path -> string -> abs_path
 
+val dirname : abs_path -> abs_path
+
 val is_directory : abs_path -> bool
 
 val encode_yaml : Yaml.value -> string

--- a/src-util/myUtil.mli
+++ b/src-util/myUtil.mli
@@ -1,7 +1,7 @@
 
 exception RemainsToBeImplemented of string
 
-type abs_path
+type abs_path = AbsPath.t
 [@@deriving show]
 
 type lib_path
@@ -27,12 +27,6 @@ val make_lib_path : string -> lib_path
 val get_abs_path_string : abs_path -> string
 
 val get_lib_path_string : lib_path -> string
-
-module AbsPath : sig
-  type t = abs_path
-
-  val compare : t -> t -> int
-end
 
 val make_absolute_if_relative : origin:string -> string -> abs_path
 

--- a/src-util/optionMonad.ml
+++ b/src-util/optionMonad.ml
@@ -4,3 +4,18 @@ let ( >>= ) x f =
   | Some(v)   -> f v
 
 let return v = Some(v)
+
+let ( let* ) = ( >>= )
+
+let foldM f acc vs =
+  vs |> List.fold_left (fun res v ->
+    res >>= fun acc ->
+    f acc v
+  ) (return acc)
+
+let mapM f vs =
+  vs |> foldM (fun acc v ->
+    f v >>= fun y ->
+    return @@ Alist.extend acc y
+  ) Alist.empty >>= fun acc ->
+  return (Alist.to_list acc)

--- a/src-util/optionMonad.mli
+++ b/src-util/optionMonad.mli
@@ -1,2 +1,5 @@
 val ( >>= ) : 'a option -> ('a -> 'b option) -> 'b option
 val return : 'a -> 'a option
+val ( let* ) : 'a option -> ('a -> 'b option) -> 'b option
+val foldM : ('a -> 'b -> 'a option) -> 'a -> 'b list -> 'a option
+val mapM : ('a -> 'b option) -> 'a list -> ('b list) option

--- a/test/common/absPathTest.ml
+++ b/test/common/absPathTest.ml
@@ -11,7 +11,22 @@ let of_string_exn_test () =
   ]
 
 
+let make_relative_test () =
+  List.iter (fun (s_from, s_target, expected) ->
+    let from = AbsPath.of_string_exn s_from in
+    let target = AbsPath.of_string_exn s_target in
+    let got = AbsPath.make_relative ~from target in
+    Alcotest.(check string) "make_relative" expected got
+  ) [
+    ("/foo/bar", "/foo/bar/baz.txt", "baz.txt");
+    ("/foo/bar/qux", "/foo/bar/baz.txt", "../baz.txt");
+    ("/foo/bar/qux/quux", "/foo/bar/baz.txt", "../../baz.txt");
+    ("/foo/bar", "/foo/bar", ".");
+  ]
+
+
 let test_cases =
   Alcotest.[
     test_case "of_string_exn" `Quick of_string_exn_test;
+    test_case "make_relative" `Quick make_relative_test;
   ]

--- a/test/common/absPathTest.ml
+++ b/test/common/absPathTest.ml
@@ -1,0 +1,17 @@
+
+let of_string_exn_test () =
+  List.iter (fun (input, expected) ->
+    let got = AbsPath.to_components (AbsPath.of_string_exn input) in
+    Alcotest.(check (list string)) "of_string_exn" expected got
+  ) [
+    ("/foo/bar/baz.txt", ["foo"; "bar"; "baz.txt"]);
+    ("/foo//bar/baz.txt", ["foo"; "bar"; "baz.txt"]);
+    ("/foo/./bar/baz.txt", ["foo"; "bar"; "baz.txt"]);
+    ("/foo/../bar/baz.txt", ["bar"; "baz.txt"]);
+  ]
+
+
+let test_cases =
+  Alcotest.[
+    test_case "of_string_exn" `Quick of_string_exn_test;
+  ]

--- a/test/common/commonTest.ml
+++ b/test/common/commonTest.ml
@@ -3,4 +3,5 @@ let () =
   let open Alcotest in
   run "SATySFi-Util Test" [
     ("DependencyGraph", DependencyGraphTest.test_cases);
+    ("AbsPath", AbsPathTest.test_cases);
   ]

--- a/test/saphe/dune
+++ b/test/saphe/dune
@@ -1,0 +1,5 @@
+(test
+  (name sapheTest)
+  (libraries
+    sapheMain
+    alcotest))

--- a/test/saphe/packageConfigTest.ml
+++ b/test/saphe/packageConfigTest.ml
@@ -1,0 +1,83 @@
+
+open SapheTestUtil
+open SapheMain__ConfigError
+open SapheMain__PackageSystemBase
+module PackageConfig = SapheMain__PackageConfig
+
+
+let input1 = {yaml|
+ecosystem: "^0.0.1"
+language: "^0.1.0"
+name: "stdlib"
+authors:
+  - "Takashi Suwa"
+registries:
+  - name: "default"
+    git:
+      url: "https://github.com/SATySFi/default-registry"
+      branch: "temp-dev-saphe"
+contents:
+  library:
+    main_module: "Stdlib"
+    source_directories:
+    - "./src"
+    test_directories:
+    - "./test"
+    dependencies: []
+    test_dependencies:
+    - used_as: "Testing"
+      registered:
+        registry: "default"
+        name: "testing"
+        requirement: "^0.0.1"
+|yaml}
+
+
+let expected1 =
+  ParsedPackageConfig{
+    language_requirement = SemanticVersion.CompatibleWith(make_version "0.1.0");
+    package_name = "stdlib";
+    package_authors = ["Takashi Suwa"];
+    external_resources = [];
+    package_contents =
+      ParsedLibrary{
+        main_module_name = "Stdlib";
+        source_directories = [ "./src" ];
+        test_directories = [ "./test" ];
+        dependencies = [];
+        test_dependencies = [
+          ParsedPackageDependency{
+            used_as = "Testing";
+            spec =
+              ParsedRegisteredDependency{
+                package_name = "testing";
+                registry_local_name = "default";
+                version_requirement = SemanticVersion.CompatibleWith(make_version "0.0.1");
+              };
+            };
+        ];
+        markdown_conversion = None;
+      };
+    registry_specs = [
+      ("default", GitRegistry{
+        url = "https://github.com/SATySFi/default-registry";
+        branch = "temp-dev-saphe";
+      });
+    ];
+  }
+
+
+let parsed_package_config = Alcotest.of_pp pp_parsed_package_config
+let yaml_error = Alcotest.of_pp pp_yaml_error
+
+
+let parse_test_1 () =
+  let got = PackageConfig.parse input1 in
+  let expected = Ok(expected1) in
+  Alcotest.(check (result parsed_package_config yaml_error)) "parse" expected got
+
+
+let test_cases =
+  Alcotest.[
+    test_case "parse 1" `Quick parse_test_1;
+  ]

--- a/test/saphe/packageConstraintSolverTest.ml
+++ b/test/saphe/packageConstraintSolverTest.ml
@@ -1,0 +1,163 @@
+
+open SapheTestUtil
+open SapheMain__PackageSystemBase
+module Constant = SapheMain__Constant
+module PackageConstraintSolver = SapheMain__PackageConstraintSolver
+
+
+let registry_hash_value =
+  "c0bebeef4423"
+
+
+let language_version =
+  make_version "0.1.0"
+
+
+let make_dependency ~(used_as : string) (package_name : package_name) (s_version : string) : package_dependency =
+  PackageDependency{
+    used_as;
+    spec =
+      RegisteredDependency{
+        registered_package_id = RegisteredPackageId.{ package_name; registry_hash_value };
+        version_requirement   = SemanticVersion.CompatibleWith(make_version s_version);
+      };
+  }
+
+
+let make_dependency_in_registry ~(used_as : string) (package_name : package_name) (s_version : string) : package_dependency_in_registry =
+  PackageDependencyInRegistry{
+    used_as;
+    package_name;
+    version_requirement = SemanticVersion.CompatibleWith(make_version s_version);
+  }
+
+
+let make_impl (s_version : string) (deps : package_dependency_in_registry list) : implementation_record =
+  ImplRecord{
+    version              = make_version s_version;
+    source               = NoSource;
+    language_requirement = SemanticVersion.CompatibleWith(language_version);
+    dependencies         = deps;
+  }
+
+
+let make_registered_lock (package_name : package_name) (s_version : string) : RegisteredLock.t =
+  RegisteredLock.{
+    registered_package_id = RegisteredPackageId.{ package_name; registry_hash_value };
+    locked_version        = make_version s_version;
+  }
+
+
+let make_locked_dependency ~(used_as : string) (package_name : package_name) (s_version : string) : locked_dependency =
+  {
+    depended_lock      = Lock.Registered(make_registered_lock package_name s_version);
+    dependency_used_as = used_as;
+  }
+
+
+let make_solution ?(explicitly_depended : string option) ?(test_only : bool = false) (package_name : package_name) (s_version : string) (deps : locked_dependency list) : package_solution =
+  {
+    lock                = Lock.Registered(make_registered_lock package_name s_version);
+    locked_source       = NoSource;
+    locked_dependencies = deps;
+    used_in_test_only   = test_only;
+    explicitly_depended;
+    explicitly_test_depended = None;
+  }
+
+
+let check package_context dependencies_with_flags expected =
+  let got = PackageConstraintSolver.solve package_context dependencies_with_flags in
+  Alcotest.(check (option (list (of_pp pp_package_solution)))) "solutions" expected got
+
+
+let make_registered_package_impls =
+  List.fold_left (fun map (package_name, impls) ->
+    let registered_package_id = RegisteredPackageId.{ package_name; registry_hash_value } in
+    map |> RegisteredPackageIdMap.add registered_package_id impls
+  ) RegisteredPackageIdMap.empty
+
+
+let solve_test_1 () =
+  let package_context =
+    let local_fixed_dependencies = LocalFixedPackageIdMap.empty in
+    let registered_package_impls =
+      make_registered_package_impls [
+        ("foo", [
+          make_impl "1.0.0" [];
+          make_impl "2.0.0" [];
+        ]);
+        ("bar", [
+          make_impl "1.0.0" [ make_dependency_in_registry ~used_as:"Foo" "foo" "2.0.0" ];
+        ]);
+        ("qux", [
+          make_impl "1.0.0" [ make_dependency_in_registry ~used_as:"Foo" "foo" "1.0.0" ];
+        ]);
+      ]
+    in
+    { language_version; local_fixed_dependencies; registered_package_impls }
+  in
+  let dependencies_with_flags =
+    [
+      (SourceDependency, make_dependency ~used_as:"Bar" "bar" "1.0.0");
+      (SourceDependency, make_dependency ~used_as:"Qux" "qux" "1.0.0");
+    ]
+  in
+  let expected =
+    Some([
+      make_solution ~explicitly_depended:"Bar"
+        "bar" "1.0.0" [ make_locked_dependency ~used_as:"Foo" "foo" "2.0.0" ];
+      make_solution
+        "foo" "1.0.0" [];
+      make_solution
+        "foo" "2.0.0" [];
+      make_solution ~explicitly_depended:"Qux"
+        "qux" "1.0.0" [ make_locked_dependency ~used_as:"Foo" "foo" "1.0.0" ];
+    ])
+  in
+  check package_context dependencies_with_flags expected
+
+
+let solve_test_2 () =
+  let package_context =
+    let local_fixed_dependencies = LocalFixedPackageIdMap.empty in
+    let registered_package_impls =
+      make_registered_package_impls [
+        ("foo", [
+          make_impl "1.0.0" [];
+          make_impl "1.1.0" [];
+        ]);
+        ("bar", [
+          make_impl "1.0.0" [ make_dependency_in_registry ~used_as:"FooA" "foo" "1.1.0" ];
+        ]);
+        ("qux", [
+          make_impl "1.0.0" [ make_dependency_in_registry ~used_as:"FooB" "foo" "1.0.0" ];
+        ]);
+      ]
+    in
+    { language_version; local_fixed_dependencies; registered_package_impls }
+  in
+  let dependencies_with_flags =
+    [
+      (SourceDependency, make_dependency ~used_as:"Bar" "bar" "1.0.0");
+      (SourceDependency, make_dependency ~used_as:"Qux" "qux" "1.0.0");
+    ]
+  in
+  let expected =
+    Some([
+      make_solution ~explicitly_depended:"Bar"
+        "bar" "1.0.0" [ make_locked_dependency ~used_as:"FooA" "foo" "1.1.0" ];
+      make_solution
+        "foo" "1.1.0" [];
+      make_solution ~explicitly_depended:"Qux"
+        "qux" "1.0.0" [ make_locked_dependency ~used_as:"FooB" "foo" "1.1.0" ];
+    ])
+  in
+  check package_context dependencies_with_flags expected
+
+
+let test_cases =
+  Alcotest.[
+    test_case "solve 1" `Quick solve_test_1;
+    test_case "solve 2" `Quick solve_test_2;
+  ]

--- a/test/saphe/sapheTest.ml
+++ b/test/saphe/sapheTest.ml
@@ -1,0 +1,7 @@
+
+let () =
+  let open Alcotest in
+  run "Saphe Test" [
+    ("PackageConfig", PackageConfigTest.test_cases);
+    ("PackageConstraintSolver", PackageConstraintSolverTest.test_cases);
+  ]

--- a/test/saphe/sapheTestUtil.ml
+++ b/test/saphe/sapheTestUtil.ml
@@ -1,0 +1,5 @@
+
+let make_version (s_version : string) : SemanticVersion.t =
+  match SemanticVersion.parse s_version with
+  | Some(semver) -> semver
+  | None         -> assert false

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,4 +1,4 @@
 *.saphe.lock.yaml
 !*.saphe.lock.yaml.expected
 *.satysfi-deps.yaml
-init-lib/
+/init-lib/

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -123,6 +123,7 @@ $(INIT_LIB)/satysfi-deps.yaml: $(INIT_LIB)/saphe.lock.yaml
 # Tests for local fixed packages:
 $(LOCAL_FIXED).saphe.lock.yaml: $(LOCAL_FIXED).saty $(LOCAL_FIXED).saphe.yaml
 	$(SAPHE) solve $<
+	diff $@ $(LOCAL_FIXED).saphe.lock.yaml.expected
 
 $(LOCAL_FIXED).pdf: $(LOCAL_FIXED).saty $(LOCAL_FIXED).saphe.lock.yaml
 	$(SAPHE) build $< -o $@

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,7 @@
 INIT_DOC = init-doc/foo
 INIT_MD = init-md/foo
 INIT_LIB = init-lib
+LOCAL_FIXED = local-fixed/doc
 
 DOC_TARGETS = \
 	clip.pdf \
@@ -16,6 +17,7 @@ DOC_TARGETS = \
 	rename-dep1.pdf \
 	$(INIT_DOC).pdf \
 	$(INIT_MD).pdf \
+	$(LOCAL_FIXED).pdf \
 #	first.pdf \
 #	math1.pdf \
 #	refactor4.pdf \
@@ -78,6 +80,7 @@ clean-init::
 	rm -f $(INIT_MD).md $(INIT_MD).saphe.yaml
 	rm -f $(INIT_MD).saphe.lock.yaml $(INIT_MD).satysfi-deps.yaml $(INIT_MD).satysfi-aux $(INIT_MD).pdf
 	rm -rf $(INIT_LIB)
+	rm -f $(LOCAL_FIXED).saphe.lock.yaml
 
 # Dependencies on program files:
 clip.pdf: head.satyh
@@ -116,3 +119,10 @@ $(INIT_LIB)/saphe.lock.yaml: $(INIT_LIB)/saphe.yaml
 $(INIT_LIB)/satysfi-deps.yaml: $(INIT_LIB)/saphe.lock.yaml
 	$(SAPHE) build $(INIT_LIB)
 	$(SAPHE) test $(INIT_LIB)
+
+# Tests for local fixed packages:
+$(LOCAL_FIXED).saphe.lock.yaml: $(LOCAL_FIXED).saty $(LOCAL_FIXED).saphe.yaml
+	$(SAPHE) solve $<
+
+$(LOCAL_FIXED).pdf: $(LOCAL_FIXED).saty $(LOCAL_FIXED).saphe.lock.yaml
+	$(SAPHE) build $< -o $@

--- a/tests/local-fixed/doc.saphe.lock.yaml.expected
+++ b/tests/local-fixed/doc.saphe.lock.yaml.expected
@@ -1,0 +1,113 @@
+ecosystem: ^0.0.1
+locks:
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.annot.0.0.1
+  dependencies:
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.stdlib.0.0.1
+    used_as: Stdlib
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: annot
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.code.0.0.1
+  dependencies:
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.stdlib.0.0.1
+    used_as: Stdlib
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-latin-modern.0.0.1
+    used_as: FontLatinModern
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: code
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-ipa-ex.0.0.1
+  dependencies: []
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: font-ipa-ex
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-junicode.0.0.1
+  dependencies: []
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: font-junicode
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-latin-modern.0.0.1
+  dependencies: []
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: font-latin-modern
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-latin-modern-math.0.0.1
+  dependencies: []
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: font-latin-modern-math
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.footnote-scheme.0.0.1
+  dependencies:
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.stdlib.0.0.1
+    used_as: Stdlib
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: footnote-scheme
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.math.0.0.1
+  dependencies:
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.stdlib.0.0.1
+    used_as: Stdlib
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: math
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.std-ja-report.0.0.1
+  dependencies:
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.stdlib.0.0.1
+    used_as: Stdlib
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.math.0.0.1
+    used_as: Math
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.annot.0.0.1
+    used_as: Annot
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.code.0.0.1
+    used_as: Code
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.footnote-scheme.0.0.1
+    used_as: FootnoteScheme
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-junicode.0.0.1
+    used_as: FontJunicode
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-latin-modern.0.0.1
+    used_as: FontLatinModern
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-ipa-ex.0.0.1
+    used_as: FontIpaEx
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-latin-modern-math.0.0.1
+    used_as: FontLatinModernMath
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: std-ja-report
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.stdlib.0.0.1
+  dependencies: []
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: stdlib
+    version: 0.0.1
+- name: local./Users/tsuwa/codes/SATySFi/tests/local-fixed/show-value
+  dependencies:
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.stdlib.0.0.1
+    used_as: Stdlib
+  test_only: false
+  local:
+    absolute_path: /Users/tsuwa/codes/SATySFi/tests/local-fixed/show-value
+dependencies:
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.std-ja-report.0.0.1
+  used_as: StdJaReport
+- name: local./Users/tsuwa/codes/SATySFi/tests/local-fixed/show-value
+  used_as: ShowValue
+test_dependencies: []

--- a/tests/local-fixed/doc.saphe.lock.yaml.expected
+++ b/tests/local-fixed/doc.saphe.lock.yaml.expected
@@ -98,16 +98,16 @@ locks:
     registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
     package_name: stdlib
     version: 0.0.1
-- name: local./Users/tsuwa/codes/SATySFi/tests/local-fixed/show-value
+- name: local.show-value
   dependencies:
   - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.stdlib.0.0.1
     used_as: Stdlib
   test_only: false
   local:
-    absolute_path: /Users/tsuwa/codes/SATySFi/tests/local-fixed/show-value
+    relative_path: show-value
 dependencies:
 - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.std-ja-report.0.0.1
   used_as: StdJaReport
-- name: local./Users/tsuwa/codes/SATySFi/tests/local-fixed/show-value
+- name: local.show-value
   used_as: ShowValue
 test_dependencies: []

--- a/tests/local-fixed/doc.saphe.yaml
+++ b/tests/local-fixed/doc.saphe.yaml
@@ -1,0 +1,21 @@
+ecosystem: "^0.0.1"
+language: "^0.1.0"
+name: "local-fixed"
+authors:
+  - "Takashi Suwa"
+registries:
+  - name: "default"
+    git:
+      url: "https://github.com/SATySFi/default-registry"
+      branch: "temp-dev-saphe"
+contents:
+  document:
+    dependencies:
+      - used_as: "StdJaReport"
+        registered:
+          registry: "default"
+          name: "std-ja-report"
+          requirement: "^0.0.1"
+      - used_as: "ShowValue"
+        local:
+          path: "./show-value/"

--- a/tests/local-fixed/doc.saty
+++ b/tests/local-fixed/doc.saty
@@ -1,0 +1,13 @@
+use package open StdJaReport
+use package ShowValue
+
+document (|
+  title = {The Title of Your Document},
+  author = {Your Name},
+|) '<
+  +chapter{First Chapter}<
+    +p{
+      Hello, world! \ShowValue.int(42 + 57);
+    }
+  >
+>

--- a/tests/local-fixed/show-value/.gitignore
+++ b/tests/local-fixed/show-value/.gitignore
@@ -1,0 +1,1 @@
+satysfi-envelope.yaml

--- a/tests/local-fixed/show-value/saphe.yaml
+++ b/tests/local-fixed/show-value/saphe.yaml
@@ -1,0 +1,21 @@
+ecosystem: "^0.0.1"
+language: "^0.1.0"
+name: "show-value"
+authors:
+  - "Your Name"
+registries:
+  - name: "default"
+    git:
+      url: "https://github.com/SATySFi/default-registry"
+      branch: "temp-dev-saphe"
+contents:
+  library:
+    main_module: "ShowValue"
+    source_directories:
+    - "./src"
+    dependencies:
+      - used_as: "Stdlib"
+        registered:
+          registry: "default"
+          name: "stdlib"
+          requirement: "^0.0.1"

--- a/tests/local-fixed/show-value/src/show-value.satyh
+++ b/tests/local-fixed/show-value/src/show-value.satyh
@@ -1,0 +1,4 @@
+module ShowValue = struct
+  val inline \int n =
+    embed-string (arabic n)
+end


### PR DESCRIPTION
By this PR, we will be able to use `local` dependencies, each of which regards a subdirectory as a (non-versioned) package. See `tests/local-fixed/doc.saphe.yaml`:

```yaml
ecosystem: "^0.0.1"
language: "^0.1.0"
name: "local-fixed"
authors:
  - "Takashi Suwa"
registries:
  - name: "default"
    git:
      url: "https://github.com/SATySFi/default-registry"
      branch: "temp-dev-saphe"
contents:
  document:
    dependencies:
      - used_as: "StdJaReport"
        registered:
          registry: "default"
          name: "std-ja-report"
          requirement: "^0.0.1"
      - used_as: "ShowValue"
        local:
          path: "./show-value/"
```