### PR TITLE
Allow external dependencies in registries

### DIFF
--- a/src-saphe/canonicalRegistryUrl.ml
+++ b/src-saphe/canonicalRegistryUrl.ml
@@ -3,6 +3,7 @@ type error =
   | ContainsQueryParameter of { url : string }
   | NoUriScheme            of { url : string }
   | UnexpectedUrlScheme    of { url : string; scheme : string }
+[@@deriving show { with_path = false }]
 
 
 let make (s_registry_url : string) : (string, error) result =

--- a/src-saphe/packageConstraintSolver.ml
+++ b/src-saphe/packageConstraintSolver.ml
@@ -181,18 +181,27 @@ module SolverInput = struct
     ([], [])
 
 
-  let make_internal_dependency_from_registry (registry_hash_value : string) (context : package_context) (requires : package_dependency_in_registry list) : dependency list =
+  let make_internal_dependency_from_registry (self_registry_hash_value : string) (context : package_context) (requires : package_dependency_in_registry list) : dependency list =
     requires |> List.map (function
-    | PackageDependencyInRegistry{ package_name; used_as; version_requirement } ->
+    | PackageDependencyInRegistry{
+        used_as;
+        external_registry_hash_value;
+        package_name;
+        version_requirement;
+      } ->
         let compatibility =
           match version_requirement with
           | SemanticVersion.CompatibleWith(semver) ->
               SemanticVersion.get_compatibility_unit semver
         in
-        let registered_package_id = RegisteredPackageId.{ package_name; registry_hash_value } in
+        let registry_hash_value =
+          match external_registry_hash_value with
+          | Some(r) -> r
+          | None    -> self_registry_hash_value
+        in
         let role =
           Role.RegisteredRole{
-            registered_package_id;
+            registered_package_id = RegisteredPackageId.{ registry_hash_value; package_name };
             compatibility;
             context;
           }

--- a/src-saphe/packageRegistryArranger.ml
+++ b/src-saphe/packageRegistryArranger.ml
@@ -1,6 +1,5 @@
 
 open PackageSystemBase
-open ConfigError
 
 
 module CanonicalRegistryRemoteSet = Set.Make(struct
@@ -13,34 +12,28 @@ module CanonicalRegistryRemoteSet = Set.Make(struct
 end)
 
 
-type 'a ok = ('a, config_error) result
-
-
-let canonicalize_registry_remote (GitRegistry{ url; branch } : registry_remote) : registry_remote ok =
+let canonicalize_registry_remote (ferr : CanonicalRegistryUrl.error -> 'e) (GitRegistry{ url; branch } : registry_remote) : (registry_remote, 'e) result =
   let open ResultMonad in
-  let* canonical_url =
-    CanonicalRegistryUrl.make url
-     |> Result.map_error (fun e -> CanonicalRegistryUrlError(e))
-  in
+  let* canonical_url = CanonicalRegistryUrl.make url |> Result.map_error ferr in
   return @@ GitRegistry{ url = canonical_url; branch }
 
 
-let rec aux (f : 'a -> registry_remote -> (registry_remote list * 'a) ok) (already_seen : CanonicalRegistryRemoteSet.t) (stack : registry_remote list) (acc : 'a) : 'a ok =
+let rec aux (ferr : CanonicalRegistryUrl.error -> 'e) (f : 'a -> registry_remote -> (registry_remote list * 'a, 'e) result) (already_seen : CanonicalRegistryRemoteSet.t) (stack : registry_remote list) (acc : 'a) : ('a, 'e) result =
   let open ResultMonad in
   match stack with
   | [] ->
       return acc
 
   | r :: stack ->
-      let* canonical_registry_remote = canonicalize_registry_remote r in
+      let* canonical_registry_remote = canonicalize_registry_remote ferr r in
       if already_seen |> CanonicalRegistryRemoteSet.mem canonical_registry_remote then
-        aux f already_seen stack acc
+        aux ferr f already_seen stack acc
       else
         let* (rs, acc) = f acc canonical_registry_remote in
         let already_seen = already_seen |> CanonicalRegistryRemoteSet.add canonical_registry_remote in
         let stack = List.append rs stack in
-        aux f already_seen stack acc
+        aux ferr f already_seen stack acc
 
 
-let main (f : 'a -> registry_remote -> (registry_remote list * 'a) ok) (init_stack : registry_remote list) (init_acc : 'a) : 'a ok =
-  aux f CanonicalRegistryRemoteSet.empty init_stack init_acc
+let main ~err:(ferr : CanonicalRegistryUrl.error -> 'e) (f : 'a -> registry_remote -> (registry_remote list * 'a, 'e) result) (init_stack : registry_remote list) (init_acc : 'a) : ('a, 'e) result =
+  aux ferr f CanonicalRegistryRemoteSet.empty init_stack init_acc

--- a/src-saphe/packageRegistryArranger.ml
+++ b/src-saphe/packageRegistryArranger.ml
@@ -1,0 +1,46 @@
+
+open PackageSystemBase
+open ConfigError
+
+
+module CanonicalRegistryRemoteSet = Set.Make(struct
+  type t = registry_remote
+
+  let compare (r1 : t) (r2 : t) =
+    let GitRegistry{ url = canonical_url1; branch = branch1 } = r1 in
+    let GitRegistry{ url = canonical_url2; branch = branch2 } = r2 in
+    List.compare String.compare [ canonical_url1; branch1 ] [ canonical_url2; branch2 ]
+end)
+
+
+type 'a ok = ('a, config_error) result
+
+
+let canonicalize_registry_remote (GitRegistry{ url; branch } : registry_remote) : registry_remote ok =
+  let open ResultMonad in
+  let* canonical_url =
+    CanonicalRegistryUrl.make url
+     |> Result.map_error (fun e -> CanonicalRegistryUrlError(e))
+  in
+  return @@ GitRegistry{ url = canonical_url; branch }
+
+
+let rec aux (f : 'a -> registry_remote -> (registry_remote list * 'a) ok) (already_seen : CanonicalRegistryRemoteSet.t) (stack : registry_remote list) (acc : 'a) : 'a ok =
+  let open ResultMonad in
+  match stack with
+  | [] ->
+      return acc
+
+  | r :: stack ->
+      let* canonical_registry_remote = canonicalize_registry_remote r in
+      if already_seen |> CanonicalRegistryRemoteSet.mem canonical_registry_remote then
+        aux f already_seen stack acc
+      else
+        let* (rs, acc) = f acc canonical_registry_remote in
+        let already_seen = already_seen |> CanonicalRegistryRemoteSet.add canonical_registry_remote in
+        let stack = List.append rs stack in
+        aux f already_seen stack acc
+
+
+let main (f : 'a -> registry_remote -> (registry_remote list * 'a) ok) (init_stack : registry_remote list) (init_acc : 'a) : 'a ok =
+  aux f CanonicalRegistryRemoteSet.empty init_stack init_acc

--- a/src-saphe/packageRegistryReader.ml
+++ b/src-saphe/packageRegistryReader.ml
@@ -55,7 +55,7 @@ let listup_release_configs (package_name : package_name) (absdir_single_package 
   Alist.to_list acc
 
 
-let main (absdir_registry_repo : abs_path) : ((package_name * implementation_record list) list, config_error) result =
+let main (absdir_registry_repo : abs_path) : ((package_name * (registry_remote list * implementation_record) list) list, config_error) result =
   let open ResultMonad in
 
   (* Lists up package directories: *)
@@ -75,6 +75,7 @@ let main (absdir_registry_repo : abs_path) : ((package_name * implementation_rec
           let*
             PackageReleaseConfig.{
               ecosystem_requirement;
+              registry_remotes;
               package_name = package_name_for_checking;
               implementation;
             } = PackageReleaseConfig.load abspath_release_config
@@ -98,7 +99,7 @@ let main (absdir_registry_repo : abs_path) : ((package_name * implementation_rec
               from_content  = package_version_for_checking;
             }
           else
-            return @@ Alist.extend implacc implementation
+            return @@ Alist.extend implacc (registry_remotes, implementation)
         ) Alist.empty
       in
       return @@ Alist.extend acc (package_name, Alist.to_list implacc)

--- a/src-saphe/packageReleaseConfig.ml
+++ b/src-saphe/packageReleaseConfig.ml
@@ -3,6 +3,7 @@ open MyUtil
 open ConfigError
 open ConfigUtil
 open PackageSystemBase
+open PackageReleaseConfigImpl
 
 
 type 'a ok = ('a, config_error) result
@@ -26,39 +27,95 @@ let source_decoder : implementation_source ConfigDecoder.t =
   ]
 
 
-let dependency_in_registry_config_decoder =
+let dependency_in_registry_config_decoder : parsed_package_dependency_in_registry ConfigDecoder.t =
   let open ConfigDecoder in
   get "used_as" string >>= fun used_as ->
+  get_opt "registry" string >>= fun registry_local_name_option ->
   get "name" package_name_decoder >>= fun package_name ->
   get "requirement" requirement_decoder >>= fun version_requirement ->
-  succeed @@ PackageDependencyInRegistry{
+  succeed @@ ParsedPackageDependencyInRegistry{
     used_as;
+    registry_local_name_option;
     package_name;
     version_requirement;
   }
 
 
-let release_config_decoder : t ConfigDecoder.t =
+let release_config_decoder : parsed_package_release_config ConfigDecoder.t =
   let open ConfigDecoder in
   get "saphe" requirement_decoder >>= fun ecosystem_requirement ->
   get "satysfi" requirement_decoder >>= fun language_requirement ->
   get "name" string >>= fun package_name ->
   get "version" version_decoder >>= fun package_version ->
   get_or_else "source" source_decoder NoSource >>= fun source ->
+  get_or_else "registries" (list registry_spec_decoder) [] >>= fun registry_specs ->
   get "dependencies" (list dependency_in_registry_config_decoder) >>= fun dependencies ->
-  succeed @@ {
+  succeed @@ ParsedPackageReleaseConfig{
+    ecosystem_requirement;
+    language_requirement;
+    package_name;
+    package_version;
+    source;
+    registry_specs;
+    dependencies;
+  }
+
+
+let validate_dependency (localmap : registry_remote RegistryLocalNameMap.t) (p_dep : parsed_package_dependency_in_registry) : package_dependency_in_registry ok =
+  let open ResultMonad in
+  let
+    ParsedPackageDependencyInRegistry{
+      used_as;
+      registry_local_name_option;
+      package_name;
+      version_requirement;
+    } = p_dep
+  in
+  let* external_registry_hash_value =
+    match registry_local_name_option with
+    | None ->
+        return None
+
+    | Some(registry_local_name) ->
+        let* r = ConfigUtil.lookup_registry_hash_value registry_local_name localmap in
+        return @@ Some(r)
+  in
+  return @@ PackageDependencyInRegistry{
+    used_as;
+    external_registry_hash_value;
+    package_name;
+    version_requirement;
+  }
+
+let validate (p_package_release_config : parsed_package_release_config) : t ok =
+  let open ResultMonad in
+  let
+    ParsedPackageReleaseConfig{
+      ecosystem_requirement;
+      language_requirement;
+      package_name;
+      package_version;
+      source;
+      registry_specs;
+      dependencies;
+    } = p_package_release_config
+  in
+  let* (localmap, registry_remotes) = ConfigUtil.construct_registry_local_map registry_specs in
+  let* dependencies = mapM (validate_dependency localmap) dependencies in
+  return @@ {
     ecosystem_requirement;
     package_name;
     implementation = ImplRecord{
       language_requirement;
       package_version;
       source;
+      registry_remotes;
       dependencies;
     };
   }
 
 
-let parse (s : string) : (t, yaml_error) result =
+let parse (s : string) : (parsed_package_release_config, yaml_error) result =
   ConfigDecoder.run release_config_decoder s
 
 
@@ -68,5 +125,8 @@ let load (abspath_release_config : abs_path) : t ok =
     read_file abspath_release_config
       |> Result.map_error (fun _ -> ReleaseConfigNotFound(abspath_release_config))
   in
-  parse s
-    |> Result.map_error (fun e -> ReleaseConfigError(abspath_release_config, e))
+  let* internal =
+    parse s
+      |> Result.map_error (fun e -> ReleaseConfigError(abspath_release_config, e))
+  in
+  validate internal

--- a/src-saphe/packageReleaseConfig.ml
+++ b/src-saphe/packageReleaseConfig.ml
@@ -10,6 +10,7 @@ type 'a ok = ('a, config_error) result
 
 type t = {
   ecosystem_requirement : SemanticVersion.requirement;
+  registry_remotes      : registry_remote list;
   package_name          : package_name;
   implementation        : implementation_record;
 }
@@ -105,11 +106,11 @@ let validate (p_package_release_config : parsed_package_release_config) : t ok =
   return @@ {
     ecosystem_requirement;
     package_name;
+    registry_remotes;
     implementation = ImplRecord{
       language_requirement;
       package_version;
       source;
-      registry_remotes;
       dependencies;
     };
   }

--- a/src-saphe/packageReleaseConfigImpl.ml
+++ b/src-saphe/packageReleaseConfigImpl.ml
@@ -1,0 +1,24 @@
+
+open PackageSystemBase
+
+
+type parsed_package_dependency_in_registry =
+  | ParsedPackageDependencyInRegistry of {
+      used_as                    : string;
+      registry_local_name_option : registry_local_name option;
+      package_name               : package_name;
+      version_requirement        : SemanticVersion.requirement;
+    }
+[@@deriving show { with_path = false }]
+
+type parsed_package_release_config =
+  | ParsedPackageReleaseConfig of {
+      ecosystem_requirement : SemanticVersion.requirement;
+      language_requirement  : SemanticVersion.requirement;
+      package_name          : package_name;
+      package_version       : SemanticVersion.t;
+      source                : implementation_source;
+      registry_specs        : (registry_local_name * registry_remote) list;
+      dependencies          : parsed_package_dependency_in_registry list;
+    }
+[@@deriving show { with_path = false }]

--- a/src-saphe/packageSystemBase.ml
+++ b/src-saphe/packageSystemBase.ml
@@ -129,9 +129,10 @@ type package_dependency =
 
 type package_dependency_in_registry =
   | PackageDependencyInRegistry of {
-      package_name        : package_name;
-      used_as             : string;
-      version_requirement : SemanticVersion.requirement;
+      used_as                      : string;
+      external_registry_hash_value : registry_hash_value option;
+      package_name                 : package_name;
+      version_requirement          : SemanticVersion.requirement;
     }
 [@@deriving show { with_path = false }]
 
@@ -143,11 +144,19 @@ type implementation_source =
     }
 [@@deriving show { with_path = false }]
 
+type registry_remote =
+  | GitRegistry of {
+      url    : string;
+      branch : string;
+    }
+[@@deriving show { with_path = false }]
+
 type implementation_record =
   | ImplRecord of {
       language_requirement : SemanticVersion.requirement;
       package_version      : SemanticVersion.t;
       source               : implementation_source;
+      registry_remotes     : registry_remote list;
       dependencies         : package_dependency_in_registry list;
     }
 [@@deriving show { with_path = false }]
@@ -188,13 +197,6 @@ type implementation_spec =
       lock   : Lock.t;
       source : implementation_source;
     }
-
-type registry_remote =
-  | GitRegistry of {
-      url    : string;
-      branch : string;
-    }
-[@@deriving show { with_path = false }]
 
 type extraction = {
   extracted_from : string;

--- a/src-saphe/packageSystemBase.ml
+++ b/src-saphe/packageSystemBase.ml
@@ -156,7 +156,6 @@ type implementation_record =
       language_requirement : SemanticVersion.requirement;
       package_version      : SemanticVersion.t;
       source               : implementation_source;
-      registry_remotes     : registry_remote list;
       dependencies         : package_dependency_in_registry list;
     }
 [@@deriving show { with_path = false }]

--- a/test/saphe/packageConstraintSolverTest.ml
+++ b/test/saphe/packageConstraintSolverTest.ml
@@ -44,12 +44,11 @@ let make_dependency_in_registry ~(used_as : string) ?(external_registry_hash_val
   }
 
 
-let make_impl (s_version : string) ?(registry_remotes : registry_remote list = []) (deps : package_dependency_in_registry list) : implementation_record =
+let make_impl (s_version : string) (deps : package_dependency_in_registry list) : implementation_record =
   ImplRecord{
     language_requirement  = SemanticVersion.CompatibleWith(language_version);
     package_version       = make_version s_version;
     source                = NoSource;
-    registry_remotes      = registry_remotes;
     dependencies          = deps;
   }
 
@@ -245,7 +244,6 @@ let solve_test_4 () =
         ];
         make_entry "bar" [
           make_impl "1.0.0"
-            ~registry_remotes:[ GitRegistry{ url = "example.com"; branch = "master" } ] (* Dummy *)
             [
                make_dependency_in_registry
                  ~used_as:"Foo" ~external_registry_hash_value "foo" "2.0.0"

--- a/test/saphe/packageConstraintSolverTest.ml
+++ b/test/saphe/packageConstraintSolverTest.ml
@@ -5,7 +5,7 @@ module Constant = SapheMain__Constant
 module PackageConstraintSolver = SapheMain__PackageConstraintSolver
 
 
-let registry_hash_value =
+let default_registry_hash_value =
   "c0bebeef4423"
 
 
@@ -17,7 +17,7 @@ let language_version =
   make_version "0.1.0"
 
 
-let make_registered_dependency ~(used_as : string) (package_name : package_name) (s_version : string) : package_dependency =
+let make_registered_dependency ~(used_as : string) ?(registry_hash_value : registry_hash_value = default_registry_hash_value) (package_name : package_name) (s_version : string) : package_dependency =
   PackageDependency{
     used_as;
     spec =
@@ -54,23 +54,23 @@ let make_impl (s_version : string) ?(registry_remotes : registry_remote list = [
   }
 
 
-let make_registered_lock (package_name : package_name) (s_version : string) : RegisteredLock.t =
+let make_registered_lock ?(registry_hash_value : registry_hash_value = default_registry_hash_value) (package_name : package_name) (s_version : string) : RegisteredLock.t =
   RegisteredLock.{
     registered_package_id = RegisteredPackageId.{ package_name; registry_hash_value };
     locked_version        = make_version s_version;
   }
 
 
-let make_locked_dependency ~(used_as : string) (package_name : package_name) (s_version : string) : locked_dependency =
+let make_locked_dependency ~(used_as : string) ?(registry_hash_value : registry_hash_value = default_registry_hash_value) (package_name : package_name) (s_version : string) : locked_dependency =
   {
-    depended_lock      = Lock.Registered(make_registered_lock package_name s_version);
+    depended_lock      = Lock.Registered(make_registered_lock ~registry_hash_value package_name s_version);
     dependency_used_as = used_as;
   }
 
 
-let make_registered_solution ?(explicitly_depended : string option) ?(test_only : bool = false) (package_name : package_name) (s_version : string) (deps : locked_dependency list) : package_solution =
+let make_registered_solution ?(explicitly_depended : string option) ?(test_only : bool = false) ?(registry_hash_value : registry_hash_value = default_registry_hash_value) (package_name : package_name) (s_version : string) (deps : locked_dependency list) : package_solution =
   {
-    lock                = Lock.Registered(make_registered_lock package_name s_version);
+    lock                = Lock.Registered(make_registered_lock ~registry_hash_value package_name s_version);
     locked_source       = NoSource;
     locked_dependencies = deps;
     used_in_test_only   = test_only;
@@ -95,11 +95,18 @@ let check package_context dependencies_with_flags expected =
   Alcotest.(check (option (list (of_pp pp_package_solution)))) "solutions" expected got
 
 
-let make_registered_package_impls =
-  List.fold_left (fun map (package_name, impls) ->
+type entry = registry_hash_value * package_name * implementation_record list
+
+
+let make_registered_package_impls : entry list -> (implementation_record list) RegisteredPackageIdMap.t =
+  List.fold_left (fun map (registry_hash_value, package_name, impls) ->
     let registered_package_id = RegisteredPackageId.{ package_name; registry_hash_value } in
     map |> RegisteredPackageIdMap.add registered_package_id impls
   ) RegisteredPackageIdMap.empty
+
+
+let make_entry ?(registry_hash_value : registry_hash_value = default_registry_hash_value) (package_name : package_name) (impls : implementation_record list) : entry =
+  (registry_hash_value, package_name, impls)
 
 
 let make_local_fixed_dependencies =
@@ -113,16 +120,16 @@ let solve_test_1 () =
     let local_fixed_dependencies = make_local_fixed_dependencies [] in
     let registered_package_impls =
       make_registered_package_impls [
-        ("foo", [
+        make_entry "foo" [
           make_impl "1.0.0" [];
           make_impl "2.0.0" [];
-        ]);
-        ("bar", [
+        ];
+        make_entry "bar" [
           make_impl "1.0.0" [ make_dependency_in_registry ~used_as:"Foo" "foo" "2.0.0" ];
-        ]);
-        ("qux", [
+        ];
+        make_entry "qux" [
           make_impl "1.0.0" [ make_dependency_in_registry ~used_as:"Foo" "foo" "1.0.0" ];
-        ]);
+        ];
       ]
     in
     { language_version; local_fixed_dependencies; registered_package_impls }
@@ -153,16 +160,16 @@ let solve_test_2 () =
     let local_fixed_dependencies = make_local_fixed_dependencies [] in
     let registered_package_impls =
       make_registered_package_impls [
-        ("foo", [
+        make_entry "foo" [
           make_impl "1.0.0" [];
           make_impl "1.1.0" [];
-        ]);
-        ("bar", [
+        ];
+        make_entry "bar" [
           make_impl "1.0.0" [ make_dependency_in_registry ~used_as:"FooA" "foo" "1.1.0" ];
-        ]);
-        ("qux", [
+        ];
+        make_entry "qux" [
           make_impl "1.0.0" [ make_dependency_in_registry ~used_as:"FooB" "foo" "1.0.0" ];
-        ]);
+        ];
       ]
     in
     { language_version; local_fixed_dependencies; registered_package_impls }
@@ -197,12 +204,12 @@ let solve_test_3 () =
     in
     let registered_package_impls =
       make_registered_package_impls [
-        ("foo", [
+        make_entry "foo" [
           make_impl "1.0.0" [];
-        ]);
-        ("bar", [
+        ];
+        make_entry "bar" [
           make_impl "1.0.0" [ make_dependency_in_registry ~used_as:"FooA" "foo" "1.0.0" ];
-        ]);
+        ];
       ]
     in
     { language_version; local_fixed_dependencies; registered_package_impls }
@@ -226,9 +233,61 @@ let solve_test_3 () =
   check package_context dependencies_with_flags expected
 
 
+let solve_test_4 () =
+  let external_registry_hash_value = "effec4f01023" in
+  let package_context =
+    let local_fixed_dependencies = make_local_fixed_dependencies [] in
+    let registered_package_impls =
+      make_registered_package_impls [
+        make_entry ~registry_hash_value:external_registry_hash_value "foo" [
+          make_impl "1.0.0" [];
+          make_impl "2.0.0" [];
+        ];
+        make_entry "bar" [
+          make_impl "1.0.0"
+            ~registry_remotes:[ GitRegistry{ url = "example.com"; branch = "master" } ] (* Dummy *)
+            [
+               make_dependency_in_registry
+                 ~used_as:"Foo" ~external_registry_hash_value "foo" "2.0.0"
+            ];
+        ];
+        make_entry "qux" [
+          make_impl "1.0.0" [ make_dependency_in_registry ~used_as:"Bar" "bar" "1.0.0" ];
+        ];
+      ]
+    in
+    { language_version; local_fixed_dependencies; registered_package_impls }
+  in
+  let dependencies_with_flags =
+    [
+      (SourceDependency, make_registered_dependency ~used_as:"Bar" "bar" "1.0.0");
+      (SourceDependency, make_registered_dependency ~used_as:"Qux" "qux" "1.0.0");
+    ]
+  in
+  let expected =
+    Some([
+      make_registered_solution ~explicitly_depended:"Bar"
+        "bar" "1.0.0" [
+          make_locked_dependency
+            ~used_as:"Foo" ~registry_hash_value:external_registry_hash_value "foo" "2.0.0";
+        ];
+      make_registered_solution ~explicitly_depended:"Qux"
+        "qux" "1.0.0" [
+          make_locked_dependency
+            ~used_as:"Bar" "bar" "1.0.0"
+        ];
+      make_registered_solution
+        ~registry_hash_value:external_registry_hash_value
+        "foo" "2.0.0" [];
+    ])
+  in
+  check package_context dependencies_with_flags expected
+
+
 let test_cases =
   Alcotest.[
-    test_case "solve 1" `Quick solve_test_1;
-    test_case "solve 2" `Quick solve_test_2;
-    test_case "solve 3" `Quick solve_test_3;
+    test_case "solve 1 (basic)" `Quick solve_test_1;
+    test_case "solve 2 (different versions of a common package)" `Quick solve_test_2;
+    test_case "solve 3 (local fixed dependencies)" `Quick solve_test_3;
+    test_case "solve 4 (external registries)" `Quick solve_test_4;
   ]

--- a/test/saphe/packageConstraintSolverTest.ml
+++ b/test/saphe/packageConstraintSolverTest.ml
@@ -35,19 +35,21 @@ let make_local_fixed_dependency ~(used_as : string) (abspathstr : string) : pack
   }
 
 
-let make_dependency_in_registry ~(used_as : string) (package_name : package_name) (s_version : string) : package_dependency_in_registry =
+let make_dependency_in_registry ~(used_as : string) ?(external_registry_hash_value : registry_hash_value option) (package_name : package_name) (s_version : string) : package_dependency_in_registry =
   PackageDependencyInRegistry{
     used_as;
+    external_registry_hash_value;
     package_name;
     version_requirement = SemanticVersion.CompatibleWith(make_version s_version);
   }
 
 
-let make_impl (s_version : string) (deps : package_dependency_in_registry list) : implementation_record =
+let make_impl (s_version : string) ?(registry_remotes : registry_remote list = []) (deps : package_dependency_in_registry list) : implementation_record =
   ImplRecord{
     language_requirement  = SemanticVersion.CompatibleWith(language_version);
     package_version       = make_version s_version;
     source                = NoSource;
+    registry_remotes      = registry_remotes;
     dependencies          = deps;
   }
 

--- a/test/saphe/packageRegistryArrangerTest.ml
+++ b/test/saphe/packageRegistryArrangerTest.ml
@@ -1,0 +1,43 @@
+
+open SapheMain__PackageSystemBase
+module PackageRegistryArranger = SapheMain__PackageRegistryArranger
+module CanonicalRegistryUrl = SapheMain__CanonicalRegistryUrl
+
+
+let error = Alcotest.of_pp CanonicalRegistryUrl.pp_error
+
+
+let solve_test () =
+  let open ResultMonad in
+  let make url = GitRegistry{ url; branch = "master" } in
+  let a = make "https://url-a.com" in
+  let b = make "https://url-b.com" in
+  let c = make "https://url-c.com" in
+  let d = make "https://url-d.com" in
+  let e = make "https://url-e.com" in
+  let got =
+    PackageRegistryArranger.main
+      ~err:(fun e -> e)
+      (fun n (GitRegistry{ url; _ }) ->
+        let (i, deps) =
+          match url with
+          | "https://url-a.com" -> (1, [e; b])
+          | "https://url-b.com" -> (10, [a; e])
+          | "https://url-c.com" -> (100, [a; c])
+          | "https://url-d.com" -> (1000, [d])
+          | "https://url-e.com" -> (10000, [d])
+          | _                   -> assert false
+        in
+        return (deps, n + i)
+      )
+      [a]
+      0
+  in
+  let expected = Ok(11011) in  (* Only `c` is ignored *)
+  Alcotest.(check (result int error)) "check" expected got
+
+
+let test_cases =
+  Alcotest.[
+    test_case "solve" `Quick solve_test;
+  ]

--- a/test/saphe/packageReleaseConfigTest.ml
+++ b/test/saphe/packageReleaseConfigTest.ml
@@ -36,6 +36,66 @@ let expected1 =
   }
 
 
+let input2 = {yaml|
+saphe: "^0.0.1"
+satysfi: "^0.1.0"
+name: "foo"
+version: "0.0.1"
+source:
+  tar_gzip:
+    url: "https://example.com/packages/foo.tar.gz"
+    checksum: "c0bebeef4423abad1dea"
+authors:
+- "Takashi Suwa"
+registries:
+- name: "an-external-registry"
+  git:
+    url: "https://example.com/an-external-registry"
+    branch: "master"
+dependencies:
+- used_as: "Bar"
+  registry: "an-external-registry"
+  name: "bar"
+  requirement: "^1.0.0"
+- used_as: "Qux"
+  name: "qux"
+  requirement: "^1.2.1"
+|yaml}
+
+
+let expected2 =
+  ParsedPackageReleaseConfig{
+    ecosystem_requirement = CompatibleWith(make_version "0.0.1");
+    language_requirement = CompatibleWith(make_version "0.1.0");
+    package_name          = "foo";
+    package_version       = make_version "0.0.1";
+    source = TarGzip{
+      url      = "https://example.com/packages/foo.tar.gz";
+      checksum = "c0bebeef4423abad1dea";
+    };
+    registry_specs = [
+      ("an-external-registry", GitRegistry{
+        url    = "https://example.com/an-external-registry";
+        branch = "master";
+      });
+    ];
+    dependencies = [
+      ParsedPackageDependencyInRegistry{
+        used_as                    = "Bar";
+        registry_local_name_option = Some("an-external-registry");
+        package_name               = "bar";
+        version_requirement        = CompatibleWith(make_version "1.0.0");
+      };
+      ParsedPackageDependencyInRegistry{
+        used_as                    = "Qux";
+        registry_local_name_option = None;
+        package_name               = "qux";
+        version_requirement        = CompatibleWith(make_version "1.2.1");
+      };
+    ];
+  }
+
+
 let parsed_release_config = Alcotest.of_pp pp_parsed_package_release_config
 let yaml_error = Alcotest.of_pp pp_yaml_error
 
@@ -46,7 +106,14 @@ let parse_test_1 () =
   Alcotest.(check (result parsed_release_config yaml_error)) "parse" expected got
 
 
+let parse_test_2 () =
+  let got = PackageReleaseConfig.parse input2 in
+  let expected = Ok(expected2) in
+  Alcotest.(check (result parsed_release_config yaml_error)) "parse" expected got
+
+
 let test_cases =
   Alcotest.[
-    test_case "parse 1" `Quick parse_test_1;
+    test_case "parse 1 (basic)" `Quick parse_test_1;
+    test_case "parse 2 (external registries)" `Quick parse_test_2;
   ]

--- a/test/saphe/packageReleaseConfigTest.ml
+++ b/test/saphe/packageReleaseConfigTest.ml
@@ -1,6 +1,7 @@
 
 open SapheMain__ConfigError
 open SapheMain__PackageSystemBase
+open SapheMain__PackageReleaseConfigImpl
 open SapheTestUtil
 module PackageReleaseConfig = SapheMain__PackageReleaseConfig
 
@@ -21,22 +22,21 @@ dependencies: []
 
 
 let expected1 =
-  PackageReleaseConfig.{
+  ParsedPackageReleaseConfig{
     ecosystem_requirement = CompatibleWith(make_version "0.0.1");
+    language_requirement = CompatibleWith(make_version "0.1.0");
     package_name          = "stdlib";
-    implementation = ImplRecord{
-      language_requirement = CompatibleWith(make_version "0.1.0");
-      package_version      = make_version "0.0.1";
-      source = TarGzip{
-        url      = "https://example.com/packages/stdlib.tar.gz";
-        checksum = "c0bebeef4423abad1dea";
-      };
-      dependencies         = [];
+    package_version       = make_version "0.0.1";
+    source = TarGzip{
+      url      = "https://example.com/packages/stdlib.tar.gz";
+      checksum = "c0bebeef4423abad1dea";
     };
+    registry_specs        = [];
+    dependencies          = [];
   }
 
 
-let parsed_release_config = Alcotest.of_pp PackageReleaseConfig.pp
+let parsed_release_config = Alcotest.of_pp pp_parsed_package_release_config
 let yaml_error = Alcotest.of_pp pp_yaml_error
 
 

--- a/test/saphe/packageReleaseConfigTest.ml
+++ b/test/saphe/packageReleaseConfigTest.ml
@@ -24,7 +24,7 @@ dependencies: []
 let expected1 =
   ParsedPackageReleaseConfig{
     ecosystem_requirement = CompatibleWith(make_version "0.0.1");
-    language_requirement = CompatibleWith(make_version "0.1.0");
+    language_requirement  = CompatibleWith(make_version "0.1.0");
     package_name          = "stdlib";
     package_version       = make_version "0.0.1";
     source = TarGzip{
@@ -66,7 +66,7 @@ dependencies:
 let expected2 =
   ParsedPackageReleaseConfig{
     ecosystem_requirement = CompatibleWith(make_version "0.0.1");
-    language_requirement = CompatibleWith(make_version "0.1.0");
+    language_requirement  = CompatibleWith(make_version "0.1.0");
     package_name          = "foo";
     package_version       = make_version "0.0.1";
     source = TarGzip{

--- a/test/saphe/sapheTest.ml
+++ b/test/saphe/sapheTest.ml
@@ -5,4 +5,5 @@ let () =
     ("PackageConfig", PackageConfigTest.test_cases);
     ("PackageReleaseConfig", PackageReleaseConfigTest.test_cases);
     ("PackageConstraintSolver", PackageConstraintSolverTest.test_cases);
+    ("PackageRegistryArranger", PackageRegistryArrangerTest.test_cases);
   ]


### PR DESCRIPTION
(See https://github.com/gfngfn/SATySFi/pull/422)

You will be able to use external registries in your package release configs:

```diff
 saphe: "^0.0.1"
 satysfi: "^0.1.0"
 name: "your-cool-pkg"
 version: "0.0.1"
 source:
   tar_gzip:
     url: "https://foo.com/your-cool-pkg.0.0.1.tar.gz"
     checksum: "52fb5bf621027c218c2522d4ccb1e375"
+registries:
+- name: "an-external-registry"
+  git:
+    url: "https://bar.com/an-external-registry"
+    branch: "master"
 dependencies:
 - used_as: "Stdlib"
   name: "stdlib"
   requirement: "^0.0.1"
 - used_as: "YourLibrary"
+  registry: "an-external-registry"
   name: "your-library"
   requirement: "^0.0.1"
```