### PR TITLE
fix mitou-report numbering bug

### DIFF
--- a/lib-satysfi/dist/packages/mitou-report.satyh
+++ b/lib-satysfi/dist/packages/mitou-report.satyh
@@ -397,7 +397,7 @@ end = struct
   let page-number-string pbinfo =
     match !no-page-number-max-ref with
     | None              -> ` `
-    | Some(nopagenomax) -> arabic (pbinfo#page-number + nopagenomax)
+    | Some(nopagenomax) -> arabic (pbinfo#page-number - nopagenomax)
 
 
   let section-scheme ctx label title inner =


### PR DESCRIPTION
This PR fixes a bug of the `mitou-report` package.

I am using the `mitou-report` package, and I noticed that the numbering of pages in the TOC was wrong. It should start at 1.

<img width="894" alt="スクリーンショット 2024-02-26 18 48 35" src="https://github.com/gfngfn/SATySFi/assets/45118249/8d7b73bd-00a5-4555-a729-1fa34a1a2145">

https://github.com/gfngfn/SATySFi/blob/8792aa885536eed2f6ce047fcf302e864d92cf61/lib-satysfi/dist/packages/mitou-report.satyh#L400

I changed `+` in the code above to `-` and it had been correctly numbered.

<img width="781" alt="スクリーンショット 2024-02-26 18 54 20" src="https://github.com/gfngfn/SATySFi/assets/45118249/8c4c853f-e4b4-4aa9-b90c-53ec8d12f1d4">

I don't know the details of the API being used, but comparing line 400 and 365, I guessed that this is a typo.

https://github.com/gfngfn/SATySFi/blob/8792aa885536eed2f6ce047fcf302e864d92cf61/lib-satysfi/dist/packages/mitou-report.satyh#L365