### PR TITLE
Separate `eval_document_file` to `BuildDocument` module

### DIFF
--- a/src/backend/buildDocument.ml
+++ b/src/backend/buildDocument.ml
@@ -1,0 +1,144 @@
+
+open ConfigError
+open MyUtil
+open Types
+
+
+module StoreIDMap = Map.Make(StoreID)
+
+
+type frozen_environment = {
+  frozen_main      : location EvalVarIDMap.t;
+  frozen_store_ref : (syntactic_value StoreIDHashTable.t) ref;
+  frozen_store_map : syntactic_value StoreIDMap.t;
+  frozen_config    : runtime_config;
+}
+
+
+let freeze_environment (env : environment) : frozen_environment =
+  let
+    {
+      env_main   = valenv;
+      env_store  = stenvref;
+      env_config = runtime_config;
+    } = env
+  in
+  let stmap =
+    StoreIDMap.empty |> StoreIDHashTable.fold (fun stid value stmap ->
+      stmap |> StoreIDMap.add stid value
+    ) (!stenvref)
+  in
+  {
+    frozen_main      = valenv;
+    frozen_store_ref = stenvref;
+    frozen_store_map = stmap;
+    frozen_config    = runtime_config;
+  }
+
+
+let unfreeze_environment (frenv : frozen_environment) : environment =
+  let
+    {
+      frozen_main = valenv;
+      frozen_store_ref = stenvref;
+      frozen_store_map = stmap;
+      frozen_config    = runtime_config;
+    } = frenv
+  in
+  let stenv = StoreIDHashTable.create 128 in
+  stmap |> StoreIDMap.iter (fun stid value -> StoreIDHashTable.add stenv stid value);
+  stenvref := stenv;
+  {
+    env_main   = valenv;
+    env_store  = ref stenv;
+    env_config = runtime_config;
+  }
+
+
+let transform_pdf (pdf_config : HandlePdf.config) ~(page_number_limit : int) = function
+  | BaseConstant(BCDocument(paper_size, pbstyle, columnhookf, columnendhookf, pagecontf, pagepartsf, imvblst)) ->
+      begin
+        Logging.start_page_break ();
+        State.start_page_break ();
+        match pbstyle with
+        | SingleColumn ->
+            PageBreak.main pdf_config ~paper_size
+              columnhookf pagecontf pagepartsf imvblst
+
+        | MultiColumn(origin_shifts) ->
+            PageBreak.main_multicolumn pdf_config ~page_number_limit ~paper_size
+              origin_shifts columnhookf columnendhookf pagecontf pagepartsf imvblst
+      end
+
+  | value ->
+      EvalUtil.report_bug_value "main; not a DocumentValue(...)" value
+
+
+let transform_text =
+  EvalUtil.get_string
+
+
+let output_pdf (abspath_out : abs_path) (pdfret : HandlePdf.t) : unit =
+  HandlePdf.write_to_file abspath_out pdfret
+
+
+let output_text (abspath_out : abs_path) (data : string) : unit =
+  Core.Out_channel.write_all (get_abs_path_string abspath_out) ~data
+
+
+(* Initialization that should be performed before every cross-reference-solving loop *)
+let reset_pdf () =
+  ImageInfo.initialize ();
+  NamedDest.initialize ();
+  ()
+
+
+let evaluate (reset : unit -> unit) ~(is_bytecomp_mode : bool) (i : int) (env_freezed : frozen_environment) (ast : abstract_tree) : (syntactic_value, config_error) result =
+  let open ResultMonad in
+  Logging.start_evaluation i;
+  reset ();
+  let env = unfreeze_environment env_freezed in
+  let value =
+    if is_bytecomp_mode then
+      let (value, _) = Bytecomp.compile_and_exec_0 env ast in
+      value
+    else
+      Evaluator.interpret_0 env ast
+  in
+  Logging.end_evaluation ();
+  return value
+
+
+let build_document (transform : syntactic_value -> 'a) (reset : unit -> unit) (output : abs_path -> 'a -> unit) (display_config : Logging.config) ~(is_bytecomp_mode : bool) (env : environment) (ast : abstract_tree) (abspath_out : abs_path) (abspath_dump : abs_path) =
+  let open ResultMonad in
+  let env_freezed = freeze_environment env in
+  let rec aux (i : int) =
+    let* value = evaluate reset ~is_bytecomp_mode i env_freezed ast in
+    let document = transform value in
+    match CrossRef.needs_another_trial abspath_dump with
+    | CrossRef.NeedsAnotherTrial ->
+        Logging.needs_another_trial ();
+        aux (i + 1)
+
+    | CrossRef.CountMax ->
+        Logging.achieve_count_max ();
+        output abspath_out document;
+        Logging.end_output display_config abspath_out;
+        return ()
+
+    | CrossRef.CanTerminate unresolved_crossrefs ->
+        Logging.achieve_fixpoint unresolved_crossrefs;
+        output abspath_out document;
+        Logging.end_output display_config abspath_out;
+        return ()
+  in
+  aux 1
+
+
+let main (output_mode : output_mode) (pdf_config : HandlePdf.config) ~(page_number_limit : int) =
+  match output_mode with
+  | PdfMode ->
+      build_document (transform_pdf pdf_config ~page_number_limit) reset_pdf output_pdf
+
+  | TextMode(_) ->
+      build_document transform_text Fun.id output_text

--- a/src/backend/buildDocument.mli
+++ b/src/backend/buildDocument.mli
@@ -1,0 +1,17 @@
+
+open ConfigError
+open MyUtil
+open Types
+
+
+val main :
+  output_mode ->
+  HandlePdf.config ->
+  page_number_limit:int ->
+  Logging.config ->
+  is_bytecomp_mode:bool ->
+  environment ->
+  abstract_tree ->
+  abs_path ->
+  abs_path ->
+  (unit, config_error) result

--- a/src/backend/handlePdf.ml
+++ b/src/backend/handlePdf.ml
@@ -6,7 +6,7 @@ open HorzBox
 
 
 type t =
-  | PDF of Pdf.t * Pdfpage.t Alist.t * abs_path
+  | PDF of Pdf.t * Pdfpage.t Alist.t
 
 type config = {
   debug_show_bbox        : bool;
@@ -467,7 +467,7 @@ let add_column_to_page
   Page(paper, pagecontsch, Alist.cat opacc opacccolumn, pbinfo)
 
 
-let write_page (config : config) (Page(paper, _pagecontsch, opaccpage, pbinfo) : page) (pagepartsf : page_parts_scheme_func) ((PDF(pdf, pageacc, flnm)) : t) : t =
+let write_page (config : config) (Page(paper, _pagecontsch, opaccpage, pbinfo) : page) (pagepartsf : page_parts_scheme_func) ((PDF(pdf, pageacc)) : t) : t =
 
   let fs = fs_pdf config in
   let paper_height = get_paper_height paper in
@@ -495,15 +495,15 @@ let write_page (config : config) (Page(paper, _pagecontsch, opaccpage, pbinfo) :
   in
   let pagenew = Annotation.add_to_pdf pdf pagenew in
   let () = NamedDest.notify_pagebreak pbinfo.current_page_number in
-  PDF(pdf, Alist.extend pageacc pagenew, flnm)
+  PDF(pdf, Alist.extend pageacc pagenew)
 
 
-let create_empty_pdf (abspath : abs_path) : t =
+let create_empty_pdf () : t =
   let pdf = Pdf.empty () in
-  PDF(pdf, Alist.empty, abspath)
+  PDF(pdf, Alist.empty)
 
 
-let write_to_file ((PDF(pdf, pageacc, abspath)) : t) : unit =
+let write_to_file (abspath : abs_path) ((PDF(pdf, pageacc)) : t) : unit =
   Logging.begin_to_embed_fonts ();
   let pdfdict_font = FontInfo.get_font_dictionary pdf in
   let pdfarr_procset =

--- a/src/backend/handlePdf.mli
+++ b/src/backend/handlePdf.mli
@@ -5,7 +5,7 @@ open HorzBox
 
 type t
 
-val create_empty_pdf : abs_path -> t
+val create_empty_pdf : unit -> t
 
 type config = {
   debug_show_bbox        : bool;
@@ -19,7 +19,7 @@ type page
 
 val write_page : config -> page -> page_parts_scheme_func -> t -> t
 
-val write_to_file : t -> unit
+val write_to_file : abs_path -> t -> unit
 
 val make_empty_page : paper_size:(length * length) -> page_break_info -> page_content_scheme -> page
 

--- a/src/backend/pageBreak.ml
+++ b/src/backend/pageBreak.ml
@@ -1,6 +1,5 @@
 (* -*- coding: utf-8 -*- *)
 
-open MyUtil
 open LengthInterface
 open HorzBox
 
@@ -693,9 +692,9 @@ let chop_single_column_with_insertion (pbinfo : page_break_info) (content_height
   chop_single_column pbinfo content_height (List.append pbvblst_inserted pbvblst)
 
 
-let main (pdf_config : HandlePdf.config) (absname_out : abs_path) ~(paper_size : length * length) (columnhookf : column_hook_func) (pagecontf : page_content_scheme_func) (pagepartsf : page_parts_scheme_func) (vblst : vert_box list) : HandlePdf.t =
+let main (pdf_config : HandlePdf.config) ~(paper_size : length * length) (columnhookf : column_hook_func) (pagecontf : page_content_scheme_func) (pagepartsf : page_parts_scheme_func) (vblst : vert_box list) : HandlePdf.t =
 
-  let pdfinit = HandlePdf.create_empty_pdf absname_out in
+  let pdfinit = HandlePdf.create_empty_pdf () in
 
   let rec aux pageno (pdfacc : HandlePdf.t) pbvblst =
     let pbinfo = { current_page_number = pageno; } in
@@ -714,9 +713,9 @@ let main (pdf_config : HandlePdf.config) (absname_out : abs_path) ~(paper_size :
   aux 1 pdfinit pbvblst
 
 
-let main_multicolumn (pdf_config : HandlePdf.config) ~(page_number_limit : int) (absname_out : abs_path) ~(paper_size : length * length) (origin_shifts : length list) (columnhookf : column_hook_func) (columnendhookf : column_hook_func) (pagecontf : page_content_scheme_func) (pagepartsf : page_parts_scheme_func) (vblst : vert_box list) : HandlePdf.t =
+let main_multicolumn (pdf_config : HandlePdf.config) ~(page_number_limit : int) ~(paper_size : length * length) (origin_shifts : length list) (columnhookf : column_hook_func) (columnendhookf : column_hook_func) (pagecontf : page_content_scheme_func) (pagepartsf : page_parts_scheme_func) (vblst : vert_box list) : HandlePdf.t =
 
-  let pdfinit = HandlePdf.create_empty_pdf absname_out in
+  let pdfinit = HandlePdf.create_empty_pdf () in
 
   let rec iter_on_column
       (pbinfo : page_break_info) (content_height : length)

--- a/src/backend/pageBreak.mli
+++ b/src/backend/pageBreak.mli
@@ -1,5 +1,4 @@
 
-open MyUtil
 open LengthInterface
 open HorzBox
 
@@ -7,9 +6,9 @@ exception PageNumberLimitExceeded of int
 
 val solidify : vert_box list -> intermediate_vert_box list
 
-val main : HandlePdf.config -> abs_path -> paper_size:(length * length) -> column_hook_func -> page_content_scheme_func -> page_parts_scheme_func -> vert_box list -> HandlePdf.t
+val main : HandlePdf.config -> paper_size:(length * length) -> column_hook_func -> page_content_scheme_func -> page_parts_scheme_func -> vert_box list -> HandlePdf.t
 
-val main_multicolumn : HandlePdf.config -> page_number_limit:int -> abs_path -> paper_size:(length * length) -> length list -> column_hook_func -> column_hook_func -> page_content_scheme_func -> page_parts_scheme_func -> vert_box list -> HandlePdf.t
+val main_multicolumn : HandlePdf.config -> page_number_limit:int -> paper_size:(length * length) -> length list -> column_hook_func -> column_hook_func -> page_content_scheme_func -> page_parts_scheme_func -> vert_box list -> HandlePdf.t
 
 val adjust_to_first_line : intermediate_vert_box list -> length * length
 

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -100,8 +100,8 @@ let unfreeze_environment (frenv : frozen_environment) : environment =
   }
 
 
-let output_pdf (pdfret : HandlePdf.t) : unit =
-  HandlePdf.write_to_file pdfret
+let output_pdf (abspath_out : abs_path) (pdfret : HandlePdf.t) : unit =
+  HandlePdf.write_to_file abspath_out pdfret
 
 
 let output_text (abspath_out : abs_path) (data : string) : unit =
@@ -174,11 +174,11 @@ let eval_document_file (display_config : Logging.config) (pdf_config : HandlePdf
             let pdf =
               match pbstyle with
               | SingleColumn ->
-                  PageBreak.main pdf_config abspath_out ~paper_size
+                  PageBreak.main pdf_config ~paper_size
                     columnhookf pagecontf pagepartsf imvblst
 
               | MultiColumn(origin_shifts) ->
-                  PageBreak.main_multicolumn pdf_config ~page_number_limit abspath_out ~paper_size
+                  PageBreak.main_multicolumn pdf_config ~page_number_limit ~paper_size
                     origin_shifts columnhookf columnendhookf pagecontf pagepartsf imvblst
             in
             begin
@@ -189,13 +189,13 @@ let eval_document_file (display_config : Logging.config) (pdf_config : HandlePdf
 
               | CrossRef.CountMax ->
                   Logging.achieve_count_max ();
-                  output_pdf pdf;
+                  output_pdf abspath_out pdf;
                   Logging.end_output display_config abspath_out;
                   return ()
 
               | CrossRef.CanTerminate unresolved_crossrefs ->
                   Logging.achieve_fixpoint unresolved_crossrefs;
-                  output_pdf pdf;
+                  output_pdf abspath_out pdf;
                   Logging.end_output display_config abspath_out;
                   return ()
             end

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -12,19 +12,6 @@ let version =
     (SemanticVersion.to_string Constant.current_language_version)
 
 
-(* Initialization that should be performed before every cross-reference-solving loop *)
-let reset (output_mode : output_mode) =
-  let open ResultMonad in
-  match output_mode with
-  | TextMode(_) ->
-      return ()
-
-  | PdfMode ->
-      ImageInfo.initialize ();
-      NamedDest.initialize ();
-      return ()
-
-
 (* Initialization that should be performed before typechecking *)
 let initialize ~(base_dir : abs_path) ~(is_bytecomp_mode : bool) (output_mode : output_mode) (runtime_config : runtime_config) : Typeenv.t * environment =
   FreeID.initialize ();
@@ -49,65 +36,6 @@ let initialize ~(base_dir : abs_path) ~(is_bytecomp_mode : bool) (output_mode : 
   (tyenv, env)
 
 
-module StoreIDMap = Map.Make(StoreID)
-
-
-type frozen_environment = {
-  frozen_main      : location EvalVarIDMap.t;
-  frozen_store_ref : (syntactic_value StoreIDHashTable.t) ref;
-  frozen_store_map : syntactic_value StoreIDMap.t;
-  frozen_config    : runtime_config;
-}
-
-
-let freeze_environment (env : environment) : frozen_environment =
-  let
-    {
-      env_main   = valenv;
-      env_store  = stenvref;
-      env_config = runtime_config;
-    } = env
-  in
-  let stmap =
-    StoreIDMap.empty |> StoreIDHashTable.fold (fun stid value stmap ->
-      stmap |> StoreIDMap.add stid value
-    ) (!stenvref)
-  in
-  {
-    frozen_main      = valenv;
-    frozen_store_ref = stenvref;
-    frozen_store_map = stmap;
-    frozen_config    = runtime_config;
-  }
-
-
-let unfreeze_environment (frenv : frozen_environment) : environment =
-  let
-    {
-      frozen_main = valenv;
-      frozen_store_ref = stenvref;
-      frozen_store_map = stmap;
-      frozen_config    = runtime_config;
-    } = frenv
-  in
-  let stenv = StoreIDHashTable.create 128 in
-  stmap |> StoreIDMap.iter (fun stid value -> StoreIDHashTable.add stenv stid value);
-  stenvref := stenv;
-  {
-    env_main   = valenv;
-    env_store  = ref stenv;
-    env_config = runtime_config;
-  }
-
-
-let output_pdf (abspath_out : abs_path) (pdfret : HandlePdf.t) : unit =
-  HandlePdf.write_to_file abspath_out pdfret
-
-
-let output_text (abspath_out : abs_path) (data : string) : unit =
-  Core.Out_channel.write_all (get_abs_path_string abspath_out) ~data
-
-
 let eval_library_file (display_config : Logging.config) ~(is_bytecomp_mode : bool) ~(run_tests : bool) (env : environment) (abspath : abs_path) (binds : binding list) : environment =
   Logging.begin_to_eval_file display_config abspath;
   if is_bytecomp_mode then
@@ -119,91 +47,6 @@ let eval_library_file (display_config : Logging.config) ~(is_bytecomp_mode : boo
   else
     let (env, _) = Evaluator.interpret_bindings_0 ~run_tests env binds in
     env
-
-
-let eval_main ~(is_bytecomp_mode : bool) (output_mode : output_mode) (i : int) (env_freezed : frozen_environment) (ast : abstract_tree) : (syntactic_value, config_error) result =
-  let open ResultMonad in
-  Logging.start_evaluation i;
-  let* () = reset output_mode in
-  let env = unfreeze_environment env_freezed in
-  let value =
-    if is_bytecomp_mode then
-      let (value, _) = Bytecomp.compile_and_exec_0 env ast in
-      value
-    else
-      Evaluator.interpret_0 env ast
-  in
-  Logging.end_evaluation ();
-  return value
-
-
-let eval_document_file (display_config : Logging.config) (pdf_config : HandlePdf.config) ~(page_number_limit : int) ~(is_bytecomp_mode : bool) (output_mode : output_mode) (env : environment) (ast : abstract_tree) (abspath_out : abs_path) (abspath_dump : abs_path) =
-  let open ResultMonad in
-  let env_freezed = freeze_environment env in
-  match output_mode with
-  | TextMode(_) ->
-      let rec aux (i : int) =
-        let* value_str = eval_main ~is_bytecomp_mode output_mode i env_freezed ast in
-        let s = EvalUtil.get_string value_str in
-        match CrossRef.needs_another_trial abspath_dump with
-        | CrossRef.NeedsAnotherTrial ->
-            Logging.needs_another_trial ();
-            aux (i + 1)
-
-        | CrossRef.CountMax ->
-            Logging.achieve_count_max ();
-            output_text abspath_out s;
-            Logging.end_output display_config abspath_out;
-            return ()
-
-        | CrossRef.CanTerminate unresolved_crossrefs ->
-            Logging.achieve_fixpoint unresolved_crossrefs;
-            output_text abspath_out s;
-            Logging.end_output display_config abspath_out;
-            return ()
-      in
-      aux 1
-
-  | PdfMode ->
-      let rec aux (i : int) =
-        let* value_doc = eval_main ~is_bytecomp_mode output_mode i env_freezed ast in
-        match value_doc with
-        | BaseConstant(BCDocument(paper_size, pbstyle, columnhookf, columnendhookf, pagecontf, pagepartsf, imvblst)) ->
-            Logging.start_page_break ();
-            State.start_page_break ();
-            let pdf =
-              match pbstyle with
-              | SingleColumn ->
-                  PageBreak.main pdf_config ~paper_size
-                    columnhookf pagecontf pagepartsf imvblst
-
-              | MultiColumn(origin_shifts) ->
-                  PageBreak.main_multicolumn pdf_config ~page_number_limit ~paper_size
-                    origin_shifts columnhookf columnendhookf pagecontf pagepartsf imvblst
-            in
-            begin
-              match CrossRef.needs_another_trial abspath_dump with
-              | CrossRef.NeedsAnotherTrial ->
-                  Logging.needs_another_trial ();
-                  aux (i + 1)
-
-              | CrossRef.CountMax ->
-                  Logging.achieve_count_max ();
-                  output_pdf abspath_out pdf;
-                  Logging.end_output display_config abspath_out;
-                  return ()
-
-              | CrossRef.CanTerminate unresolved_crossrefs ->
-                  Logging.achieve_fixpoint unresolved_crossrefs;
-                  output_pdf abspath_out pdf;
-                  Logging.end_output display_config abspath_out;
-                  return ()
-            end
-
-        | _ ->
-            EvalUtil.report_bug_value "main; not a DocumentValue(...)" value_doc
-      in
-      aux 1
 
 
 (* Performs preprecessing. the evaluation is run by the naive interpreter
@@ -240,7 +83,7 @@ let preprocess_and_evaluate (display_config : Logging.config) (pdf_config : Hand
   (* Performs evaluation: *)
   let env = evaluate_bindings display_config ~is_bytecomp_mode ~run_tests env codebinds in
   let ast_doc = unlift_code code_doc in
-  eval_document_file display_config pdf_config ~page_number_limit ~is_bytecomp_mode output_mode env ast_doc abspath_out abspath_dump
+  BuildDocument.main output_mode pdf_config ~page_number_limit display_config ~is_bytecomp_mode env ast_doc abspath_out abspath_dump
 
 
 let get_candidate_file_extensions (output_mode : output_mode) =


### PR DESCRIPTION
* Removed dependency to `CrossRef`, `PageBreak` from `main.ml`
* Organized some codes which handles `CrossRef`
* Extracted differences between output modes to 3 steps: `transform`, `reset` and `output`
