### PR TITLE
fix duplication of font-latin-bold

### DIFF
--- a/lib-satysfi/dist/packages/stdjareport.satyh
+++ b/lib-satysfi/dist/packages/stdjareport.satyh
@@ -35,7 +35,6 @@ module StdJaReport : sig
   val font-latin-roman  : string * float * float
   val font-latin-bold   : string * float * float
   val font-latin-italic : string * float * float
-  val font-latin-bold   : string * float * float
   val font-latin-sans   : string * float * float
   val font-latin-mono   : string * float * float
   val font-cjk-mincho   : string * float * float
@@ -117,7 +116,6 @@ end = struct
   let font-latin-roman  = (`Junicode`   , font-ratio-latin, 0.)
   let font-latin-bold   = (`Junicode-b` , font-ratio-latin, 0.)
   let font-latin-italic = (`Junicode-it`, font-ratio-latin, 0.)
-  let font-latin-bold   = (`Junicode-b` , font-ratio-latin, 0.)
   let font-latin-sans   = (`lmsans`    , font-ratio-latin, 0.)
   let font-latin-mono   = (`lmmono`    , font-ratio-latin, 0.)
   let font-cjk-mincho   = (`ipaexm`    , font-ratio-cjk  , 0.)


### PR DESCRIPTION
I removed lines 38 and 120 in stdjareport.satyh. They duplicated some of the changes in 25b83af which had been committed by the time #126 was merged.