### PR TITLE
`Pervasives` -> `Stdlib`

### DIFF
--- a/src/backend/fontFormat.ml
+++ b/src/backend/fontFormat.ml
@@ -369,14 +369,14 @@ let per_mille ~(units_per_em : int) (w : design_units) : per_mille =
 module GSet = Set.Make
   (struct
     type t = original_glyph_id
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end)
 
 
 module GMap = Map.Make
   (struct
     type t = original_glyph_id
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end)
 
 
@@ -1973,7 +1973,7 @@ module MathInfoMap = Map.Make
   (struct
     type t = original_glyph_id
     let equal = (=)
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end)
 
 

--- a/src/backend/horzBox.ml
+++ b/src/backend/horzBox.ml
@@ -177,7 +177,7 @@ let pp_math_variant_style =
 module MathVariantCharMap = Map.Make
   (struct
     type t = Uchar.t * math_char_class
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end)
 
 

--- a/src/chardecoder/charBasis.ml
+++ b/src/chardecoder/charBasis.ml
@@ -21,14 +21,14 @@ type script =
 module ScriptSchemeMap = Map.Make
   (struct
     type t = script
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end)
 
 
 module ScriptSpaceMap = Map.Make
   (struct
     type t = script * script
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end)
 
 

--- a/src/frontend/evalVarID.ml
+++ b/src/frontend/evalVarID.ml
@@ -25,7 +25,7 @@ let equal evid1 evid2 =
 
 
 let compare evid1 evid2 =
-  Pervasives.compare evid1.number evid2.number
+  Stdlib.compare evid1.number evid2.number
 
 
 let show_direct evid =

--- a/src/frontend/exhchecker.ml
+++ b/src/frontend/exhchecker.ml
@@ -34,7 +34,7 @@ and expand_type =
 
 module ElementSet = Set.Make(struct
   type t = type_element
-  let compare = Pervasives.compare
+  let compare = Stdlib.compare
 end)
 
 

--- a/src/frontend/storeID.ml
+++ b/src/frontend/storeID.ml
@@ -11,7 +11,7 @@ let min_id_in_document = ref 0
 let equal = (=)
 
 
-let compare = Pervasives.compare
+let compare = Stdlib.compare
 
 
 let hash = Hashtbl.hash

--- a/src/frontend/typechecker.ml
+++ b/src/frontend/typechecker.ml
@@ -111,7 +111,7 @@ let rec is_nonexpansive_expression e =
 module PatternVarMap = Map.Make
   (struct
     type t = var_name
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end)
 
 


### PR DESCRIPTION
The `Pervasives` module is no longer included in OCaml 5.0, and `Stdlib` is the recommended replacement. `Stdlib` itself has been included since OCaml 4.07 and is stable enough.