### PR TITLE
(For 0.1.0-alpha.1) Refine `Stdlib`’s interface

### DIFF
--- a/default-registry-commit-hash.txt
+++ b/default-registry-commit-hash.txt
@@ -1,1 +1,1 @@
-eb530c83e714b51427899bfa4eb14215b8d32322	refs/heads/temp-dev-saphe
+297fe64dcb0b91003b7fb4274d485791bcce0701	refs/heads/temp-dev-saphe

--- a/default-registry-commit-hash.txt
+++ b/default-registry-commit-hash.txt
@@ -1,1 +1,1 @@
-c1ad31ed4912da52369285287716a6e2242435eb	refs/heads/temp-dev-saphe
+6f999952b41a3e7480a833f72ac173327765ddba	refs/heads/temp-dev-saphe

--- a/default-registry-commit-hash.txt
+++ b/default-registry-commit-hash.txt
@@ -1,1 +1,1 @@
-297fe64dcb0b91003b7fb4274d485791bcce0701	refs/heads/temp-dev-saphe
+c1ad31ed4912da52369285287716a6e2242435eb	refs/heads/temp-dev-saphe

--- a/demo/demo.saty
+++ b/demo/demo.saty
@@ -1,5 +1,5 @@
 use package open Stdlib
-use package open Stdlib.Pervasives
+use package open Stdlib.Logo
 use package open Math
 use package open Annot
 use package open Code
@@ -222,17 +222,17 @@ document ?(
                     | (x0 :: x1 :: _ :: x3 :: _, xlast :: _) ->
                         let grlstY1 =
                           [y1, y2] |> List.map (fun y ->
-                            stroke 0.5pt Color.black (Gr.line (x0, y) (xlast, y)))
+                            stroke 0.5pt Color.black (Path.line (x0, y) (xlast, y)))
                         in
                         let grlstY2 =
                           [y0, ylast] |> List.map (fun y ->
-                            stroke 1pt Color.black (Gr.line (x0, y) (xlast, y)))
+                            stroke 1pt Color.black (Path.line (x0, y) (xlast, y)))
                         in
                         let grlstX =
                           [x1, x3] |> List.map (fun x ->
-                            stroke 0.5pt Color.black (Gr.line (x, y0) (x, ylast)))
+                            stroke 0.5pt Color.black (Path.line (x, y0) (x, ylast)))
                         in
-                        (stroke 0.5pt Color.black (Gr.line (x0, y1) (x1, y2)))
+                        (stroke 0.5pt Color.black (Path.line (x0, y1) (x1, y2)))
                           :: (List.append grlstX (List.append grlstY1 grlstY2))
 
                     | _ -> []

--- a/demo/local.satyh
+++ b/demo/local.satyh
@@ -8,13 +8,11 @@ use package StdJaBook
 
 module Local = struct
 
-
   val inline ctx \gray inner =
     let pads-code = (2pt, 2pt, 2pt, 2pt) in
     let decoset-code = HDecoSet.rectangle-round-fill 4pt 2pt (Color.gray 0.9) in
     let ib-frame = inline-frame-breakable pads-code decoset-code (read-inline ctx inner) in
-      script-guard Latin ib-frame
-
+    script-guard Latin ib-frame
 
   val inline ctx \dfn word =
     let ctx-dfn =
@@ -22,55 +20,46 @@ module Local = struct
           |> StdJaBook.set-cjk-font StdJaBook.font-cjk-gothic
           |> set-text-color (RGB(0.8, 0., 0.))
     in
-      read-inline ctx-dfn word
-
+    read-inline ctx-dfn word
 
   val inline ctx \file filename =
     let ctx-file =
       ctx |> StdJaBook.set-latin-font StdJaBook.font-latin-mono
     in
-      script-guard Latin (read-inline ctx-file filename)
-
+    script-guard Latin (read-inline ctx-file filename)
 
   val math ctx \sums m1 m2 =
     read-math ctx ${\Math.sum_{#m1}^{#m2}}
 
-
   val math ctx \limto m1 m2 =
     read-math ctx ${\Math.lim_{#m1 \Math.to #m2}}
-
 
   val block ctx +frame content =
     let pads = (10pt, 10pt, 10pt, 10pt) in
     let decoset = VDecoSet.simple-frame-stroke 1pt (Color.gray 0.75) in
-      block-frame-breakable ctx pads decoset (fun ctx -> read-block ctx content)
-
+    block-frame-breakable ctx pads decoset (fun ctx -> read-block ctx content)
 
   val block ctx +centering it =
     line-break true true ctx (inline-fil ++ read-inline ctx it ++ inline-fil)
 
-
   val block ctx +p-latin content =
     let ctx-latin = ctx |> set-font-size (get-font-size ctx *' 1.2) |> set-leading 20pt in
-      line-break true true ctx-latin
-        (inline-skip ((get-font-size ctx-latin) *' 2.) ++ read-inline ctx-latin content ++ inline-fil)
-
+    line-break true true ctx-latin
+      (inline-skip ((get-font-size ctx-latin) *' 2.) ++ read-inline ctx-latin content ++ inline-fil)
 
   val block ctx +image-frame content =
     let pads = (10pt, 10pt, 10pt, 10pt) in
     let decoset = VDecoSet.simple-frame-stroke 1pt Color.black in
-      block-frame-breakable ctx pads decoset (fun ctx -> read-block ctx '<+centering{#content;}>)
-
+    block-frame-breakable ctx pads decoset (fun ctx -> read-block ctx '<+centering{#content;}>)
 
   val block ctx +paragraph-frame content =
     let pads = (15pt, 15pt, 15pt, 15pt) in
     let decoset = VDecoSet.simple-frame-stroke 1pt (Color.gray 0.75) in
-      block-frame-breakable ctx pads decoset (fun ctx -> read-block (ctx |> set-hyphen-penalty 150) content)
-
+    block-frame-breakable ctx pads decoset (fun ctx -> read-block (ctx |> set-hyphen-penalty 150) content)
 
   val block ctx +math-list mlst =
     let ib =
-      mlst |> List.fold-left-adjacent (fun ibacc m _ mnextopt -> (
+      mlst |> List.fold-adjacent (fun ibacc m _ mnextopt -> (
         let ib = embed-math ctx (read-math ctx m) in
         match mnextopt with
         | None    -> ibacc ++ ib ++ inline-fil
@@ -78,16 +67,14 @@ module Local = struct
         end
       )) inline-fil
     in
-      line-break true true ctx ib
-
+    line-break true true ctx ib
 
   val inline ctx \insert-image w path =
     let img = load-image path in
-      use-image-by-width img w
-
+    use-image-by-width img w
 
   val block ctx +display-boxes content code =
     read-block (ctx |> set-paragraph-margin 12pt 0pt) '<+frame(content);>
-      +++ read-block (ctx |> set-paragraph-margin 0pt 12pt) '<+Code.code(code);>
+      +++ read-block (ctx |> set-paragraph-margin 0pt 12pt) '<+Code.Default.code(code);>
 
 end

--- a/doc/doc-lang.saty
+++ b/doc/doc-lang.saty
@@ -1,5 +1,5 @@
 use package open Stdlib
-use package open Stdlib.Pervasives
+use package open Stdlib.Logo
 use package open StdJa
 use package open Math
 use open LocalMath of `local-math`
@@ -8,7 +8,7 @@ document (|
   title = {\SATySFi;言語仕様},
   author = {Takashi SUWA},
 |) '<
-  +section {構文} <
+  +section{構文}<
     +p{
       \SATySFi;の構文は以下のように定義されている：
     }

--- a/doc/doc-primitives.saty
+++ b/doc/doc-primitives.saty
@@ -1,4 +1,5 @@
-use package open Stdlib.Pervasives
+use package open Stdlib
+use package open Stdlib.Logo
 use package open Math
 use package open Itemize
 use package open StdJaBook
@@ -9,8 +10,8 @@ document ?(
   show-toc = true,
 ) (|
   title = {
-    \SATySFi;の\fil-both;\no-break{基本型}と
-    \fil-both;\no-break{プリミティヴ}
+    \SATySFi;の\Inline.fil-both;\Inline.no-break{基本型}と
+    \Inline.fil-both;\Inline.no-break{プリミティヴ}
   },
   author = {Takashi SUWA},
 |) '<

--- a/doc/local.satyh
+++ b/doc/local.satyh
@@ -13,22 +13,20 @@ module Local = struct
     | Record          of list (inline-text * type-syntax)
     | FuncType        of type-syntax * type-syntax
 
-
   val ( --> ) ty1 ty2 =
     FuncType(ty1, ty2)
-  %  ${\paren{#m1 \to #m2}}
 
   val type-name name =
     TypeName(name)
-  %  text-in-math MathOrd (fun ctx -> read-inline ctx name)
 
   val type-constructor name tylst =
     TypeConstructor(name, tylst)
 
-  val type-tuple tylst = Tuple(tylst)
+  val type-tuple tylst =
+    Tuple(tylst)
 
-  val type-record tylst = Record(tylst)
-
+  val type-record tylst =
+    Record(tylst)
 
   val tU = type-name {unit}
   val tI = type-name {int}
@@ -71,15 +69,11 @@ module Local = struct
   val tPROD tylst = type-tuple tylst
   val tRECORD tylst = type-record tylst
   val tANY = type-name {Any}
-  %  val token = type-name {list} in
-  %    ${\paren{#m}\math-skip!(4pt)#token}
-
 
   val rec math-of-type ctx ty =
     match ty with
     | TypeName(it) ->
         embed-inline-to-math MathOrd (read-inline ctx it)
-
     | TypeConstructor(it, tylst) ->
         let mlst =
           tylst |> List.map (fun ty -> (
@@ -94,7 +88,6 @@ module Local = struct
         in
         Math.join-boxes ctx (read-math ctx ${\Math.math-skip!(4pt)})
           (List.append mlst [ embed-inline-to-math MathOrd (read-inline ctx it) ])
-
     | Tuple(tylst) ->
         let mlst =
           tylst |> List.map (fun ty -> (
@@ -108,7 +101,6 @@ module Local = struct
           ))
         in
         Math.paren ctx (Math.join-boxes ctx (read-math ctx ${\Math.ast}) mlst)
-
     | Record(lst) ->
         let mlst =
           lst |> List.map (fun (key, ty) -> (
@@ -118,7 +110,6 @@ module Local = struct
         in
         let m = Math.join-boxes ctx (read-math ctx ${\;\Math.math-skip!(4pt)}) mlst in
         LocalParen.record-paren ctx m
-
     | FuncType(ty1, ty2) ->
         let m1 = math-of-type ctx ty1 in
         let m2 = math-of-type ctx ty2 in
@@ -131,7 +122,6 @@ module Local = struct
         math-concat (math-concat m1 (read-math ctx ${\Math.to})) m2
     end
 
-
   val math ctx \math-of-type ty =
     math-of-type ctx ty
 
@@ -143,16 +133,13 @@ module Local = struct
     if n <= 0 then ibacc else
       repeat-inline (ibacc ++ ib) (n - 1) ib
 
-
   val inline ctx \repeat n inner =
     let ib = read-inline ctx inner in
       repeat-inline inline-nil n ib
 
-
   val gap-paragraph = 12pt
 
   val gap-command = 6pt
-
 
   val command-scheme ctx ib-name ty inner =
     let ib-colon = read-inline ctx {\ :\ } in
@@ -164,31 +151,27 @@ module Local = struct
     +++
       block-frame-breakable (ctx |> set-paragraph-margin gap-command gap-paragraph)
         (indent, 0pt, 0pt, 0pt) VDecoSet.empty (fun ctx ->
-            Pervasives.form-paragraph (ctx |> set-paragraph-margin 0pt 0pt) (ib-inner ++ inline-fil)
-          )
-
+          Block.form-paragraph (ctx |> set-paragraph-margin 0pt 0pt) (ib-inner ++ inline-fil)
+        )
 
   val name-context ctx =
     ctx |> set-dominant-narrow-script Latin
         |> set-font Latin (FontLatinModern.mono, 1., 0.)
         |> set-text-color Color.red
 
-
   val block ctx +command name ty inner =
     let ctx-name = name-context ctx in
     let ib-name = read-inline ctx-name (embed-string name) in
-      command-scheme ctx ib-name ty inner
-
+    command-scheme ctx ib-name ty inner
 
   val mutable flag <- true
-
 
   val block ctx +commands namelst ty inner =
     let ctx-name = name-context ctx in
     let ib-comma = read-inline ctx {,\ } in
     let () = flag <- true in
     let ib-name =
-      namelst |> List.fold-left (fun acc name -> (
+      namelst |> List.fold (fun acc name -> (
         let ib-name = read-inline ctx-name (embed-string name) in
         if !flag then
           let () = flag <- false in
@@ -197,25 +180,21 @@ module Local = struct
           acc ++ ib-comma ++ ib-name
       )) inline-nil
     in
-      command-scheme ctx ib-name ty inner
-
+    command-scheme ctx ib-name ty inner
 
   val block ctx +type ty inner =
     let font-size = get-font-size ctx in
     let quad = discretionary 1000 (inline-skip font-size) inline-nil inline-nil in
     let indent = (ctx |> get-font-size) *' 2. in
     let ib-inner = read-inline ctx inner in
-      block-frame-breakable ctx (indent, 0pt, 0pt, 0pt) VDecoSet.empty
-          (fun ctx ->
-            Pervasives.form-paragraph (ctx |> set-paragraph-margin 0pt 0pt)
-              (inline-skip (0pt -' indent) ++ embed-math ctx (math-of-type ctx ty) ++ quad ++ ib-inner ++ inline-fil)
-          )
-
+    block-frame-breakable ctx (indent, 0pt, 0pt, 0pt) VDecoSet.empty (fun ctx ->
+      Block.form-paragraph (ctx |> set-paragraph-margin 0pt 0pt)
+        (inline-skip (0pt -' indent) ++ embed-math ctx (math-of-type ctx ty) ++ quad ++ ib-inner ++ inline-fil)
+    )
 
   val inline \subject-to-change = {\StdJaBook.emph{〔今後仕様変更の可能性あり〕}}
 
   val inline \discouraged = {\StdJaBook.emph{〔使用非推奨〕}}
-
 
   val inline ctx \meta m =
     let ctx-meta =
@@ -223,7 +202,6 @@ module Local = struct
           |> set-font Latin StdJaBook.font-latin-italic
     in
     embed-math ctx-meta (read-math ctx-meta m)
-
 
   val inline ctx \code inner =
     let pads-code = (2pt, 2pt, 2pt, 2pt) in
@@ -235,6 +213,6 @@ module Local = struct
       inline-frame-breakable pads-code decoset-code
         (read-inline ctx-code inner)
     in
-      script-guard Latin ib-frame
+    script-guard Latin ib-frame
 
 end

--- a/doc/math1.saty
+++ b/doc/math1.saty
@@ -1,5 +1,5 @@
 use package open Stdlib
-use package open Stdlib.Pervasives
+use package open Stdlib.Logo
 use package open Math
 use package open Proof
 use package open Tabular
@@ -22,11 +22,11 @@ document ?(
     Italics correction and kerning:
       ${\paren{F^n} \paren{F} = \paren{G \frac{M m}{R^2}}^{n + 1}},
 
-    Big math: ${\paren{\frac{\paren{\frac{A}{B} + C}}{D^{\paren{n - 1}}}}_2},\fil;
+    Big math: ${\paren{\frac{\paren{\frac{A}{B} + C}}{D^{\paren{n - 1}}}}_2},\Inline.fil;
 
     parentheses: ${\paren{\paren{\paren{A} + B} + C}}, ${\brace{\brace{\brace{A} + B} + C}},
 
-    radical: ${2 \sqrt{3} + \frac{2}{\sqrt{5}} + \frac{1}{\sqrt{x^2 + 1}}}.\fil;
+    radical: ${2 \sqrt{3} + \frac{2}{\sqrt{5}} + \frac{1}{\sqrt{x^2 + 1}}}.\Inline.fil;
 
     The solution of the equation ${a x^2 + b x + c = 0} as to ${x} is
       ${x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}}.
@@ -67,7 +67,7 @@ document ?(
       bold Fraktur:  ${\math-style!(MathBoldFraktur ){#test}},
       double struck: ${\math-style!(MathDoubleStruck){#test}}.
     });
-  +p {Typing rule is defined as follows:}
+  +p {Typing rules are defined as follows:}
   +math(${
     \derive{|\paren{\app{\Gamma}{x} \synteq \tau}|}{
       \tyjd{\Gamma}{x}{\tau}
@@ -94,6 +94,6 @@ document ?(
     \tabular(fun cellf multif empty -> [
       [multif 2 1 {The}, cellf {quick}, cellf {brown}, multif 1 2 {fox jumps over}, empty,],
       [empty, multif 1 2 {the}, empty, cellf {lazy}, cellf {dog},],
-    ])(fun xs ys -> Gr.empty);
+    ])(fun xs ys -> Graphics.empty);
   }
 >

--- a/lib-satysfi/packages/annot/annot.0.0.1/src/annot.satyh
+++ b/lib-satysfi/packages/annot/annot.0.0.1/src/annot.satyh
@@ -10,15 +10,15 @@ end = struct
   val link-to-uri-frame uri borderopt =
     let deco (x, y) w h d =
       let () = register-link-to-uri uri (x, y) w h d borderopt in
-      Gr.empty
+      Graphics.empty
     in
-      (deco, deco, deco, deco)
+    (deco, deco, deco, deco)
 
 
   val link-to-location-frame name borderopt =
     let deco (x, y) w h d =
       let () = register-link-to-location name (x, y) w h d borderopt in
-      Gr.empty
+      Graphics.empty
     in
     (deco, deco, deco, deco)
 
@@ -46,9 +46,9 @@ end = struct
   val register-location-frame key =
     let decoR (x, y) w h d =
       let () = register-destination key (x, y +' h) in
-      Gr.empty
+      Graphics.empty
     in
-    let decoI _ _ _ _ = Gr.empty in
+    let decoI = Deco.empty in
     (decoR, decoR, decoI, decoI)
 
 end

--- a/lib-satysfi/packages/code/code.0.0.1/src/code.satyh
+++ b/lib-satysfi/packages/code/code.0.0.1/src/code.satyh
@@ -1,53 +1,63 @@
 use package open Stdlib
-
 use package FontLatinModern
 
-module Code
-% :> sig
-%
-%   val scheme : deco-set -> color -> context -> string -> block-boxes
-%   direct +code : [string] block-cmd
-%   direct +console : [string] block-cmd
-%   direct \code : [string] inline-cmd
-%   direct \console : [string] inline-cmd
-%   direct \d-code : [string] inline-cmd
-%   direct +file-code : [string] block-cmd
-%   direct \file-code : [string] inline-cmd
-%
-% end
- = struct
+module Code :> sig
+  signature Settings = sig
+    val font-family : font
+    val text-color : color
+    val fill-color : color
+    val stroke-color : color
+    val stroke-thickness : length
+  end
+  signature Interface = sig
+    val scheme : deco-set -> context -> string -> block-boxes
+    val +code : block [string]
+    val \d-code : inline [string]
+    val \code : inline [string]
+    val +file-code : block [string]
+    val \file-code : inline [string]
+  end
+  module Make : (X : Settings) -> Interface
+  module Default : Interface
+  module Console : Interface
+  val +console : block [string]
+  val \console : inline [string]
+end = struct
 
-  signature S = sig
-    val font-family      : font
-    val text-color       : color
-    val fill-color       : color
-    val stroke-color     : color
+  signature Settings = sig
+    val font-family : font
+    val text-color : color
+    val fill-color : color
+    val stroke-color : color
     val stroke-thickness : length
   end
 
+  signature Interface = sig
+    val scheme : deco-set -> context -> string -> block-boxes
+    val +code : block [string]
+    val \d-code : inline [string]
+    val \code : inline [string]
+    val +file-code : block [string]
+    val \file-code : inline [string]
+  end
 
-  module Make = fun(X : S) -> struct
+  module Make = fun(X : Settings) -> struct
 
     val decoset-code =
       VDecoSet.simple-frame
         X.stroke-thickness X.stroke-color X.fill-color
-
 
     val set-code-font ctx =
       ctx
         |> set-font Latin (X.font-family, 1., 0.)
         |> set-hyphen-penalty 100000
 
-
     val scheme decoset ctx code =
       let pads = (5pt, 5pt, 5pt, 5pt) in
       block-frame-breakable ctx pads decoset (fun ctx ->
         let fontsize = get-font-size ctx in
         let ctx = ctx |> set-code-font in
-        let charwid =
-          Pervasives.get-natural-width
-            (read-inline ctx {0})
-        in
+        let charwid = Inline.get-natural-advance (read-inline ctx {0}) in
         let ctx-code =
           ctx
             |> set-space-ratio (charwid /' fontsize) 0. 0.
@@ -63,7 +73,7 @@ module Code
           end
         in
         let ib-code =
-          lst |> List.fold-left-adjacent (fun ibacc (i, s) _ optnext -> (
+          lst |> List.fold-adjacent (fun ibacc (i, s) _ optnext -> (
             let ib-last =
               match optnext with
               | Some(_) -> inline-fil ++ discretionary 0 (inline-skip ((get-text-width ctx) *' 2.)) inline-nil inline-nil
@@ -81,28 +91,23 @@ module Code
           line-break true true ctx ib-code
       )
 
-
     val block ctx +code code =
       scheme decoset-code ctx code
-
 
     val inline ctx \d-code code =
       inline-fil ++ embed-block-breakable ctx
         (read-block ctx '<+code(code);>)
 
-
     val inline ctx \code code =
       script-guard Latin
         (read-inline (ctx |> set-code-font) (embed-string code))
-
 
     val block ctx +file-code file-name =
       let lf = string-unexplode [10] in
       let join s1 s2 = s1 ^ lf ^ s2 in
       let str-list = read-file file-name in
-      let code = List.fold-left join ` ` str-list in
+      let code = List.fold join ` ` str-list in
       scheme decoset-code ctx code
-
 
     val inline ctx \file-code file-name =
       inline-fil ++ embed-block-breakable ctx
@@ -110,46 +115,37 @@ module Code
 
   end
 
-
   module DefaultSettings = struct
-    val font-family      = FontLatinModern.mono
-    val text-color       = Gray(0.)
-    val fill-color       = Gray(0.875)
-    val stroke-color     = Gray(0.625)
+    val font-family = FontLatinModern.mono
+    val text-color = Gray(0.)
+    val fill-color = Gray(0.875)
+    val stroke-color = Gray(0.625)
     val stroke-thickness = 1pt
   end
 
-
-  include Make DefaultSettings
-
+  module Default = Make DefaultSettings
 
   module ConsoleSettings = struct
-    val font-family      = FontLatinModern.mono
-    val text-color       = Gray(1.)
-    val fill-color       = Gray(0.25)
-    val stroke-color     = Gray(0.25)
+    val font-family = FontLatinModern.mono
+    val text-color = Gray(1.)
+    val fill-color = Gray(0.25)
+    val stroke-color = Gray(0.25)
     val stroke-thickness = 0pt
   end
 
-
   module Console = Make ConsoleSettings
-
 
   val decoset-console =
     let deco (x, y) w h d =
-      fill ConsoleSettings.fill-color (Gr.rectangle (x, y -' d) (x +' w, y +' h))
+      fill ConsoleSettings.fill-color (Path.rectangle (x, y -' d) (x +' w, y +' h))
     in
     (deco, deco, deco, deco)
-
 
   val block ctx +console code =
     Console.scheme decoset-console ctx code
 
-
   val inline ctx \console code =
     inline-fil ++ embed-block-breakable ctx
       (read-block ctx '<+console(code);>)
-
-
 
 end

--- a/lib-satysfi/packages/footnote-scheme/footnote-scheme.0.0.1/src/footnote-scheme.satyh
+++ b/lib-satysfi/packages/footnote-scheme/footnote-scheme.0.0.1/src/footnote-scheme.satyh
@@ -63,7 +63,7 @@ end = struct
           let wid = get-text-width ctx *' bar-ratio in
           let ib =
             inline-graphics wid bar-top-margin bar-bottom-margin (fun (x, y) ->
-              stroke 0.5pt Color.black (Gr.line (x, y) (x +' wid, y))
+              stroke 0.5pt Color.black (Path.line (x, y) (x +' wid, y))
             ) ++ inline-fil
           in
           line-break false false (ctx |> set-paragraph-margin 0pt 0pt) ib
@@ -73,7 +73,7 @@ end = struct
           block-skip (size *' 0.5)
       end
     in
-      Pervasives.no-break
+      Inline.no-break
         (add-footnote (bb-before +++ bb) ++ ib-num
           ++ hook-page-break (fun _ _ -> (
             let () =

--- a/lib-satysfi/packages/itemize/itemize.0.0.1/src/itemize.satyh
+++ b/lib-satysfi/packages/itemize/itemize.0.0.1/src/itemize.satyh
@@ -7,7 +7,7 @@ module Itemize :> sig
   val \enumerate : inline [itemize]
 end = struct
 
-  val (+++>) = List.fold-left (+++)
+  val (+++>) = List.fold (+++)
   val concat-blocks = (+++>) block-nil
 
 
@@ -20,7 +20,7 @@ end = struct
     let cx = x +' 4pt in
     let cy = y +' 4pt in
     let r = 2pt in
-    fill color (Gr.circle (cx, cy) r)
+    fill color (Path.circle (cx, cy) r)
 
 
   val make-bullet ctx =
@@ -30,16 +30,16 @@ end = struct
 
   val rec listing-item ctx depth is-first is-last (Item(parent, children)) =
         let ib-bullet = make-bullet ctx in
-        let bullet-width = Pervasives.get-natural-width ib-bullet in
+        let bullet-width = Inline.get-natural-advance ib-bullet in
         let parent-indent = item-indent *' (float depth) in
         let ib-parent =
           embed-block-top ctx ((get-text-width ctx) -' parent-indent -' bullet-width) (fun ctx ->
-            Pervasives.form-paragraph (ctx |> set-paragraph-margin item-gap item-gap)
+            Block.form-paragraph (ctx |> set-paragraph-margin item-gap item-gap)
               (read-inline ctx parent ++ inline-fil)
           )
         in
         let bb-parent =
-          Pervasives.form-paragraph (ctx |> set-paragraph-margin item-gap item-gap)
+          Block.form-paragraph (ctx |> set-paragraph-margin item-gap item-gap)
             ((inline-skip parent-indent) ++ ib-bullet ++ ib-parent)
         in
         let bbs-children = List.map-with-ends (listing-item ctx (depth + 1)) children in
@@ -48,13 +48,10 @@ end = struct
 
   val rec listing-item-breakable ctx depth is-first is-last (Item(parent, children)) =
         let ib-bullet = make-bullet ctx in
-        let bullet-width = Pervasives.get-natural-width ib-bullet in
+        let bullet-width = Inline.get-natural-advance ib-bullet in
         let parent-indent = item-indent *' (float depth) in
         let pads = (parent-indent +' bullet-width, 0pt, 0pt, 0pt) in
-        let decos =
-          let deco _ _ _ _ = Gr.empty in
-          (deco, deco, deco, deco)
-        in
+        let decos = HDecoSet.empty in
         let bb-parent =
           let ctx-frame =
             let len-top = if is-first then item-gap-outer +' item-gap else item-gap in
@@ -62,7 +59,7 @@ end = struct
             ctx |> set-paragraph-margin len-top len-bottom
           in
           block-frame-breakable ctx-frame pads decos (fun ctx ->
-            Pervasives.form-paragraph ctx
+            Block.form-paragraph ctx
               (inline-skip (0pt -' bullet-width) ++ ib-bullet ++ read-inline ctx parent ++ inline-fil)
           )
         in
@@ -97,19 +94,19 @@ end = struct
           let it-num = (embed-string (arabic index)) in
             read-inline ctx {(#it-num;)\ }
         in
-        let index-width = Pervasives.get-natural-width ib-index in
+        let index-width = Inline.get-natural-advance ib-index in
         let ib-parent =
           embed-block-top ctx ((get-text-width ctx) -' parent-indent -' index-width) (fun ctx ->
-            Pervasives.form-paragraph (ctx |> set-paragraph-margin item-gap item-gap)
+            Block.form-paragraph (ctx |> set-paragraph-margin item-gap item-gap)
               (read-inline ctx parent ++ inline-fil)
           )
         in
-          Pervasives.form-paragraph (ctx |> set-paragraph-margin item-gap item-gap)
+          Block.form-paragraph (ctx |> set-paragraph-margin item-gap item-gap)
             ((inline-skip parent-indent) ++ ib-index ++ ib-parent)
 
 
   val enumerate ctx (Item(_, itmzlst)) =
-    let bblst = List.mapi (fun i -> enumerate-item (i + 1) ctx 0) itmzlst in
+    let bblst = List.map-indexed (fun i -> enumerate-item (i + 1) ctx 0) itmzlst in
     concat-blocks bblst
 
 

--- a/lib-satysfi/packages/math/math.0.0.1/src/math.satyh
+++ b/lib-satysfi/packages/math/math.0.0.1/src/math.satyh
@@ -396,7 +396,6 @@ module Math :> sig
   val \setsep : math [math-text, math-text]
   val \cases : math [list (math-text * inline-text)]
 
-  type paren = Pervasives.paren %TODO (enhance): remove this
   val paren-left : paren
   val paren-right : paren
   val paren : context -> math-boxes -> math-boxes
@@ -428,7 +427,7 @@ end = struct
 
   val join (msep : math-text) (ms : list math-text) =
     match
-      ms |> List.fold-left (fun maccopt m -> (
+      ms |> List.fold (fun maccopt m -> (
         match maccopt with
         | None       -> Some(m)
         | Some(macc) -> Some(${#macc #msep #m})
@@ -442,7 +441,7 @@ end = struct
 
   val join-boxes ctx (mbsep : math-boxes) (mbs : list math-boxes) =
     match
-      mbs |> List.fold-left (fun mbaccopt mb -> (
+      mbs |> List.fold (fun mbaccopt mb -> (
         match mbaccopt with
         | None        -> Some(mb)
         | Some(mbacc) -> Some(math-concat (math-concat mbacc mbsep) mb)
@@ -537,7 +536,7 @@ end = struct
       discretionary 100 (inline-skip mingap ++ inline-fil) inline-fil inline-fil
     in
     let ib =
-      mlst |> List.fold-left-adjacent (fun ibacc m _ optnext -> (
+      mlst |> List.fold-adjacent (fun ibacc m _ optnext -> (
         let ib-after =
           match optnext with
           | None    -> inline-fil
@@ -567,7 +566,7 @@ end = struct
     let celllstlst =
       mlstlst |> List.map (fun mlst -> (
         let mbs = mlst |> List.map (read-math ctx) in
-        mbs |> List.mapi-adjacent (fun index mb _ mb-next-opt -> (
+        mbs |> List.map-indexed-adjacent (fun index mb _ mb-next-opt -> (
           let ibm = embed-math ctx mb in
           let ib =
             match mb-next-opt with
@@ -597,7 +596,7 @@ end = struct
     in
     let margin = get-font-size ctx *' margin-ratio in
       line-break true true (ctx |> set-paragraph-margin margin margin)
-        (inline-fil ++ (tabular celllstlst (fun _ _ -> Gr.empty)) ++ inline-fil)
+        (inline-fil ++ (tabular celllstlst (fun _ _ -> Graphics.empty)) ++ inline-fil)
         % temporary
 
 
@@ -1044,12 +1043,10 @@ end = struct
   val math ctx \bi m =
     read-math (ctx |> set-math-char-class MathBoldItalic) m
 
-  type paren = Pervasives.paren %TODO (enhance): remove this
-
   val half-length hgt dpt hgtaxis fontsize =
     let minhalflen = fontsize *' 0.5 in
     let lenappend = fontsize *' 0.1 in
-      Pervasives.length-max minhalflen ((Pervasives.length-max (hgt -' hgtaxis) (hgtaxis +' dpt)) +' lenappend)
+    Length.max minhalflen ((Length.max (hgt -' hgtaxis) (hgtaxis +' dpt)) +' lenappend)
 
   val extract-spec-from-context ctx =
     let fontsize = get-font-size ctx in
@@ -1072,7 +1069,7 @@ end = struct
     let kerninfo y =
       let widkern = widparen in
       let r = 0. in
-      let gap = Pervasives.length-abs (y -' hgtaxis) in
+      let gap = Length.abs (y -' hgtaxis) in
         if halflen *' r <' gap then
           widkern *' ((gap -' halflen *' r) /' (halflen *' (1. -. r)))
         else
@@ -1095,7 +1092,7 @@ end = struct
     let kerninfo y =
       let widkern = widparen in
       let r = 0. in
-      let gap = Pervasives.length-abs (y -' hgtaxis) in
+      let gap = Length.abs (y -' hgtaxis) in
         if halflen *' r <' gap then
           widkern *' ((gap -' halflen *' r) /' (halflen *' (1. -. r)))
         else
@@ -1177,8 +1174,8 @@ end = struct
     let kerninfo y =
       let widkern = widparen *' 0.5 in
       let r = 0.25 in
-      let gap = Pervasives.length-abs (y -' hgtaxis) in
-        let diff = Pervasives.length-min (gap -' halflen *' r) (halflen *' (1. -. r)) in
+      let gap = Length.abs (y -' hgtaxis) in
+        let diff = Length.min (gap -' halflen *' r) (halflen *' (1. -. r)) in
         if 0pt <' diff then
           widkern *' (diff /' (halflen *' (1. -. r)))
         else
@@ -1390,7 +1387,7 @@ end = struct
 %          |> bezier-to (fP (p0B, q0B)) (fP (p1A, q1A)) (fP (x1, y1))
 %          |> bezier-to (fP (p1B, q1B)) (fP (p2A, q2A)) (fP (x2, y2))
 %          |> close-with-line
-        Gr.poly-line (fP (x0, y0)) [
+        Path.poly-line (fP (x0, y0)) [
           fP (p0B, q0B), fP (p1A, q1A), fP (x1, y1),
           fP (p1B, q1B), fP (p2A, q2A), fP (x2, y2),
           fP (p2B, q2B), fP (p3A, q3A), fP (x3, y3),
@@ -1411,7 +1408,7 @@ end = struct
     let halfwid = fontsize *' 0.5 in
     let graphics (x, y) =
       stroke 0.5pt color
-        (Gr.line (x +' halfwid, y +' hgtaxis -' halflen) (x +' halfwid, y +' hgtaxis +' halflen))
+        (Path.line (x +' halfwid, y +' hgtaxis -' halflen) (x +' halfwid, y +' hgtaxis +' halflen))
     in
     let kerninfo _ = 0pt in
     (inline-graphics (halfwid *' 2.) (hgtaxis +' halflen) (halflen -' hgtaxis) graphics, kerninfo)
@@ -1427,7 +1424,7 @@ end = struct
     let halfwid = halflen *' 0.5 in
     let graphics (x, y) =
       stroke 0.5pt color
-        (Gr.line (x, y +' hgtaxis -' halflen) (x +' halfwid *' 2., y +' hgtaxis +' halflen))
+        (Path.line (x, y +' hgtaxis -' halflen) (x +' halfwid *' 2., y +' hgtaxis +' halflen))
     in
     let kerninfo _ = 0pt in
     (inline-graphics (halfwid *' 2.) (hgtaxis +' halflen) (halflen -' hgtaxis) graphics, kerninfo)
@@ -1622,7 +1619,7 @@ end = struct
             [NormalCell(pads, ib1), NormalCell(pads, ib2)]
           ))
         in
-        let ib = tabular celllstlst (fun _ _ -> Gr.empty) in
+        let ib = tabular celllstlst (fun _ _ -> Graphics.empty) in
         let (_, hgt, dpt) = get-natural-metrics ib in
         let hgtaxis = size *' get-math-axis-height-ratio ctx in
         raise-inline (hgtaxis -' (hgt +' dpt) *' 0.5) ib

--- a/lib-satysfi/packages/md-ja/md-ja.0.0.1/src/md-ja.satyh
+++ b/lib-satysfi/packages/md-ja/md-ja.0.0.1/src/md-ja.satyh
@@ -167,7 +167,7 @@ end = struct
               let decoset = Annot.register-location-frame key-pdf-loc in
               let ib = inline-frame-breakable pads-zero decoset (read-inline ctx it) in
               line-break true true ctx (ib ++ inline-fil)
-            )) |> List.fold-left (+++) block-nil
+            )) |> List.fold (+++) block-nil
           in
           let bb-heading =
             let ctx = ctx |> h1-heading in
@@ -191,7 +191,7 @@ end = struct
       |)
     in
     page-break paper pagecontf pagepartsf
-      (List.fold-left (+++) block-nil [
+      (List.fold (+++) block-nil [
         bb-title, bb-author,
         block-skip skip-before-content,
         bb-main,
@@ -299,7 +299,7 @@ end = struct
       if string-same name `console` then
         '<+Code.console(fix-block-code s);>
       else
-        '<+Code.code(fix-block-code s);>
+        '<+Code.Default.code(fix-block-code s);>
     in
     read-block ctx bt
 
@@ -318,7 +318,7 @@ end = struct
     let color = (Gray(0.75)) in
     line-break true true ctx
       (inline-graphics w h h (fun (x, y) ->
-        stroke hr-thickness color (Gr.line (x, y) (x +' w, y))
+        stroke hr-thickness color (Path.line (x, y) (x +' w, y))
       ))
 
 
@@ -378,6 +378,6 @@ end = struct
 
 
   val inline ctx \hard-break =
-    Pervasives.mandatory-break ctx
+    Inline.mandatory-break ctx
 
 end

--- a/lib-satysfi/packages/proof/proof.0.0.1/src/proof.satyh
+++ b/lib-satysfi/packages/proof/proof.0.0.1/src/proof.satyh
@@ -11,10 +11,6 @@ end = struct
     embed-inline-to-math MathOrd (inline-skip len)
 
 
-  val length-max len1 len2 =
-    if len1 <' len2 then len2 else len1
-
-
   val derive ctx nameopt bopt widopt (mlst1 : list math-text) (m2 : math-text) =
     let ib-space =
       match widopt with
@@ -24,7 +20,7 @@ end = struct
     in
     embed-inline-to-math MathInner (
       let ibacc1 =
-        (mlst1 |> List.fold-left-adjacent (fun ibacc1 m prevopt _ -> (
+        (mlst1 |> List.fold-adjacent (fun ibacc1 m prevopt _ -> (
           let ibm = embed-math ctx (read-math ctx m) in
           match prevopt with
           | None    -> inline-fil ++ ibm
@@ -41,8 +37,8 @@ end = struct
       let ib2 = inline-fil ++ (embed-math ctx (read-math ctx m2)) ++ inline-fil in
       let w =
         match widopt with
-        | None      -> length-max (Pervasives.get-natural-width ib1) (Pervasives.get-natural-width ib2)
-        | Some(wid) -> length-max wid (Pervasives.get-natural-width ib2)
+        | None      -> Length.max (Inline.get-natural-advance ib1) (Inline.get-natural-advance ib2)
+        | Some(wid) -> Length.max wid (Inline.get-natural-advance ib2)
         end
       in
       let color = get-text-color ctx in
@@ -63,14 +59,14 @@ end = struct
               | Some(true)  -> 0pt
               end
             in
-            ((fun pt -> [Gr.text-rightward pt ib]), wname)
+            ((fun pt -> [Graphics.text-rightward pt ib]), wname)
         end
       in
       let axis-height = get-font-size ctx *' get-math-axis-height-ratio ctx in
       let bar =
           inline-graphics w (thickness +' gap) gap (fun (x, y) -> (
             let grs =
-              fill color (Gr.rectangle (x, y) (x +' w, y +' thickness))
+              fill color (Path.rectangle (x, y) (x +' w, y +' thickness))
                 :: (glnamef (x +' w, y -' axis-height))
             in
             unite-graphics grs

--- a/lib-satysfi/packages/std-ja-book/std-ja-book.0.0.1/src/std-ja-book.satyh
+++ b/lib-satysfi/packages/std-ja-book/std-ja-book.0.0.1/src/std-ja-book.satyh
@@ -22,9 +22,9 @@ module StdJaBook :> sig
       paper-size       : length * length,
       text-width       : length,
       text-height      : length,
-      text-origin      : Pervasives.point, %- TODO: remove this by using 'open'
-      header-origin    : Pervasives.point,
-      footer-origin    : Pervasives.point,
+      text-origin      : point,
+      header-origin    : point,
+      footer-origin    : point,
       header-width     : length,
       footer-width     : length,
     ) (|
@@ -58,7 +58,6 @@ end = struct
     | TOCElementSection    of string * inline-text
     | TOCElementSubsection of string * inline-text
 
-
   val generate-fresh-label =
     let mutable count <- 0 in
       (fun () -> (
@@ -66,9 +65,7 @@ end = struct
           `generated:` ^ (arabic (!count))
       ))
 
-
   val no-pads = (0pt, 0pt, 0pt, 0pt)
-
 
   val inline ctx \ref key =
     let opt = get-cross-reference (key ^ `:num`) in
@@ -80,7 +77,6 @@ end = struct
     in
     script-guard Latin (inline-frame-breakable no-pads (Annot.link-to-location-frame key None) (read-inline ctx it))
 
-
   val inline ctx \ref-page key =
     let opt = get-cross-reference (key ^ `:page`) in
     let it =
@@ -90,7 +86,6 @@ end = struct
       end
     in
     inline-frame-breakable no-pads (Annot.link-to-location-frame key None) (read-inline ctx it)
-
 
   val font-size-normal  = 12pt
   val font-size-title   = 32pt
@@ -122,19 +117,16 @@ end = struct
   val font-cjk-mincho   = (FontIpaEx.mincho    , font-ratio-cjk  , 0.)
   val font-cjk-gothic   = (FontIpaEx.gothic    , font-ratio-cjk  , 0.)
 
-
   val set-latin-font font ctx =
     ctx |> set-font Latin font
-
 
   val set-cjk-font font ctx =
     ctx |> set-font HanIdeographic font
         |> set-font Kana           font
 
-
   val get-standard-context wid =
     get-initial-context wid (command \Math.math)
-      |> set-code-text-command (command \Code.code)
+      |> set-code-text-command (command \Code.Default.code)
       |> set-hyphenation-dictionary HyphEnglish.hyphenation
       |> set-unicode-char-database Unidata.unidata
       |> set-dominant-wide-script Kana
@@ -149,19 +141,15 @@ end = struct
       |> set-math-font FontLatinModernMath.main
       |> set-hyphen-penalty 100
 
-
   val mutable ref-float-boxes <- []
-
 
   val height-of-float-boxes pageno =
 %    let () = display-message `get height` in
-    (!ref-float-boxes) |> List.fold-left (fun h (pn, bb) -> (
+    (!ref-float-boxes) |> List.fold (fun h (pn, bb) -> (
       if pn < pageno then h +' (get-natural-length bb) else h
     )) 0pt
 
-
   val mutable ref-figure <- 0
-
 
   val inline ctx \figure ?(label = labelopt) caption inner =
     let () = ref-figure <- !ref-figure + 1 in
@@ -176,7 +164,7 @@ end = struct
     let ds =
       match labelopt with
       | Some(label) -> Annot.register-location-frame label
-      | None        -> let d (_, _) _ _ _ = Gr.empty in (d, d, d, d)
+      | None        -> VDecoSet.empty
       end
     in
     let bb-inner =
@@ -185,11 +173,10 @@ end = struct
           +++ line-break true true ctx (inline-fil ++ read-inline ctx {図#it-num; #caption;} ++ inline-fil)
       ))
     in
-      hook-page-break (fun pbinfo _ -> (
-%        let () = display-message (`register` ^ (arabic pbinfo#page-number)) in
-        ref-float-boxes <- (pbinfo#page-number, bb-inner) :: !ref-float-boxes
-      ))
-
+    hook-page-break (fun pbinfo _ -> (
+%      let () = display-message (`register` ^ (arabic pbinfo#page-number)) in
+      ref-float-boxes <- (pbinfo#page-number, bb-inner) :: !ref-float-boxes
+    ))
 
 val title-deco =
     let pads = (5pt, 5pt, 10pt, 10pt) in
@@ -259,33 +246,29 @@ val title-deco =
 %        if get-text-width ctx <' Pervasives.get-natural-width ib-title then
 %          Pervasives.form-paragraph ctx-title (ib-title ++ inline-fil)
 %        else
-          Pervasives.form-paragraph (ctx-title |> set-paragraph-margin 12pt 0pt)
+          Block.form-paragraph (ctx-title |> set-paragraph-margin 12pt 0pt)
             (inline-fil ++ ib-title ++ inline-fil)
       in
       let bb-line =
-        Pervasives.form-paragraph (ctx |> set-paragraph-margin title-line-margin title-line-margin)
+        Block.form-paragraph (ctx |> set-paragraph-margin title-line-margin title-line-margin)
           (ib-line ++ inline-fil)
       in
-      let bb-author = Pervasives.form-paragraph ctx-author (inline-fil ++ ib-author) in
-        bb-title +++ bb-line +++ bb-author
+      let bb-author = Block.form-paragraph ctx-author (inline-fil ++ ib-author) in
+      bb-title +++ bb-line +++ bb-author
     ))
-
 
   val make-section-title ctx =
     ctx |> set-font-size font-size-section
         |> set-font Latin font-latin-sans
         |> set-cjk-font font-cjk-gothic
 
-
   val make-subsection-title ctx =
     ctx |> set-font-size font-size-subsection
         |> set-font Latin font-latin-sans
         |> set-cjk-font font-cjk-gothic
 
-
   val mutable toc-acc-ref <- []
   val mutable outline-ref <- []
-
 
   val get-cross-reference-number label =
     match get-cross-reference (label ^ `:num`) with
@@ -293,13 +276,11 @@ val title-deco =
     | Some(s) -> s
     end
 
-
   val get-cross-reference-page label =
     match get-cross-reference (label ^ `:page`) with
     | None    -> `?`
     | Some(s) -> s
     end
-
 
   val section-heading ctx ib-heading =
     let wid = get-text-width ctx in
@@ -310,8 +291,8 @@ val title-deco =
       line-break true false (ctx |> set-paragraph-margin section-top-margin 0pt)
         (inline-graphics wid h 0pt (fun (x, y) ->
           unite-graphics [
-            stroke th1 color (Gr.line (x, y +' h) (x +' wid, y +' h)),
-            stroke th2 color (Gr.line (x, y) (x +' wid, y)),
+            stroke th1 color (Path.line (x, y +' h) (x +' wid, y +' h)),
+            stroke th2 color (Path.line (x, y) (x +' wid, y)),
           ]))
     +++
       line-break false false (ctx |> set-paragraph-margin section-top-padding section-bottom-padding)
@@ -320,28 +301,25 @@ val title-deco =
       line-break false false (ctx |> set-paragraph-margin 0pt section-bottom-margin)
         (inline-graphics wid h 0pt (fun (x, y) ->
           unite-graphics [
-            stroke th2 color (Gr.line (x, y +' h) (x +' wid, y +' h)),
-            stroke th1 color (Gr.line (x, y) (x +' wid, y)),
+            stroke th2 color (Path.line (x, y +' h) (x +' wid, y +' h)),
+            stroke th1 color (Path.line (x, y) (x +' wid, y)),
           ]))
 
 
   val inline ctx \dummy it =
     let ib = read-inline (ctx |> set-text-color Color.white) it in
-    let w = Pervasives.get-natural-width ib in
+    let w = Inline.get-natural-advance ib in
     ib ++ inline-skip (0pt -' w)
-
 
   val rec repeat-inline n ib =
     if n <= 0 then inline-nil else
       ib ++ (repeat-inline (n - 1) ib)
 
-
   val make-dots-line ctx w =
     let ib = read-inline ctx {.} ++ inline-skip 1pt in
-    let wdot = Pervasives.get-natural-width ib in
+    let wdot = Inline.get-natural-advance ib in
     let n = round (w /' wdot) in
     inline-fil ++ (repeat-inline n ib)
-
 
   val document
     ?(
@@ -404,7 +382,7 @@ val title-deco =
           read-inline (make-section-title ctx-doc) {目次} ++ inline-fil
         in
         let bb-toc-main =
-          (!toc-acc-ref) |> List.reverse |> List.fold-left (fun bbacc tocelem -> (
+          (!toc-acc-ref) |> List.reverse |> List.fold (fun bbacc tocelem -> (
             match tocelem with
             | TOCElementSection(label, title) ->
                 let it-num = embed-string (get-cross-reference-number label) in
@@ -412,7 +390,7 @@ val title-deco =
                 let ib-title = read-inline ctx-doc {#it-num;. #title;} ++ inline-skip 3pt in
                 let ib-page = inline-skip 3pt ++ read-inline ctx-doc it-page in
                 let ib-middle =
-                  let w = (get-text-width ctx-doc) -' (Pervasives.get-natural-width ib-title) -' (Pervasives.get-natural-width ib-page) in
+                  let w = (get-text-width ctx-doc) -' (Inline.get-natural-advance ib-title) -' (Inline.get-natural-advance ib-page) in
                     if w <' 0pt then inline-fil else
                       make-dots-line ctx-doc w
                 in
@@ -429,17 +407,19 @@ val title-deco =
                 in
                 let ib-page = inline-skip 3pt ++ read-inline ctx-doc it-page in
                 let ib-middle =
-                  let w = (get-text-width ctx-doc) -' (Pervasives.get-natural-width ib-indent)
-                    -' (Pervasives.get-natural-width ib-title) -' (Pervasives.get-natural-width ib-page) in
-                    if w <' 0pt then inline-fil else
-                      make-dots-line ctx-doc w
+                  let w =
+                    (get-text-width ctx-doc) -' (Inline.get-natural-advance ib-indent)
+                      -' (Inline.get-natural-advance ib-title) -' (Inline.get-natural-advance ib-page)
+                  in
+                  if w <' 0pt then inline-fil else
+                    make-dots-line ctx-doc w
                 in
-                  bbacc +++ line-break true true ctx-doc
-                    (ib-indent ++ (inline-frame-breakable no-pads (Annot.link-to-location-frame label None) (ib-title ++ ib-middle ++ ib-page)))
+                bbacc +++ line-break true true ctx-doc
+                  (ib-indent ++ (inline-frame-breakable no-pads (Annot.link-to-location-frame label None) (ib-title ++ ib-middle ++ ib-page)))
             end
           )) block-nil
         in
-          (section-heading ctx-doc ib-toc-title) +++ bb-toc-main
+        (section-heading ctx-doc ib-toc-title) +++ bb-toc-main
     in
 
     % -- page settings --
@@ -467,7 +447,7 @@ val title-deco =
         in
 %        let () = display-message `insert` in
         let (bb-float-boxes, acc) =
-          (!ref-float-boxes) |> List.fold-left (fun (bbacc, acc) elem -> (
+          (!ref-float-boxes) |> List.fold (fun (bbacc, acc) elem -> (
             let (pn, bb) = elem in
               if pn < pageno then
                 let bbs =
@@ -481,11 +461,11 @@ val title-deco =
           )) (block-nil, [])
         in
         let () = ref-float-boxes <- acc in
-          line-break true true ctx ib-text
-            +++ line-break true true (ctx |> set-paragraph-margin header-line-margin-top header-line-margin-bottom)
-              ((inline-graphics hdrwid thickness 0pt
-                (fun (x, y) -> fill Color.black (Gr.rectangle (x, y) (x +' hdrwid, y +' thickness)))) ++ inline-fil)
-            +++ bb-float-boxes
+        line-break true true ctx ib-text
+          +++ line-break true true (ctx |> set-paragraph-margin header-line-margin-top header-line-margin-bottom)
+            ((inline-graphics hdrwid thickness 0pt
+              (fun (x, y) -> fill Color.black (Path.rectangle (x, y) (x +' hdrwid, y +' thickness)))) ++ inline-fil)
+          +++ bb-float-boxes
       in
       let footer =
         if show-pages then
@@ -505,18 +485,15 @@ val title-deco =
     in
     let doc = page-break page pagecontf pagepartsf (bb-title +++ bb-toc +++ bb-main) in
     let () = register-outline (List.reverse !outline-ref) in
-      doc
-
+    doc
 
   val mutable needs-indentation-ref <- true
 
   val mutable num-section <- 0
   val mutable num-subsection <- 0
 
-
   val quad-indent ctx =
     inline-skip (get-font-size ctx)
-
 
   val block ctx +p inner =
     let needs-indentation =
@@ -531,14 +508,12 @@ val title-deco =
       else
         ib-inner ++ inline-fil
     in
-      Pervasives.form-paragraph ctx br-parag
-
+    Block.form-paragraph ctx br-parag
 
   val block ctx +pn inner =
     let () = needs-indentation-ref <- true in
     let ib-inner = read-inline ctx inner in
-      Pervasives.form-paragraph ctx (ib-inner ++ inline-fil)
-
+    Block.form-paragraph ctx (ib-inner ++ inline-fil)
 
   val section-scheme ctx label title outline-title-opt inner =
     let ctx-title = make-section-title ctx in
@@ -563,8 +538,7 @@ val title-deco =
       section-heading ctx ib
     in
     let bb-inner = read-block ctx inner in
-      bb-title +++ bb-inner
-
+    bb-title +++ bb-inner
 
   val subsection-scheme ctx label title outline-title-opt inner =
     let () = num-subsection <- !num-subsection + 1 in
@@ -586,8 +560,7 @@ val title-deco =
           (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil)))
     in
     let bb-inner = read-block ctx inner in
-      bb-title +++ bb-inner
-
+    bb-title +++ bb-inner
 
   val block ctx +section ?(label = labelopt, outline-title = outline-title-opt) title inner =
     let label =
@@ -598,7 +571,6 @@ val title-deco =
     in
     section-scheme ctx label title outline-title-opt inner
 
-
   val block ctx +subsection ?(label = labelopt, outline-title = outline-title-opt) title inner =
     let label =
       match labelopt with
@@ -606,8 +578,7 @@ val title-deco =
       | Some(label) -> label
       end
     in
-      subsection-scheme ctx label title outline-title-opt inner
-
+    subsection-scheme ctx label title outline-title-opt inner
 
   val inline ctx \emph inner =
     let ctx-emph =
@@ -615,8 +586,7 @@ val title-deco =
           |> set-cjk-font font-cjk-gothic
           |> set-text-color (CMYK(1., 0., 0., 0.))
     in
-      read-inline ctx-emph inner
-
+    read-inline ctx-emph inner
 
   val inline ctx \footnote it =
     let size = get-font-size ctx in
@@ -636,8 +606,8 @@ val title-deco =
             |> set-paragraph-margin (size *' 0.5) (size *' 0.5)
           %temporary
       in
-        line-break false false ctx (read-inline ctx {#it-num; #it;} ++ inline-fil)
+      line-break false false ctx (read-inline ctx {#it-num; #it;} ++ inline-fil)
     in
-      FootnoteScheme.main ctx ibf bbf
+    FootnoteScheme.main ctx ibf bbf
 
 end

--- a/lib-satysfi/packages/std-ja-report/std-ja-report.0.0.1/src/std-ja-report.satyh
+++ b/lib-satysfi/packages/std-ja-report/std-ja-report.0.0.1/src/std-ja-report.satyh
@@ -19,9 +19,9 @@ module StdJaReport :> sig
       show-page-number : bool,
       text-width       : length,
       text-height      : length,
-      text-origin      : Pervasives.point, %- TODO: remove this by using 'open'
-      header-origin    : Pervasives.point,
-      footer-origin    : Pervasives.point,
+      text-origin      : point,
+      header-origin    : point,
+      footer-origin    : point,
       header-width     : length,
       footer-width     : length,
     ) (|
@@ -57,12 +57,6 @@ module StdJaReport :> sig
 
 end = struct
 
-%  type toc-element =
-%    | TOCElementChapter    of string * inline-text
-%    | TOCElementSection    of string * inline-text
-%    | TOCElementSubsection of string * inline-text
-
-
   val generate-fresh-label =
     let mutable count <- 0 in
       (fun () -> (
@@ -70,9 +64,7 @@ end = struct
           `generated:` ^ (arabic (!count))
       ))
 
-
   val no-pads = (0pt, 0pt, 0pt, 0pt)
-
 
   val inline ctx \ref key =
     let opt = get-cross-reference (key ^ `:num`) in
@@ -84,7 +76,6 @@ end = struct
     in
     inline-frame-breakable no-pads (Annot.link-to-location-frame key None) (read-inline ctx it)
 
-
   val inline ctx \ref-page key =
     let opt = get-cross-reference (key ^ `:page`) in
     let it =
@@ -94,7 +85,6 @@ end = struct
       end
     in
     inline-frame-breakable no-pads (Annot.link-to-location-frame key None) (read-inline ctx it)
-
 
   val font-size-normal  = 12pt
   val font-size-title   = 18pt
@@ -120,19 +110,16 @@ end = struct
   val font-cjk-mincho   = (FontIpaEx.mincho    , font-ratio-cjk  , 0.)
   val font-cjk-gothic   = (FontIpaEx.gothic    , font-ratio-cjk  , 0.)
 
-
   val set-latin-font font ctx =
     ctx |> set-font Latin font
-
 
   val set-cjk-font font ctx =
     ctx |> set-font HanIdeographic font
         |> set-font Kana           font
 
-
   val get-standard-context wid =
     get-initial-context wid (command \Math.math)
-      |> set-code-text-command (command \Code.code)
+      |> set-code-text-command (command \Code.Default.code)
       |> set-hyphenation-dictionary HyphEnglish.hyphenation
       |> set-unicode-char-database Unidata.unidata
       |> set-dominant-wide-script Kana
@@ -147,19 +134,15 @@ end = struct
       |> set-math-font FontLatinModernMath.main
       |> set-hyphen-penalty 100
 
-
   val mutable ref-float-boxes <- []
-
 
   val height-of-float-boxes pageno =
 %    let () = display-message `get height` in
-    (!ref-float-boxes) |> List.fold-left (fun h (pn, bb) -> (
+    (!ref-float-boxes) |> List.fold (fun h (pn, bb) -> (
       if pn < pageno then h +' (get-natural-length bb) else h
     )) 0pt
 
-
   val mutable ref-figure <- 0
-
 
   val inline ctx \figure ?(label = label-opt) caption inner =
     let () = ref-figure <- !ref-figure + 1 in
@@ -173,11 +156,8 @@ end = struct
     let it-num = embed-string s-num in
     let ds =
       match label-opt with
-      | Some(label) ->
-          Annot.register-location-frame label
-
-      | None ->
-          let d (_, _) _ _ _ = Gr.empty in (d, d, d, d)
+      | Some(label) -> Annot.register-location-frame label
+      | None        -> VDecoSet.empty
       end
     in
     let bb-inner =
@@ -191,30 +171,24 @@ end = struct
       ref-float-boxes <- (pbinfo#page-number, bb-inner) :: !ref-float-boxes
     ))
 
-
   val make-chapter-title ctx =
     ctx |> set-font-size font-size-chapter
         |> set-font Latin font-latin-sans
         |> set-cjk-font font-cjk-gothic
-
 
   val make-section-title ctx =
     ctx |> set-font-size font-size-section
         |> set-font Latin font-latin-sans
         |> set-cjk-font font-cjk-gothic
 
-
   val make-subsection-title ctx =
     ctx |> set-font-size font-size-subsection
         |> set-font Latin font-latin-sans
         |> set-cjk-font font-cjk-gothic
 
-
-%  val mutable toc-acc-ref <- []
   val mutable outline-ref <- []
   val mutable does-page-breaking-reach-last <- false
   val mutable ref-current-page <- 0
-
 
   val get-cross-reference-number label =
     match get-cross-reference (label ^ `:num`) with
@@ -222,32 +196,26 @@ end = struct
     | Some(s) -> s
     end
 
-
   val get-cross-reference-page label =
     match get-cross-reference (label ^ `:page`) with
     | None    -> `?`
     | Some(s) -> s
     end
 
-
   val chapter-heading ctx ib-heading =
     line-break true false
       (ctx |> set-paragraph-margin chapter-top-margin chapter-bottom-margin)
         ib-heading
-
 
   val section-heading ctx ib-heading =
     line-break true false
       (ctx |> set-paragraph-margin section-top-margin section-bottom-margin)
         ib-heading
 
-
   val inline ctx \dummy it =
-    let open Pervasives in
     let ib = read-inline (ctx |> set-text-color Color.white) it in
-    let w = get-natural-width ib in
+    let w = Inline.get-natural-advance ib in
     ib ++ inline-skip (0pt -' w)
-
 
   val document
     ?(
@@ -334,7 +302,7 @@ end = struct
         in
 %        let () = display-message `insert` in
         let (bb-float-boxes, acc) =
-          (!ref-float-boxes) |> List.fold-left (fun (bbacc, acc) elem -> (
+          (!ref-float-boxes) |> List.fold (fun (bbacc, acc) elem -> (
             let (pn, bb) = elem in
               if pn < pageno then
                 let () = display-message (`use `# ^ arabic pn) in
@@ -378,7 +346,7 @@ end = struct
       let pageno = !ref-current-page in
       let last = !does-page-breaking-reach-last in
       let remains =
-        (!ref-float-boxes) |> List.fold-left (fun b (pn, _) -> (
+        (!ref-float-boxes) |> List.fold (fun b (pn, _) -> (
           if pn < pageno then b else true
         )) false
       in
@@ -407,40 +375,33 @@ end = struct
         (bb-title +++ bb-main +++ bb-last)
     in
     let () = register-outline (List.reverse !outline-ref) in
-      doc
-
+    doc
 
   val mutable num-chapter <- 0
   val mutable num-section <- 0
   val mutable num-subsection <- 0
   val mutable num-theorems <- 0
 
-
   val quad-indent ctx =
     inline-skip (get-font-size ctx *' font-ratio-cjk)
 
-
   val block ctx +p inner =
-    let open Pervasives in
     let ib-inner = read-inline ctx inner in
     let ib-parag = (quad-indent ctx) ++ ib-inner ++ inline-fil in
-    form-paragraph ctx ib-parag
-
+    Block.form-paragraph ctx ib-parag
 
   val chapter-scheme ctx label title outline-title-opt inner =
-    let open Pervasives in
     let ctx-title = make-chapter-title ctx in
-    let () = increment num-chapter in
+    let () = Ref.increment num-chapter in
     let () = num-section <- 0 in
     let () = num-subsection <- 0 in
     let s-num = arabic (!num-chapter) in
     let () = register-cross-reference (label ^ `:num`) s-num in
-%    let () = toc-acc-ref <- (TOCElementChapter(label, title)) :: !toc-acc-ref in
     let ib-num =
       read-inline ctx-title (embed-string (s-num ^ `.`))
         ++ hook-page-break (fun pbinfo _ -> (
              let pageno = pbinfo#page-number in
-               register-cross-reference (label ^ `:page`) (arabic pageno)))
+             register-cross-reference (label ^ `:page`) (arabic pageno)))
     in
     let ib-title = read-inline ctx-title title in
     let outline-title = Option.from (extract-string ib-title) outline-title-opt in
@@ -453,17 +414,14 @@ end = struct
       chapter-heading ctx ib
     in
     let bb-inner = read-block ctx inner in
-      bb-title +++ bb-inner
-
+    bb-title +++ bb-inner
 
   val section-scheme ctx label title outline-title-opt inner =
-    let open Pervasives in
     let ctx-title = make-section-title ctx in
-    let () = increment num-section in
+    let () = Ref.increment num-section in
     let () = num-subsection <- 0 in
     let s-num = arabic (!num-chapter) ^ `.` ^ arabic (!num-section) in
     let () = register-cross-reference (label ^ `:num`) s-num in
-%    let () = toc-acc-ref <- (TOCElementSection(label, title)) :: !toc-acc-ref in
     let ib-num =
       read-inline ctx-title (embed-string (s-num ^ `.`))
         ++ hook-page-break (fun pbinfo _ -> (
@@ -481,14 +439,12 @@ end = struct
       section-heading ctx ib
     in
     let bb-inner = read-block ctx inner in
-      bb-title +++ bb-inner
-
+    bb-title +++ bb-inner
 
   val subsection-scheme ctx label title outline-title-opt inner =
     let () = num-subsection <- !num-subsection + 1 in
     let s-num = arabic (!num-chapter) ^ `.` ^ arabic (!num-section) ^ `.` ^ arabic (!num-subsection) in
     let () = register-cross-reference (label ^ `:num`) s-num in
-%    let () = toc-acc-ref <- (TOCElementSubsection(label, title)) :: !toc-acc-ref in
     let ctx-title = make-subsection-title ctx in
     let ib-num =
       read-inline ctx-title (embed-string (s-num ^ `.`))
@@ -505,7 +461,6 @@ end = struct
     let bb-inner = read-block ctx inner in
     bb-title +++ bb-inner
 
-
   val block ctx +chapter ?(label = label-opt, outline-title = outline-title-opt) title inner =
     let label =
       match label-opt with
@@ -514,7 +469,6 @@ end = struct
       end
     in
     chapter-scheme ctx label title outline-title-opt inner
-
 
   val block ctx +section ?(label = label-opt, outline-title = outline-title-opt) title inner =
     let label =
@@ -525,7 +479,6 @@ end = struct
     in
     section-scheme ctx label title outline-title-opt inner
 
-
   val block ctx +subsection ?(label = label-opt, outline-title = outline-title-opt) title inner =
     let label =
       match label-opt with
@@ -535,10 +488,8 @@ end = struct
     in
     subsection-scheme ctx label title outline-title-opt inner
 
-
   val theorem-scheme ctx ctxf category wordopt label inner =
-    let open Pervasives in
-    let () = increment num-theorems in
+    let () = Ref.increment num-theorems in
     let s-num =
       (arabic (!num-chapter)) ^ `.` ^ (arabic (!num-section)) ^ `.` ^ (arabic (!num-theorems))
     in
@@ -557,38 +508,31 @@ end = struct
     line-break true true ctx
       (ib-dfn ++ ib-word ++ inline-skip (get-font-size ctx) ++ ib-inner ++ inline-fil)
 
-
   val make-label prefix labelopt =
     match labelopt with
     | None    -> generate-fresh-label ()
     | Some(s) -> prefix ^ s
     end
 
-
   val block ctx +definition ?(word = word-opt, label = label-opt) inner =
     let label = make-label `definition:` label-opt in
     theorem-scheme ctx (fun x -> x) {Definition} word-opt label inner
-
 
   val block ctx +theorem ?(word = word-opt, label = label-opt) inner =
     let label = make-label `theorem:` label-opt in
     theorem-scheme ctx (set-latin-font font-latin-italic) {Theorem} word-opt label inner
 
-
   val block ctx +lemma ?(word = word-opt, label = label-opt) inner =
     let label = make-label `lemma:` label-opt in
     theorem-scheme ctx (set-latin-font font-latin-italic) {Lemma} word-opt label inner
-
 
   val block ctx +corollary ?(word = word-opt, label = label-opt) inner =
     let label = make-label `corollary:` label-opt in
     theorem-scheme ctx (set-latin-font font-latin-italic) {Corollary} word-opt label inner
 
-
   val block ctx +example ?(word = word-opt, label = label-opt) inner =
     let label = make-label `example:` label-opt in
     theorem-scheme ctx (fun x -> x) {Example} word-opt label inner
-
 
   val block ctx +proof ?(word = word-opt) inner =
     let ib-heading =
@@ -602,7 +546,6 @@ end = struct
     line-break true true ctx
       (ib-heading ++ inline-skip (get-font-size ctx) ++ read-inline ctx inner ++ inline-fil ++ ib-box)
 
-
   val inline ctx \emph inner =
     let ctx =
       ctx |> set-font Latin font-latin-sans
@@ -610,9 +553,7 @@ end = struct
     in
     read-inline ctx inner
 
-
   val inline \dfn inner = {\emph{#inner;}}
-
 
   val inline ctx \footnote it =
     let size = get-font-size ctx in

--- a/lib-satysfi/packages/std-ja/std-ja.0.0.1/src/std-ja.satyh
+++ b/lib-satysfi/packages/std-ja/std-ja.0.0.1/src/std-ja.satyh
@@ -21,13 +21,13 @@ module StdJa :> sig
       paper-size       : length * length,
       text-width       : length,
       text-height      : length,
-      text-origin      : Pervasives.point, %- TODO: remove this by using 'open'
-      header-origin    : Pervasives.point,
-      footer-origin    : Pervasives.point,
+      text-origin      : point,
+      header-origin    : point,
+      footer-origin    : point,
       header-width     : length,
       footer-width     : length,
     ) (|
-      title : inline-text,
+      title  : inline-text,
       author : inline-text,
     |) -> block-text -> document
 
@@ -115,7 +115,7 @@ end = struct
 
   val get-standard-context wid =
     get-initial-context wid (command \Math.math)
-      |> set-code-text-command (command \Code.code)
+      |> set-code-text-command (command \Code.Default.code)
       |> set-hyphenation-dictionary HyphEnglish.hyphenation
       |> set-unicode-char-database Unidata.unidata
       |> set-dominant-wide-script Kana
@@ -136,7 +136,7 @@ end = struct
 
   val height-of-float-boxes pageno =
 %    let () = display-message `get height` in
-    (!ref-float-boxes) |> List.fold-left (fun h (pn, bb) -> (
+    (!ref-float-boxes) |> List.fold (fun h (pn, bb) -> (
       if pn < pageno then h +' (get-natural-length bb) else h
     )) 0pt
 
@@ -148,8 +148,7 @@ end = struct
     let () = ref-figure <- !ref-figure + 1 in
     let s-num = embed-string (arabic (!ref-figure)) in
     let bb-inner =
-      let d (_, _) _ _ _ = Gr.empty in
-      block-frame-breakable ctx (2pt, 2pt, 2pt, 2pt) (d, d, d, d) (fun ctx -> (
+      block-frame-breakable ctx (2pt, 2pt, 2pt, 2pt) VDecoSet.empty (fun ctx -> (
         read-block ctx inner
           +++ line-break true true ctx (inline-fil ++ read-inline ctx {図#s-num; #caption;} ++ inline-fil)
       ))
@@ -228,11 +227,11 @@ end = struct
 %        if get-text-width ctx <' get-natural-width ib-title then
 %          form-paragraph ctx-title (ib-title ++ inline-fil)
 %        else
-          Pervasives.form-paragraph ctx-title (inline-fil ++ ib-title ++ inline-fil)
+          Block.form-paragraph ctx-title (inline-fil ++ ib-title ++ inline-fil)
       in
-      let bb-line = Pervasives.form-paragraph ctx (ib-line ++ inline-fil) in
-      let bb-author = Pervasives.form-paragraph ctx-author (inline-fil ++ ib-author) in
-        bb-title +++ bb-line +++ bb-author
+      let bb-line = Block.form-paragraph ctx (ib-line ++ inline-fil) in
+      let bb-author = Block.form-paragraph ctx-author (inline-fil ++ ib-author) in
+      bb-title +++ bb-line +++ bb-author
     ))
 
 
@@ -322,22 +321,22 @@ end = struct
           line-break true false ctx-doc (read-inline (make-section-title ctx-doc) {目次} ++ inline-fil)
         in
         let bb-toc-main =
-          (!toc-acc-ref) |> List.reverse |> List.fold-left (fun bbacc tocelem -> (
+          (!toc-acc-ref) |> List.reverse |> List.fold (fun bbacc tocelem -> (
             match tocelem with
             | TOCElementSection(label, title) ->
                 let it-num = embed-string (get-cross-reference-number label) in
                 let it-page = embed-string (get-cross-reference-page label) in
-                  bbacc +++ line-break true true ctx-doc
-                    (inline-frame-breakable no-pads (Annot.link-to-location-frame label None)
-                    (read-inline ctx-doc {#it-num;. #title;} ++ inline-fil ++ read-inline ctx-doc it-page))
+                bbacc +++ line-break true true ctx-doc
+                  (inline-frame-breakable no-pads (Annot.link-to-location-frame label None)
+                  (read-inline ctx-doc {#it-num;. #title;} ++ inline-fil ++ read-inline ctx-doc it-page))
 
             | TOCElementSubsection(label, title) ->
                   let it-num = embed-string (get-cross-reference-number label) in
                   let it-page = embed-string (get-cross-reference-page label) in
-                    bbacc +++ line-break true true ctx-doc
-                      (inline-skip 20pt ++ (inline-frame-breakable no-pads
-                        (Annot.link-to-location-frame label None)
-                        (read-inline ctx-doc {#it-num;. #title;} ++ inline-fil ++ read-inline ctx-doc it-page)))
+                  bbacc +++ line-break true true ctx-doc
+                    (inline-skip 20pt ++ (inline-frame-breakable no-pads
+                      (Annot.link-to-location-frame label None)
+                      (read-inline ctx-doc {#it-num;. #title;} ++ inline-fil ++ read-inline ctx-doc it-page)))
             end
           )) block-nil
         in
@@ -368,7 +367,7 @@ end = struct
        in
 %       let () = display-message `insert` in
        let (bb-float-boxes, acc) =
-         (!ref-float-boxes) |> List.fold-left (fun (bbacc, acc) elem -> (
+         (!ref-float-boxes) |> List.fold (fun (bbacc, acc) elem -> (
            let (pn, bb) = elem in
              if pn < pageno then
                let bbs =
@@ -376,7 +375,7 @@ end = struct
                    (inline-fil ++ embed-block-top ctx txtwid (fun _ -> bb) ++ inline-fil)
                      % 'ctx' is a dummy context
                in
-                 (bbacc +++ bbs, acc)
+               (bbacc +++ bbs, acc)
              else
                (bbacc, elem :: acc)
          )) (block-nil, [])
@@ -385,45 +384,42 @@ end = struct
           line-break true true ctx ib-text
             +++ line-break true true (ctx |> set-paragraph-margin 0pt 6pt)
               ((inline-graphics hdrwid thickness 0pt
-                (fun (x, y) -> fill Color.black (Gr.rectangle (x, y) (x +' hdrwid, y +' thickness)))) ++ inline-fil)
+                (fun (x, y) -> fill Color.black (Path.rectangle (x, y) (x +' hdrwid, y +' thickness)))) ++ inline-fil)
             +++ bb-float-boxes
       in
       let footer =
         if show-pages then
           let ctx = get-standard-context ftrwid in
           let it-pageno = embed-string (arabic pbinfo#page-number) in
-            line-break true true ctx
-              (inline-fil ++ (read-inline ctx {— #it-pageno; —}) ++ inline-fil)
+          line-break true true ctx
+            (inline-fil ++ (read-inline ctx {— #it-pageno; —}) ++ inline-fil)
         else
           block-nil
       in
-        (|
-          header-origin  = hdrorg,
-          header-content = header,
-          footer-origin  = ftrorg,
-          footer-content = footer,
-        |)
+      (|
+        header-origin  = hdrorg,
+        header-content = header,
+        footer-origin  = ftrorg,
+        footer-content = footer,
+      |)
     in
     let doc = page-break page pagecontf pagepartsf (bb-title +++ bb-toc +++ bb-main) in
     let () = register-outline (List.reverse !outline-ref) in
-      doc
-
+    doc
 
   val mutable needs-indentation-ref <- true
 
   val mutable num-section <- 0
   val mutable num-subsection <- 0
 
-
   val quad-indent ctx =
     inline-skip (get-font-size ctx)
-
 
   val block ctx +p inner =
     let needs-indentation =
       if !needs-indentation-ref then true else
         let () = needs-indentation-ref <- true in
-          false
+        false
     in
     let ib-inner = read-inline ctx inner in
     let br-parag =
@@ -432,14 +428,12 @@ end = struct
       else
         ib-inner ++ inline-fil
     in
-    Pervasives.form-paragraph ctx br-parag
-
+    Block.form-paragraph ctx br-parag
 
   val block ctx +pn inner =
     let () = needs-indentation-ref <- true in
     let ib-inner = read-inline ctx inner in
-    Pervasives.form-paragraph ctx (ib-inner ++ inline-fil)
-
+    Block.form-paragraph ctx (ib-inner ++ inline-fil)
 
   val section-scheme ctx label title outline-title-opt inner =
     let ctx-title = make-section-title ctx in
@@ -462,7 +456,7 @@ end = struct
           (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil)))
     in
     let bb-inner = read-block ctx inner in
-      bb-title +++ bb-inner
+    bb-title +++ bb-inner
 
 
   val subsection-scheme ctx label title outline-title-opt inner =
@@ -485,8 +479,7 @@ end = struct
           (ib-num ++ (inline-skip 10pt) ++ ib-title ++ (inline-fil)))
     in
     let bb-inner = read-block ctx inner in
-      bb-title +++ bb-inner
-
+    bb-title +++ bb-inner
 
   val block ctx +section ?(label = labelopt, outline-title = outline-title-opt) title inner =
     let label =
@@ -495,8 +488,7 @@ end = struct
       | Some(label) -> label
       end
     in
-      section-scheme ctx label title outline-title-opt inner
-
+    section-scheme ctx label title outline-title-opt inner
 
   val block ctx +subsection ?(label = labelopt, outline-title = outline-title-opt) title inner =
     let label =
@@ -505,8 +497,7 @@ end = struct
       | Some(label) -> label
       end
     in
-      subsection-scheme ctx label title outline-title-opt inner
-
+    subsection-scheme ctx label title outline-title-opt inner
 
   val inline ctx \emph inner =
     let ctx-emph =

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/arith.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/arith.satyg
@@ -1,7 +1,7 @@
 module Arith :> sig
-  val pi : float
+  val persistent ~pi : float
 end = struct
 
-  val pi = 3.1415926536
+  val persistent ~pi = 3.1415926536
 
 end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/arith.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/arith.satyg
@@ -1,0 +1,7 @@
+module Arith :> sig
+  val pi : float
+end = struct
+
+  val pi = 3.1415926536
+
+end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/basic.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/basic.satyg
@@ -1,0 +1,9 @@
+module Basic = struct
+
+  type ordering = Less | Equal | Greater
+
+  type point = length * length
+
+  type paren = length -> length -> context -> inline-boxes * (length -> length)
+
+end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/basic.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/basic.satyg
@@ -6,4 +6,9 @@ module Basic = struct
 
   type paren = length -> length -> context -> inline-boxes * (length -> length)
 
+  signature Ord = sig
+    type t :: o
+    val compare : t -> t -> ordering
+  end
+
 end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/block.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/block.satyh
@@ -1,7 +1,10 @@
 module Block :> sig
   val form-paragraph : context -> inline-boxes -> block-boxes
   val +skip : block [length]
+  val \skip : inline [length]
   val +clear-page : block []
+  val +ragged-right : block [inline-text]
+  val +centering : block [inline-text]
 end = struct
 
   val form-paragraph =
@@ -10,7 +13,16 @@ end = struct
   val block ctx +skip len =
     block-skip len
 
+  val inline ctx \skip len =
+    inline-fil ++ embed-block-breakable ctx (block-skip len) ++ omit-skip-after
+
   val block ctx +clear-page =
     clear-page
+
+  val block ctx +ragged-right it =
+    form-paragraph ctx (inline-fil ++ read-inline ctx it)
+
+  val block ctx +centering it =
+    form-paragraph ctx (inline-fil ++ read-inline ctx it ++ inline-fil)
 
 end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/block.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/block.satyh
@@ -1,0 +1,7 @@
+module Block :> sig
+  val form-paragraph : context -> inline-boxes -> block-boxes
+end = struct
+
+  val form-paragraph = line-break true true
+
+end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/block.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/block.satyh
@@ -1,7 +1,16 @@
 module Block :> sig
   val form-paragraph : context -> inline-boxes -> block-boxes
+  val +skip : block [length]
+  val +clear-page : block []
 end = struct
 
-  val form-paragraph = line-break true true
+  val form-paragraph =
+    line-break true true
+
+  val block ctx +skip len =
+    block-skip len
+
+  val block ctx +clear-page =
+    clear-page
 
 end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/deco.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/deco.satyh
@@ -1,4 +1,4 @@
-use Gr
+use Graphics
 use Path
 
 module Deco :> sig
@@ -7,11 +7,11 @@ module Deco :> sig
 end = struct
 
   val empty _ _ _ _ =
-    unite-graphics []
+    Graphics.empty
 
   val simple-frame t scolor fcolor (x, y) w h d =
     let path = Path.rectangle (x, y -' d) (x +' w, y +' h) in
-    unite-graphics [
+    Graphics.overlay [
       fill fcolor path,
       stroke t scolor path,
     ]

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/deco.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/deco.satyh
@@ -1,4 +1,5 @@
 use Gr
+use Path
 
 module Deco :> sig
   val empty : deco
@@ -9,7 +10,7 @@ end = struct
     unite-graphics []
 
   val simple-frame t scolor fcolor (x, y) w h d =
-    let path = Gr.rectangle (x, y -' d) (x +' w, y +' h) in
+    let path = Path.rectangle (x, y -' d) (x +' w, y +' h) in
     unite-graphics [
       fill fcolor path,
       stroke t scolor path,

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/geom.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/geom.satyh
@@ -1,17 +1,13 @@
+use open Basic
 use Pervasives
 
 module Geom :> sig
-  type point = Pervasives.point %TODO (enhance): remove this
   val atan2-point : point -> point -> float
   val div-perp : point -> point -> float -> length -> point
 end = struct
 
-  type point = Pervasives.point %TODO (enhance): remove this
-
-
   val atan2-point (x1, y1) (x2, y2) =
     atan2 ((y2 -' y1) /' 1pt) ((x2 -' x1) /' 1pt)
-
 
   val div-perp (x1, y1) (x2, y2) t len =
     let cx = x1 *' (1. -. t) +' x2 *' t in

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/geom.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/geom.satyh
@@ -1,5 +1,5 @@
 use open Basic
-use Pervasives
+use Arith
 
 module Geom :> sig
   val atan2-point : point -> point -> float
@@ -12,7 +12,7 @@ end = struct
   val div-perp (x1, y1) (x2, y2) t len =
     let cx = x1 *' (1. -. t) +' x2 *' t in
     let cy = y1 *' (1. -. t) +' y2 *' t in
-    let theta = atan2 ((y2 -' y1) /' 1pt) ((x2 -' x1) /' 1pt) +. Pervasives.math-pi /. 2. in
+    let theta = atan2 ((y2 -' y1) /' 1pt) ((x2 -' x1) /' 1pt) +. Arith.pi /. 2. in
     (cx +' len *' (cos theta), cy +' len *' (sin theta))
 
 end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/gr.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/gr.satyh
@@ -1,10 +1,10 @@
+use open Basic
 use Pervasives
 use Geom
 use List
 use Length
 
 module Gr :> sig
-  type point = Pervasives.point  %TODO (enhance): erase this
   val rectangle : point -> point -> path
   val rectangle-round : length -> point -> point -> path
   val rectangle-round-left : length -> point -> point -> path
@@ -26,8 +26,6 @@ module Gr :> sig
   val rotate-graphics : point -> float -> graphics -> graphics
   val scale-graphics : point -> float -> float -> graphics -> graphics
 end = struct
-
-  type point = Pervasives.point  %TODO (enhance): erase this
 
   val rectangle (x1, y1) (x2, y2) =
     start-path (x1, y1)

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/gr.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/gr.satyh
@@ -1,129 +1,20 @@
 use open Basic
 use Arith
 use Geom
+use Path
 use List
 use Length
 
 module Gr :> sig
-  val rectangle : point -> point -> path
-  val rectangle-round : length -> point -> point -> path
-  val rectangle-round-left : length -> point -> point -> path
-  val rectangle-round-left-lower : length -> point -> point -> path
-  val rectangle-round-left-upper : length -> point -> point -> path
-  val rectangle-round-right : length -> point -> point -> path
-  val poly-line : point -> list point -> path
-  val polygon : point -> list point -> path
-  val line : point -> point -> path
-  val circle : point -> length -> path
   val empty : graphics
   val text-centering : point -> inline-boxes -> graphics
   val text-leftward : point -> inline-boxes -> graphics
   val text-rightward : point -> inline-boxes -> graphics
   val arrow : length -> color -> length -> length -> length -> point -> point -> graphics
   val dashed-arrow : length -> length * length * length -> color -> length -> length -> length -> point -> point -> graphics
-  val rotate-path : point -> float -> path -> path
-  val scale-path : point -> float -> float -> path -> path
   val rotate-graphics : point -> float -> graphics -> graphics
   val scale-graphics : point -> float -> float -> graphics -> graphics
 end = struct
-
-  val rectangle (x1, y1) (x2, y2) =
-    start-path (x1, y1)
-      |> line-to (x1, y2)
-      |> line-to (x2, y2)
-      |> line-to (x2, y1)
-      |> close-with-line
-
-  val rectangle-round r (xA, yA) (xB, yB) =
-    let t = r *' 0.4 in
-    let x1 = Length.min xA xB in
-    let x2 = Length.max xA xB in
-    let y1 = Length.min yA yB in
-    let y2 = Length.max yA yB in
-    start-path                                 (x1, y1 +' r)
-      |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
-      |> line-to                               (x2 -' r, y1)
-      |> bezier-to (x2 -' t, y1) (x2, y1 +' t) (x2, y1 +' r)
-      |> line-to                               (x2, y2 -' r)
-      |> bezier-to (x2, y2 -' t) (x2 -' t, y2) (x2 -' r, y2)
-      |> line-to                               (x1 +' r, y2)
-      |> bezier-to (x1 +' t, y2) (x1, y2 -' t) (x1, y2 -' r)
-      |> close-with-line
-
-  val rectangle-round-left r (xA, yA) (xB, yB) =
-    let t = r *' 0.4 in
-    let x1 = Length.min xA xB in
-    let x2 = Length.max xA xB in
-    let y1 = Length.min yA yB in
-    let y2 = Length.max yA yB in
-    start-path                                 (x1, y1 +' r)
-      |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
-      |> line-to                               (x2, y1)
-      |> line-to                               (x2, y2)
-      |> line-to                               (x1 +' r, y2)
-      |> bezier-to (x1 +' t, y2) (x1, y2 -' t) (x1, y2 -' r)
-      |> close-with-line
-
-  val rectangle-round-left-lower r (xA, yA) (xB, yB) =
-    let t = r *' 0.4 in
-    let x1 = Length.min xA xB in
-    let x2 = Length.max xA xB in
-    let y1 = Length.min yA yB in
-    let y2 = Length.max yA yB in
-    start-path                                 (x1, y1 +' r)
-      |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
-      |> line-to                               (x2, y1)
-      |> line-to                               (x2, y2)
-      |> line-to                               (x1, y2)
-      |> close-with-line
-
-  val rectangle-round-left-upper r (xA, yA) (xB, yB) =
-    let t = r *' 0.4 in
-    let x1 = Length.min xA xB in
-    let x2 = Length.max xA xB in
-    let y1 = Length.min yA yB in
-    let y2 = Length.max yA yB in
-    start-path                                 (x1, y1)
-      |> line-to                               (x2, y1)
-      |> line-to                               (x2, y2)
-      |> line-to                               (x1 +' r, y2)
-      |> bezier-to (x1 +' t, y2) (x1, y2 -' t) (x1, y1 -' t)
-      |> close-with-line
-
-  val rectangle-round-right r (xA, yA) (xB, yB) =
-    let t = r *' 0.4 in
-    let x1 = Length.min xA xB in
-    let x2 = Length.max xA xB in
-    let y1 = Length.min yA yB in
-    let y2 = Length.max yA yB in
-    start-path                                 (x1, y1)
-      |> line-to                               (x2 -' r, y1)
-      |> bezier-to (x2 -' t, y1) (x2, y1 +' t) (x2, y1 +' r)
-      |> line-to                               (x2, y2 -' r)
-      |> bezier-to (x2, y2 -' t) (x2 -' t, y2) (x2 -' r, y2)
-      |> line-to                               (x1, y2)
-      |> close-with-line
-
-  val poly-line pt-init pts =
-    pts |> List.fold (fun acc pt -> (
-      acc |> line-to pt
-    )) (start-path pt-init) |> terminate-path
-
-  val polygon pt-init pts =
-    pts |> List.fold (fun acc pt -> (
-      acc |> line-to pt
-    )) (start-path pt-init) |> close-with-line
-
-  val line pt1 pt2 =
-    start-path pt1 |> line-to pt2 |> terminate-path
-
-  val circle (cx, cy) r =
-    let t = r *' 0.55228 in
-    start-path (cx -' r, cy)
-      |> bezier-to (cx -' r, cy +' t) (cx -' t, cy +' r) (cx, cy +' r)
-      |> bezier-to (cx +' t, cy +' r) (cx +' r, cy +' t) (cx +' r, cy)
-      |> bezier-to (cx +' r, cy -' t) (cx +' t, cy -' r) (cx, cy -' r)
-      |> close-with-bezier (cx -' t, cy -' r) (cx -' r, cy -' t)
 
   val empty =
     unite-graphics []
@@ -157,8 +48,8 @@ end = struct
     let (p1, q1) = (cx +' lenP *' (cos phi), cy +' lenP *' (sin phi)) in
     let (p2, q2) = (cx -' lenP *' (cos phi), cy -' lenP *' (sin phi)) in
     unite-graphics [
-      strokef color (line pt1 (mx, my)),
-      fill color (polygon pt2 [(p1, q1), (mx, my), (p2, q2)]),
+      strokef color (Path.line pt1 (mx, my)),
+      fill color (Path.polygon pt2 [(p1, q1), (mx, my), (p2, q2)]),
     ]
 
   val arrow thkns =
@@ -166,19 +57,6 @@ end = struct
 
   val dashed-arrow thkns dash =
     arrow-scheme (dashed-stroke thkns dash)
-
-  val rotate-path centpt angle path =
-    let (centx, centy) = centpt in
-    let rad = angle *. Arith.pi /. 180. in
-    path |> shift-path (0pt -' centx, 0pt -' centy)
-         |> linear-transform-path (cos rad) (0. -. (sin rad)) (sin rad) (cos rad)
-         |> shift-path centpt
-
-  val scale-path centpt scalex scaley path =
-    let (centx, centy) = centpt in
-    path |> shift-path (0pt -' centx, 0pt -' centy)
-         |> linear-transform-path scalex 0. 0. scaley
-         |> shift-path centpt
 
   val rotate-graphics centpt angle gr =
     let (centx, centy) = centpt in

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/gr.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/gr.satyh
@@ -1,5 +1,5 @@
 use open Basic
-use Pervasives
+use Arith
 use Geom
 use List
 use Length
@@ -153,7 +153,7 @@ end = struct
     let theta = Geom.atan2-point pt2 pt1 in
     let (cx, cy) = (x2 +' lenL *' (cos theta), y2 +' lenL *' (sin theta)) in
     let (mx, my) = (x2 +' lenM *' (cos theta), y2 +' lenM *' (sin theta)) in
-    let phi = theta +. Pervasives.math-pi /. 2. in
+    let phi = theta +. Arith.pi /. 2. in
     let (p1, q1) = (cx +' lenP *' (cos phi), cy +' lenP *' (sin phi)) in
     let (p2, q2) = (cx -' lenP *' (cos phi), cy -' lenP *' (sin phi)) in
     unite-graphics [
@@ -169,7 +169,7 @@ end = struct
 
   val rotate-path centpt angle path =
     let (centx, centy) = centpt in
-    let rad = angle *. Pervasives.math-pi /. 180. in
+    let rad = angle *. Arith.pi /. 180. in
     path |> shift-path (0pt -' centx, 0pt -' centy)
          |> linear-transform-path (cos rad) (0. -. (sin rad)) (sin rad) (cos rad)
          |> shift-path centpt
@@ -182,7 +182,7 @@ end = struct
 
   val rotate-graphics centpt angle gr =
     let (centx, centy) = centpt in
-    let rad = angle *. Pervasives.math-pi /. 180. in
+    let rad = angle *. Arith.pi /. 180. in
     gr |> shift-graphics (0pt -' centx, 0pt -' centy)
        |> linear-transform-graphics (cos rad) (0. -. (sin rad)) (sin rad) (cos rad)
        |> shift-graphics centpt

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/gr.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/gr.satyh
@@ -1,6 +1,7 @@
 use Pervasives
 use Geom
 use List
+use Length
 
 module Gr :> sig
   type point = Pervasives.point  %TODO (enhance): erase this
@@ -38,10 +39,10 @@ end = struct
 
   val rectangle-round r (xA, yA) (xB, yB) =
     let t = r *' 0.4 in
-    let x1 = Pervasives.length-min xA xB in
-    let x2 = Pervasives.length-max xA xB in
-    let y1 = Pervasives.length-min yA yB in
-    let y2 = Pervasives.length-max yA yB in
+    let x1 = Length.min xA xB in
+    let x2 = Length.max xA xB in
+    let y1 = Length.min yA yB in
+    let y2 = Length.max yA yB in
       start-path                                 (x1, y1 +' r)
         |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
         |> line-to                               (x2 -' r, y1)
@@ -55,10 +56,10 @@ end = struct
 
   val rectangle-round-left r (xA, yA) (xB, yB) =
     let t = r *' 0.4 in
-    let x1 = Pervasives.length-min xA xB in
-    let x2 = Pervasives.length-max xA xB in
-    let y1 = Pervasives.length-min yA yB in
-    let y2 = Pervasives.length-max yA yB in
+    let x1 = Length.min xA xB in
+    let x2 = Length.max xA xB in
+    let y1 = Length.min yA yB in
+    let y2 = Length.max yA yB in
       start-path                                 (x1, y1 +' r)
         |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
         |> line-to                               (x2, y1)
@@ -70,10 +71,10 @@ end = struct
 
   val rectangle-round-left-lower r (xA, yA) (xB, yB) =
     let t = r *' 0.4 in
-    let x1 = Pervasives.length-min xA xB in
-    let x2 = Pervasives.length-max xA xB in
-    let y1 = Pervasives.length-min yA yB in
-    let y2 = Pervasives.length-max yA yB in
+    let x1 = Length.min xA xB in
+    let x2 = Length.max xA xB in
+    let y1 = Length.min yA yB in
+    let y2 = Length.max yA yB in
       start-path                                 (x1, y1 +' r)
         |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
         |> line-to                               (x2, y1)
@@ -84,10 +85,10 @@ end = struct
 
   val rectangle-round-left-upper r (xA, yA) (xB, yB) =
     let t = r *' 0.4 in
-    let x1 = Pervasives.length-min xA xB in
-    let x2 = Pervasives.length-max xA xB in
-    let y1 = Pervasives.length-min yA yB in
-    let y2 = Pervasives.length-max yA yB in
+    let x1 = Length.min xA xB in
+    let x2 = Length.max xA xB in
+    let y1 = Length.min yA yB in
+    let y2 = Length.max yA yB in
       start-path                                 (x1, y1)
         |> line-to                               (x2, y1)
         |> line-to                               (x2, y2)
@@ -98,10 +99,10 @@ end = struct
 
   val rectangle-round-right r (xA, yA) (xB, yB) =
     let t = r *' 0.4 in
-    let x1 = Pervasives.length-min xA xB in
-    let x2 = Pervasives.length-max xA xB in
-    let y1 = Pervasives.length-min yA yB in
-    let y2 = Pervasives.length-max yA yB in
+    let x1 = Length.min xA xB in
+    let x2 = Length.max xA xB in
+    let y1 = Length.min yA yB in
+    let y2 = Length.max yA yB in
       start-path                                 (x1, y1)
         |> line-to                               (x2 -' r, y1)
         |> bezier-to (x2 -' t, y1) (x2, y1 +' t) (x2, y1 +' r)

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/gr.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/gr.satyh
@@ -36,23 +36,21 @@ end = struct
       |> line-to (x2, y1)
       |> close-with-line
 
-
   val rectangle-round r (xA, yA) (xB, yB) =
     let t = r *' 0.4 in
     let x1 = Length.min xA xB in
     let x2 = Length.max xA xB in
     let y1 = Length.min yA yB in
     let y2 = Length.max yA yB in
-      start-path                                 (x1, y1 +' r)
-        |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
-        |> line-to                               (x2 -' r, y1)
-        |> bezier-to (x2 -' t, y1) (x2, y1 +' t) (x2, y1 +' r)
-        |> line-to                               (x2, y2 -' r)
-        |> bezier-to (x2, y2 -' t) (x2 -' t, y2) (x2 -' r, y2)
-        |> line-to                               (x1 +' r, y2)
-        |> bezier-to (x1 +' t, y2) (x1, y2 -' t) (x1, y2 -' r)
-        |> close-with-line
-
+    start-path                                 (x1, y1 +' r)
+      |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
+      |> line-to                               (x2 -' r, y1)
+      |> bezier-to (x2 -' t, y1) (x2, y1 +' t) (x2, y1 +' r)
+      |> line-to                               (x2, y2 -' r)
+      |> bezier-to (x2, y2 -' t) (x2 -' t, y2) (x2 -' r, y2)
+      |> line-to                               (x1 +' r, y2)
+      |> bezier-to (x1 +' t, y2) (x1, y2 -' t) (x1, y2 -' r)
+      |> close-with-line
 
   val rectangle-round-left r (xA, yA) (xB, yB) =
     let t = r *' 0.4 in
@@ -60,14 +58,13 @@ end = struct
     let x2 = Length.max xA xB in
     let y1 = Length.min yA yB in
     let y2 = Length.max yA yB in
-      start-path                                 (x1, y1 +' r)
-        |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
-        |> line-to                               (x2, y1)
-        |> line-to                               (x2, y2)
-        |> line-to                               (x1 +' r, y2)
-        |> bezier-to (x1 +' t, y2) (x1, y2 -' t) (x1, y2 -' r)
-        |> close-with-line
-
+    start-path                                 (x1, y1 +' r)
+      |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
+      |> line-to                               (x2, y1)
+      |> line-to                               (x2, y2)
+      |> line-to                               (x1 +' r, y2)
+      |> bezier-to (x1 +' t, y2) (x1, y2 -' t) (x1, y2 -' r)
+      |> close-with-line
 
   val rectangle-round-left-lower r (xA, yA) (xB, yB) =
     let t = r *' 0.4 in
@@ -75,13 +72,12 @@ end = struct
     let x2 = Length.max xA xB in
     let y1 = Length.min yA yB in
     let y2 = Length.max yA yB in
-      start-path                                 (x1, y1 +' r)
-        |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
-        |> line-to                               (x2, y1)
-        |> line-to                               (x2, y2)
-        |> line-to                               (x1, y2)
-        |> close-with-line
-
+    start-path                                 (x1, y1 +' r)
+      |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
+      |> line-to                               (x2, y1)
+      |> line-to                               (x2, y2)
+      |> line-to                               (x1, y2)
+      |> close-with-line
 
   val rectangle-round-left-upper r (xA, yA) (xB, yB) =
     let t = r *' 0.4 in
@@ -89,13 +85,12 @@ end = struct
     let x2 = Length.max xA xB in
     let y1 = Length.min yA yB in
     let y2 = Length.max yA yB in
-      start-path                                 (x1, y1)
-        |> line-to                               (x2, y1)
-        |> line-to                               (x2, y2)
-        |> line-to                               (x1 +' r, y2)
-        |> bezier-to (x1 +' t, y2) (x1, y2 -' t) (x1, y1 -' t)
-        |> close-with-line
-
+    start-path                                 (x1, y1)
+      |> line-to                               (x2, y1)
+      |> line-to                               (x2, y2)
+      |> line-to                               (x1 +' r, y2)
+      |> bezier-to (x1 +' t, y2) (x1, y2 -' t) (x1, y1 -' t)
+      |> close-with-line
 
   val rectangle-round-right r (xA, yA) (xB, yB) =
     let t = r *' 0.4 in
@@ -103,43 +98,37 @@ end = struct
     let x2 = Length.max xA xB in
     let y1 = Length.min yA yB in
     let y2 = Length.max yA yB in
-      start-path                                 (x1, y1)
-        |> line-to                               (x2 -' r, y1)
-        |> bezier-to (x2 -' t, y1) (x2, y1 +' t) (x2, y1 +' r)
-        |> line-to                               (x2, y2 -' r)
-        |> bezier-to (x2, y2 -' t) (x2 -' t, y2) (x2 -' r, y2)
-        |> line-to                               (x1, y2)
-        |> close-with-line
+    start-path                                 (x1, y1)
+      |> line-to                               (x2 -' r, y1)
+      |> bezier-to (x2 -' t, y1) (x2, y1 +' t) (x2, y1 +' r)
+      |> line-to                               (x2, y2 -' r)
+      |> bezier-to (x2, y2 -' t) (x2 -' t, y2) (x2 -' r, y2)
+      |> line-to                               (x1, y2)
+      |> close-with-line
 
-
-  val poly-line ptinit ptlst =
-    ptlst |> List.fold-left (fun acc pt -> (
+  val poly-line pt-init pts =
+    pts |> List.fold (fun acc pt -> (
       acc |> line-to pt
-    )) (start-path ptinit) |> terminate-path
+    )) (start-path pt-init) |> terminate-path
 
-
-  val polygon ptinit ptlst =
-    ptlst |> List.fold-left (fun acc pt -> (
+  val polygon pt-init pts =
+    pts |> List.fold (fun acc pt -> (
       acc |> line-to pt
-    )) (start-path ptinit) |> close-with-line
-
+    )) (start-path pt-init) |> close-with-line
 
   val line pt1 pt2 =
     start-path pt1 |> line-to pt2 |> terminate-path
 
-
   val circle (cx, cy) r =
     let t = r *' 0.55228 in
-      start-path (cx -' r, cy)
-        |> bezier-to (cx -' r, cy +' t) (cx -' t, cy +' r) (cx, cy +' r)
-        |> bezier-to (cx +' t, cy +' r) (cx +' r, cy +' t) (cx +' r, cy)
-        |> bezier-to (cx +' r, cy -' t) (cx +' t, cy -' r) (cx, cy -' r)
-        |> close-with-bezier (cx -' t, cy -' r) (cx -' r, cy -' t)
-
+    start-path (cx -' r, cy)
+      |> bezier-to (cx -' r, cy +' t) (cx -' t, cy +' r) (cx, cy +' r)
+      |> bezier-to (cx +' t, cy +' r) (cx +' r, cy +' t) (cx +' r, cy)
+      |> bezier-to (cx +' r, cy -' t) (cx +' t, cy -' r) (cx, cy -' r)
+      |> close-with-bezier (cx -' t, cy -' r) (cx -' r, cy -' t)
 
   val empty =
     unite-graphics []
-
 
   val get-nonempty-graphics-bbox gr =
     match get-graphics-bbox gr with
@@ -147,24 +136,20 @@ end = struct
     | Some(bbox) -> bbox
     end
 
-
   val text-centering pt ib =
     let gr = draw-text pt ib in
     let ((xmin, _), (xmax, _)) = get-nonempty-graphics-bbox gr in
     let wid = xmax -' xmin in
     shift-graphics (0pt -' wid *' 0.5, 0pt) gr
 
-
   val text-rightward =
     draw-text
-
 
   val text-leftward pt ib =
     let gr = draw-text pt ib in
     let ((xmin, _), (xmax, _)) = get-nonempty-graphics-bbox gr in
     let wid = xmax -' xmin in
     shift-graphics (0pt -' wid, 0pt) gr
-
 
   val arrow-scheme strokef color lenL lenM lenP ((x1, y1) as pt1) ((x2, y2) as pt2) =
     let theta = Geom.atan2-point pt2 pt1 in
@@ -178,14 +163,11 @@ end = struct
       fill color (polygon pt2 [(p1, q1), (mx, my), (p2, q2)]),
     ]
 
-
   val arrow thkns =
     arrow-scheme (stroke thkns)
 
-
   val dashed-arrow thkns dash =
     arrow-scheme (dashed-stroke thkns dash)
-
 
   val rotate-path centpt angle path =
     let (centx, centy) = centpt in
@@ -194,13 +176,11 @@ end = struct
          |> linear-transform-path (cos rad) (0. -. (sin rad)) (sin rad) (cos rad)
          |> shift-path centpt
 
-
   val scale-path centpt scalex scaley path =
     let (centx, centy) = centpt in
     path |> shift-path (0pt -' centx, 0pt -' centy)
          |> linear-transform-path scalex 0. 0. scaley
          |> shift-path centpt
-
 
   val rotate-graphics centpt angle gr =
     let (centx, centy) = centpt in
@@ -209,11 +189,9 @@ end = struct
        |> linear-transform-graphics (cos rad) (0. -. (sin rad)) (sin rad) (cos rad)
        |> shift-graphics centpt
 
-
   val scale-graphics centpt scalex scaley gr =
     let (centx, centy) = centpt in
     gr |> shift-graphics (0pt -' centx, 0pt -' centy)
        |> linear-transform-graphics scalex 0. 0. scaley
        |> shift-graphics centpt
-
 end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/graphics.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/graphics.satyh
@@ -5,19 +5,44 @@ use Path
 use List
 use Length
 
-module Gr :> sig
+module Graphics :> sig
+  val overlay : list graphics -> graphics
+  val shift : length * length -> graphics -> graphics
+  val linear-transform : float -> float -> float -> float -> graphics -> graphics
+  val rotate : point -> float -> graphics -> graphics
+  val scale : point -> float -> float -> graphics -> graphics
   val empty : graphics
   val text-centering : point -> inline-boxes -> graphics
   val text-leftward : point -> inline-boxes -> graphics
   val text-rightward : point -> inline-boxes -> graphics
   val arrow : length -> color -> length -> length -> length -> point -> point -> graphics
   val dashed-arrow : length -> length * length * length -> color -> length -> length -> length -> point -> point -> graphics
-  val rotate-graphics : point -> float -> graphics -> graphics
-  val scale-graphics : point -> float -> float -> graphics -> graphics
 end = struct
 
+  val overlay =
+    unite-graphics
+
+  val shift =
+    shift-graphics
+
+  val linear-transform =
+    linear-transform-graphics
+
+  val rotate centpt angle gr =
+    let (centx, centy) = centpt in
+    let rad = angle *. Arith.pi /. 180. in
+    gr |> shift (0pt -' centx, 0pt -' centy)
+       |> linear-transform (cos rad) (0. -. (sin rad)) (sin rad) (cos rad)
+       |> shift centpt
+
+  val scale centpt scalex scaley gr =
+    let (centx, centy) = centpt in
+    gr |> shift (0pt -' centx, 0pt -' centy)
+       |> linear-transform scalex 0. 0. scaley
+       |> shift centpt
+
   val empty =
-    unite-graphics []
+    overlay []
 
   val get-nonempty-graphics-bbox gr =
     match get-graphics-bbox gr with
@@ -29,7 +54,7 @@ end = struct
     let gr = draw-text pt ib in
     let ((xmin, _), (xmax, _)) = get-nonempty-graphics-bbox gr in
     let wid = xmax -' xmin in
-    shift-graphics (0pt -' wid *' 0.5, 0pt) gr
+    shift (0pt -' wid *' 0.5, 0pt) gr
 
   val text-rightward =
     draw-text
@@ -38,7 +63,7 @@ end = struct
     let gr = draw-text pt ib in
     let ((xmin, _), (xmax, _)) = get-nonempty-graphics-bbox gr in
     let wid = xmax -' xmin in
-    shift-graphics (0pt -' wid, 0pt) gr
+    shift (0pt -' wid, 0pt) gr
 
   val arrow-scheme strokef color lenL lenM lenP ((x1, y1) as pt1) ((x2, y2) as pt2) =
     let theta = Geom.atan2-point pt2 pt1 in
@@ -47,7 +72,7 @@ end = struct
     let phi = theta +. Arith.pi /. 2. in
     let (p1, q1) = (cx +' lenP *' (cos phi), cy +' lenP *' (sin phi)) in
     let (p2, q2) = (cx -' lenP *' (cos phi), cy -' lenP *' (sin phi)) in
-    unite-graphics [
+    overlay [
       strokef color (Path.line pt1 (mx, my)),
       fill color (Path.polygon pt2 [(p1, q1), (mx, my), (p2, q2)]),
     ]
@@ -58,16 +83,4 @@ end = struct
   val dashed-arrow thkns dash =
     arrow-scheme (dashed-stroke thkns dash)
 
-  val rotate-graphics centpt angle gr =
-    let (centx, centy) = centpt in
-    let rad = angle *. Arith.pi /. 180. in
-    gr |> shift-graphics (0pt -' centx, 0pt -' centy)
-       |> linear-transform-graphics (cos rad) (0. -. (sin rad)) (sin rad) (cos rad)
-       |> shift-graphics centpt
-
-  val scale-graphics centpt scalex scaley gr =
-    let (centx, centy) = centpt in
-    gr |> shift-graphics (0pt -' centx, 0pt -' centy)
-       |> linear-transform-graphics scalex 0. 0. scaley
-       |> shift-graphics centpt
 end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/hdecoset.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/hdecoset.satyh
@@ -1,4 +1,4 @@
-use Gr
+use Graphics
 use Path
 
 module HDecoSet :> sig
@@ -8,9 +8,8 @@ module HDecoSet :> sig
 end = struct
 
   val empty =
-    let deco _ _ _ _ = Gr.empty in
+    let deco _ _ _ _ = Graphics.empty in
     (deco, deco, deco, deco)
-
 
   val simple-frame-stroke t scolor =
     let strokef = stroke t scolor in
@@ -21,7 +20,7 @@ end = struct
       strokef (Path.poly-line (x +' w, y -' d) [ (x, y -' d), (x, y +' h), (x +' w, y +' h) ])
     in
     let decoM (x, y) w h d =
-      unite-graphics [
+      Graphics.overlay [
         strokef (Path.line (x, y -' d) (x +' w, y -' d)),
         strokef (Path.line (x, y +' h) (x +' w, y +' h)),
       ]
@@ -30,7 +29,6 @@ end = struct
       strokef (Path.poly-line (x, y -' d) [ (x +' w, y -' d), (x +' w, y +' h), (x, y +' h) ])
     in
     (decoS, decoH, decoM, decoT)
-
 
   val rectangle-round-fill r extra color =
     let decoS (x, y) wid hgt dpt =

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/hdecoset.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/hdecoset.satyh
@@ -1,4 +1,5 @@
 use Gr
+use Path
 
 module HDecoSet :> sig
   val empty : deco-set
@@ -14,35 +15,35 @@ end = struct
   val simple-frame-stroke t scolor =
     let strokef = stroke t scolor in
     let decoS (x, y) w h d =
-      strokef (Gr.rectangle (x, y -' d) (x +' w, y +' h))
+      strokef (Path.rectangle (x, y -' d) (x +' w, y +' h))
     in
     let decoH (x, y) w h d =
-      strokef (Gr.poly-line (x +' w, y -' d) [ (x, y -' d), (x, y +' h), (x +' w, y +' h) ])
+      strokef (Path.poly-line (x +' w, y -' d) [ (x, y -' d), (x, y +' h), (x +' w, y +' h) ])
     in
     let decoM (x, y) w h d =
       unite-graphics [
-        strokef (Gr.line (x, y -' d) (x +' w, y -' d)),
-        strokef (Gr.line (x, y +' h) (x +' w, y +' h)),
+        strokef (Path.line (x, y -' d) (x +' w, y -' d)),
+        strokef (Path.line (x, y +' h) (x +' w, y +' h)),
       ]
     in
     let decoT (x, y) w h d =
-      strokef (Gr.poly-line (x, y -' d) [ (x +' w, y -' d), (x +' w, y +' h), (x, y +' h) ])
+      strokef (Path.poly-line (x, y -' d) [ (x +' w, y -' d), (x +' w, y +' h), (x, y +' h) ])
     in
     (decoS, decoH, decoM, decoT)
 
 
   val rectangle-round-fill r extra color =
     let decoS (x, y) wid hgt dpt =
-      fill color (Gr.rectangle-round r (x, y -' dpt) (x +' wid, y +' hgt))
+      fill color (Path.rectangle-round r (x, y -' dpt) (x +' wid, y +' hgt))
     in
     let decoH (x, y) wid hgt dpt =
-      fill color (Gr.rectangle-round-left r (x, y -' dpt) (x +' wid +' extra, y +' hgt))
+      fill color (Path.rectangle-round-left r (x, y -' dpt) (x +' wid +' extra, y +' hgt))
     in
     let decoM (x, y) wid hgt dpt =
-      fill color (Gr.rectangle (x, y -' dpt) (x +' wid +' extra, y +' hgt))
+      fill color (Path.rectangle (x, y -' dpt) (x +' wid +' extra, y +' hgt))
     in
     let decoT (x, y) wid hgt dpt =
-      fill color (Gr.rectangle-round-right r (x -' extra, y -' dpt) (x +' wid, y +' hgt))
+      fill color (Path.rectangle-round-right r (x -' extra, y -' dpt) (x +' wid, y +' hgt))
     in
     (decoS, decoH, decoM, decoT)
 

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/inline.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/inline.satyh
@@ -1,12 +1,13 @@
 module Inline :> sig
   val get-natural-advance : inline-boxes -> length
   val kern : length -> inline-boxes
-  val \hskip : inline [length]
+  val \skip : inline [length]
   val no-break : inline-boxes -> inline-boxes
   val \no-break : inline [inline-text]
   val \fil : inline []
   val \fil-both : inline []
   val mandatory-break : context -> inline-boxes
+  val \mandatory-break : inline []
 end = struct
 
   val get-natural-advance ib =
@@ -15,7 +16,7 @@ end = struct
 
   val kern len = inline-skip (0pt -' len)
 
-  val inline ctx \hskip len =
+  val inline ctx \skip len =
     inline-skip len
 
   val no-break ib =
@@ -32,5 +33,8 @@ end = struct
 
   val mandatory-break ctx =
     discretionary 0 (inline-skip (get-text-width ctx *' 2.)) inline-fil inline-nil
+
+  val inline ctx \mandatory-break =
+    mandatory-break ctx
 
 end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/inline.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/inline.satyh
@@ -1,44 +1,36 @@
-module Pervasives = struct
+module Inline :> sig
+  val get-natural-advance : inline-boxes -> length
+  val kern : length -> inline-boxes
+  val \hskip : inline [length]
+  val no-break : inline-boxes -> inline-boxes
+  val \no-break : inline [inline-text]
+  val \fil : inline []
+  val \fil-both : inline []
+  val mandatory-break : context -> inline-boxes
+end = struct
 
-  val get-natural-width ib =
+  val get-natural-advance ib =
     let (wid, _, _) = get-natural-metrics ib in
     wid
 
-
-  val form-paragraph = line-break true true
-
-
   val kern len = inline-skip (0pt -' len)
-
 
   val inline ctx \hskip len =
     inline-skip len
 
-
   val no-break ib =
     inline-frame-outer (0pt, 0pt, 0pt, 0pt) (fun _ _ _ _ -> unite-graphics []) ib
-
 
   val inline ctx \no-break inner =
     no-break (read-inline ctx inner)
 
-
   val inline ctx \fil =
     discretionary 0 inline-nil inline-fil inline-nil
-
 
   val inline ctx \fil-both =
     discretionary 0 inline-nil inline-fil inline-fil
 
-
   val mandatory-break ctx =
     discretionary 0 (inline-skip (get-text-width ctx *' 2.)) inline-fil inline-nil
-
-
-  val math-pi = 3.1415926536
-
-
-  val increment r =
-    r <- !r + 1
 
 end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/int.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/int.satyg
@@ -1,0 +1,32 @@
+use open Basic
+
+module Int :> sig
+  type t = int
+  val ~lift : int -> code int
+  val persistent ~compare : int -> int -> ordering
+  val persistent ~equal : int -> int -> bool
+  val persistent ~max : int -> int -> int
+  val persistent ~min : int -> int -> int
+end = struct
+
+  type t = int
+
+  val ~lift = lift-int
+
+  val persistent ~compare n1 n2 =
+    if n1 == n2 then
+      Equal
+    else if n1 > n2 then
+      Greater
+    else
+      Less
+
+  val persistent ~equal = ( == )
+
+  val persistent ~max n1 n2 =
+    if n1 >= n2 then n1 else n2
+
+  val persistent ~min n1 n2 =
+    if n1 <= n2 then n1 else n2
+
+end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/length.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/length.satyh
@@ -1,11 +1,15 @@
 module Length :> sig
   type t = length
+  val ~lift : length -> code length
   val persistent ~max : length -> length -> length
   val persistent ~min : length -> length -> length
   val persistent ~abs : length -> length
 end = struct
 
   type t = length
+
+  val ~lift =
+    lift-length
 
   val persistent ~max len1 len2 =
     if len1 <' len2 then len2 else len1

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/length.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/length.satyh
@@ -1,0 +1,19 @@
+module Length :> sig
+  type t = length
+  val persistent ~max : length -> length -> length
+  val persistent ~min : length -> length -> length
+  val persistent ~abs : length -> length
+end = struct
+
+  type t = length
+
+  val persistent ~max len1 len2 =
+    if len1 <' len2 then len2 else len1
+
+  val persistent ~min len1 len2 =
+    if len1 <' len2 then len1 else len2
+
+  val persistent ~abs len =
+    if len <' 0pt then 0pt -' len else len
+
+end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/list.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/list.satyg
@@ -8,7 +8,7 @@ module List :> sig
   val persistent ~equal 'a : ('a -> 'a -> bool) -> list 'a -> list 'a -> bool
   val persistent ~fold 'a 'b : ('a -> 'b -> 'a) -> 'a -> list 'b -> 'a
   val persistent ~fold-indexed 'a 'b : ('a -> int -> 'b -> 'a) -> 'a -> list 'b -> 'a
-  val persistent ~fold-back 'a 'b : ('a -> 'b -> 'b) -> 'b -> list 'a -> 'b
+  val persistent ~fold-back 'a 'b : ('a -> 'b -> 'b) -> list 'a -> 'b -> 'b
   val persistent ~fold-adjacent 'a 'b : ('a -> 'b -> option 'b -> option 'b -> 'a) -> 'a -> list 'b -> 'a
   val persistent ~fold-indexed-adjacent 'a 'b : ('a -> int -> 'b -> option 'b -> option 'b -> 'a) -> 'a -> list 'b -> 'a
   val persistent ~reverse 'a : list 'a -> list 'a
@@ -61,10 +61,10 @@ end = struct
     | _                      -> false
     end
 
-  val persistent ~rec fold f init ys =
+  val persistent ~rec fold f acc ys =
     match ys with
-    | []      -> init
-    | x :: xs -> fold f (f init x) xs
+    | []      -> acc
+    | x :: xs -> fold f (f acc x) xs
     end
 
   val persistent ~fold-indexed f =
@@ -76,21 +76,21 @@ end = struct
     in
     aux 0 f
 
-  val persistent ~rec fold-back f init ys =
+  val persistent ~rec fold-back f ys acc =
     match ys with
-    | []      -> init
-    | x :: xs -> f x (fold-back f init xs)
+    | []      -> acc
+    | x :: xs -> f x (fold-back f xs acc)
     end
 
   val persistent ~fold-adjacent f =
-    let rec aux left-opt acc xs =
+    let rec aux prev-opt acc xs =
       match xs with
       | [] ->
           acc
       | head :: [] ->
-          f acc head left-opt None
+          f acc head prev-opt None
       | head :: ((right :: _) as tail) ->
-          let acc-new = f acc head left-opt (Some(right)) in
+          let acc-new = f acc head prev-opt (Some(right)) in
           aux (Some(head)) acc-new tail
       end
     in
@@ -98,8 +98,8 @@ end = struct
 
   val persistent ~fold-indexed-adjacent f init xs =
     let (_, acc) =
-      xs |> fold-adjacent (fun (i, acc) x left-opt right-opt -> (
-        (i + 1, f acc i x left-opt right-opt)
+      xs |> fold-adjacent (fun (i, acc) x prev-opt next-opt -> (
+        (i + 1, f acc i x prev-opt next-opt)
       )) (0, init)
     in
     acc
@@ -123,19 +123,19 @@ end = struct
     aux 0 f
 
   val persistent ~map-adjacent f xs =
-    xs |> fold-adjacent (fun acc x left-opt right-opt -> (
-      f x left-opt right-opt :: acc
+    xs |> fold-adjacent (fun acc x prev-opt next-opt -> (
+      f x prev-opt next-opt :: acc
     )) [] |> reverse
 
   val persistent ~map-indexed-adjacent f xs =
-    xs |> fold-indexed-adjacent (fun acc i x left-opt right-opt -> (
-      f i x left-opt right-opt :: acc
+    xs |> fold-indexed-adjacent (fun acc i x prev-opt next-opt -> (
+      f i x prev-opt next-opt :: acc
     )) [] |> reverse
 
   val persistent ~map-with-ends f xs =
-    fold-adjacent (fun acc x prev next -> (
-      let is-first = Option.is-none prev in
-      let is-last = Option.is-none next in
+    fold-adjacent (fun acc x prev-opt next-opt -> (
+      let is-first = Option.is-none prev-opt in
+      let is-last = Option.is-none next-opt in
       let y = f is-first is-last x in
       y :: acc
     )) [] xs |> reverse
@@ -147,7 +147,7 @@ end = struct
     end
 
   val persistent ~concat xs =
-    fold-back append [] xs
+    fold-back append xs []
 
   val persistent ~pure x =
     [x]
@@ -194,7 +194,7 @@ end = struct
     end
 
   val persistent ~length xs =
-    fold-back (fun _ i -> i + 1) 0 xs
+    fold (fun i _ -> i + 1) 0 xs
 
   val persistent ~nth lst =
     let rec aux i n xs =

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/list.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/list.satyg
@@ -5,26 +5,29 @@ module List :> sig
   type t 'a = list 'a
   val persistent ~compare 'a : ('a -> 'a -> ordering) -> list 'a -> list 'a -> ordering
   val persistent ~equal 'a : ('a -> 'a -> bool) -> list 'a -> list 'a -> bool
-  val persistent ~map 'a 'b : ('a -> 'b) -> list 'a -> list 'b
-  val persistent ~map-indexed 'a 'b : (int -> 'a -> 'b) -> list 'a -> list 'b
-  val persistent ~iter 'a : ('a -> unit) -> list 'a -> unit
-  val persistent ~iter-indexed 'a : (int -> 'a -> unit) -> list 'a -> unit
   val persistent ~fold 'a 'b : ('a -> 'b -> 'a) -> 'a -> list 'b -> 'a
   val persistent ~fold-indexed 'a 'b : ('a -> int -> 'b -> 'a) -> 'a -> list 'b -> 'a
   val persistent ~fold-back 'a 'b : ('a -> 'b -> 'b) -> 'b -> list 'a -> 'b
-  val persistent ~filter 'a : ('a -> bool) -> list 'a -> list 'a
-  val persistent ~assoc 'a 'b : ('a -> 'a -> bool) -> 'a -> list ('a * 'b) -> option 'b
-  val persistent ~reverse 'a : list 'a -> list 'a
-  val persistent ~append 'a : list 'a -> list 'a -> list 'a
-  val persistent ~concat 'a : list (list 'a) -> list 'a
   val persistent ~fold-adjacent 'a 'b : ('a -> 'b -> option 'b -> option 'b -> 'a) -> 'a -> list 'b -> 'a
   val persistent ~fold-indexed-adjacent 'a 'b : ('a -> int -> 'b -> option 'b -> option 'b -> 'a) -> 'a -> list 'b -> 'a
+  val persistent ~reverse 'a : list 'a -> list 'a
+  val persistent ~map 'a 'b : ('a -> 'b) -> list 'a -> list 'b
+  val persistent ~map-indexed 'a 'b : (int -> 'a -> 'b) -> list 'a -> list 'b
   val persistent ~map-adjacent 'a 'b : ('a -> option 'a -> option 'a -> 'b) -> list 'a -> list 'b
   val persistent ~map-indexed-adjacent 'a 'b : (int -> 'a -> option 'a -> option 'a -> 'b) -> list 'a -> list 'b
+  val persistent ~map-with-ends 'a 'b : (bool -> bool -> 'a -> 'b) -> list 'a -> list 'b
+  val persistent ~append 'a : list 'a -> list 'a -> list 'a
+  val persistent ~concat 'a : list (list 'a) -> list 'a
+  val persistent ~pure 'a : 'a -> list 'a
+  val persistent ~bind 'a 'b : list 'a -> ('a -> list 'b) -> list 'b
+  val persistent ~iter 'a : ('a -> unit) -> list 'a -> unit
+  val persistent ~iter-indexed 'a : (int -> 'a -> unit) -> list 'a -> unit
+  val persistent ~filter 'a : ('a -> bool) -> list 'a -> list 'a
+  val persistent ~filter-map 'a 'b : ('a -> option 'b) -> list 'a -> list 'b
+  val persistent ~assoc 'a 'b : ('a -> 'a -> bool) -> 'a -> list ('a * 'b) -> option 'b
   val persistent ~length 'a : list 'a -> int
   val persistent ~nth 'a : int -> list 'a -> option 'a
   val persistent ~is-empty 'a : list 'a -> bool
-  val persistent ~map-with-ends 'a 'b : (bool -> bool -> 'a -> 'b) -> list 'a -> list 'b
 end = struct
 
   type t 'a = list 'a
@@ -51,36 +54,6 @@ end = struct
     | _                      -> false
     end
 
-  val persistent ~rec map f ys =
-    match ys with
-    | []      -> []
-    | x :: xs -> (f x) :: map f xs
-    end
-
-  val persistent ~map-indexed f =
-    let rec aux i f ys =
-      match ys with
-      | []      -> []
-      | x :: xs -> (f i x) :: aux (i + 1) f xs
-      end
-    in
-    aux 0 f
-
-  val persistent ~rec iter f ys =
-    match ys with
-    | []      -> ()
-    | x :: xs -> let () = f x in iter f xs
-    end
-
-  val persistent ~iter-indexed f =
-    let rec aux i f ys =
-      match ys with
-      | []      -> ()
-      | x :: xs -> let () = f i x in aux (i + 1) f xs
-      end
-    in
-    aux 0 f
-
   val persistent ~rec fold f init ys =
     match ys with
     | []      -> init
@@ -101,30 +74,6 @@ end = struct
     | []      -> init
     | x :: xs -> f x (fold-back f init xs)
     end
-
-  val persistent ~rec filter p ys =
-    match ys with
-    | []      -> []
-    | x :: xs -> if p x then x :: filter p xs else filter p xs
-    end
-
-  val persistent ~rec assoc eq a ys =
-    match ys with
-    | []           -> None
-    | (x, y) :: xs -> if eq a x then Some(y) else assoc eq a xs
-    end
-
-  val persistent ~reverse xs =
-    fold (fun acc x -> x :: acc) [] xs
-
-  val persistent ~rec append xs1 xs2 =
-    match xs1 with
-    | []      -> xs2
-    | x :: xs -> x :: append xs xs2
-    end
-
-  val persistent ~concat xs =
-    fold-back append [] xs
 
   val persistent ~fold-adjacent f =
     let rec aux left-opt acc xs =
@@ -148,6 +97,24 @@ end = struct
     in
     acc
 
+  val persistent ~reverse xs =
+    fold (fun acc x -> x :: acc) [] xs
+
+  val persistent ~rec map f ys =
+    match ys with
+    | []      -> []
+    | x :: xs -> (f x) :: map f xs
+    end
+
+  val persistent ~map-indexed f =
+    let rec aux i f ys =
+      match ys with
+      | []      -> []
+      | x :: xs -> (f i x) :: aux (i + 1) f xs
+      end
+    in
+    aux 0 f
+
   val persistent ~map-adjacent f xs =
     xs |> fold-adjacent (fun acc x left-opt right-opt -> (
       f x left-opt right-opt :: acc
@@ -157,6 +124,67 @@ end = struct
     xs |> fold-indexed-adjacent (fun acc i x left-opt right-opt -> (
       f i x left-opt right-opt :: acc
     )) [] |> reverse
+
+  val persistent ~map-with-ends f xs =
+    fold-adjacent (fun acc x prev next -> (
+      let is-first = Option.is-none prev in
+      let is-last = Option.is-none next in
+      let y = f is-first is-last x in
+      y :: acc
+    )) [] xs |> reverse
+
+  val persistent ~rec append xs1 xs2 =
+    match xs1 with
+    | []      -> xs2
+    | x :: xs -> x :: append xs xs2
+    end
+
+  val persistent ~concat xs =
+    fold-back append [] xs
+
+  val persistent ~pure x =
+    [x]
+
+  val persistent ~bind xs f =
+    concat (map f xs)
+
+  val persistent ~rec iter f ys =
+    match ys with
+    | []      -> ()
+    | x :: xs -> let () = f x in iter f xs
+    end
+
+  val persistent ~iter-indexed f =
+    let rec aux i f ys =
+      match ys with
+      | []      -> ()
+      | x :: xs -> let () = f i x in aux (i + 1) f xs
+      end
+    in
+    aux 0 f
+
+  val persistent ~rec filter p ys =
+    match ys with
+    | []      -> []
+    | x :: xs -> if p x then x :: filter p xs else filter p xs
+    end
+
+  val persistent ~rec filter-map f ys =
+    match ys with
+    | [] ->
+        []
+    | x :: xs ->
+        match f x with
+        | None    -> filter-map f xs
+        | Some(v) -> v :: filter-map f xs
+        end
+    end
+
+  val persistent ~rec assoc eq a ys =
+    match ys with
+    | []           -> None
+    | (x, y) :: xs -> if eq a x then Some(y) else assoc eq a xs
+    end
 
   val persistent ~length xs =
     fold-back (fun _ i -> i + 1) 0 xs
@@ -170,20 +198,10 @@ end = struct
     in
     aux 0 lst
 
-
   val persistent ~is-empty xs =
     match xs with
     | []     -> true
     | _ :: _ -> false
     end
-
-
-  val persistent ~map-with-ends f xs =
-    fold-adjacent (fun acc x prev next -> (
-      let is-first = Option.is-none prev in
-      let is-last = Option.is-none next in
-      let y = f is-first is-last x in
-      y :: acc
-    )) [] xs |> reverse
 
 end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/list.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/list.satyg
@@ -1,6 +1,10 @@
+use open Basic
 use Option
 
 module List :> sig
+  type t 'a = list 'a
+  val persistent ~compare 'a : ('a -> 'a -> ordering) -> list 'a -> list 'a -> ordering
+  val persistent ~equal 'a : ('a -> 'a -> bool) -> list 'a -> list 'a -> bool
   val persistent ~map 'a 'b : ('a -> 'b) -> list 'a -> list 'b
   val persistent ~map-indexed 'a 'b : (int -> 'a -> 'b) -> list 'a -> list 'b
   val persistent ~iter 'a : ('a -> unit) -> list 'a -> unit
@@ -23,139 +27,163 @@ module List :> sig
   val persistent ~map-with-ends 'a 'b : (bool -> bool -> 'a -> 'b) -> list 'a -> list 'b
 end = struct
 
-    val persistent ~rec map f ys =
+  type t 'a = list 'a
+
+  val persistent ~rec compare comp xs1 xs2 =
+    match (xs1, xs2) with
+    | ([], []) ->
+        Equal
+    | (x1 :: ys1, x2 :: ys2) ->
+        match comp x1 x2 with
+        | Equal -> compare comp ys1 ys2
+        | other -> other
+        end
+    | ([], _ :: _) ->
+        Less
+    | (_ :: _, []) ->
+        Greater
+    end
+
+  val persistent ~rec equal eq xs1 xs2 =
+    match (xs1, xs2) with
+    | ([], [])               -> true
+    | (x1 :: ys1, x2 :: ys2) -> if eq x1 x2 then equal eq ys1 ys2 else false
+    | _                      -> false
+    end
+
+  val persistent ~rec map f ys =
+    match ys with
+    | []      -> []
+    | x :: xs -> (f x) :: map f xs
+    end
+
+  val persistent ~map-indexed f =
+    let rec aux i f ys =
       match ys with
       | []      -> []
-      | x :: xs -> (f x) :: map f xs
+      | x :: xs -> (f i x) :: aux (i + 1) f xs
       end
+    in
+    aux 0 f
 
-    val persistent ~map-indexed f =
-      let rec aux i f ys =
-        match ys with
-        | []      -> []
-        | x :: xs -> (f i x) :: aux (i + 1) f xs
-        end
-      in
-      aux 0 f
+  val persistent ~rec iter f ys =
+    match ys with
+    | []      -> ()
+    | x :: xs -> let () = f x in iter f xs
+    end
 
-    val persistent ~rec iter f ys =
+  val persistent ~iter-indexed f =
+    let rec aux i f ys =
       match ys with
       | []      -> ()
-      | x :: xs -> let () = f x in iter f xs
+      | x :: xs -> let () = f i x in aux (i + 1) f xs
       end
+    in
+    aux 0 f
 
-    val persistent ~iter-indexed f =
-      let rec aux i f ys =
-        match ys with
-        | []      -> ()
-        | x :: xs -> let () = f i x in aux (i + 1) f xs
-        end
-      in
-      aux 0 f
+  val persistent ~rec fold f init ys =
+    match ys with
+    | []      -> init
+    | x :: xs -> fold f (f init x) xs
+    end
 
-    val persistent ~rec fold f init ys =
+  val persistent ~fold-indexed f =
+    let rec aux i f acc ys =
       match ys with
-      | []      -> init
-      | x :: xs -> fold f (f init x) xs
+      | []      -> acc
+      | x :: xs -> aux (i + 1) f (f acc i x) xs
       end
+    in
+    aux 0 f
 
-    val persistent ~fold-indexed f =
-      let rec aux i f acc ys =
-        match ys with
-        | []      -> acc
-        | x :: xs -> aux (i + 1) f (f acc i x) xs
-        end
-      in
-      aux 0 f
+  val persistent ~rec fold-back f init ys =
+    match ys with
+    | []      -> init
+    | x :: xs -> f x (fold-back f init xs)
+    end
 
-    val persistent ~rec fold-back f init ys =
-      match ys with
-      | []      -> init
-      | x :: xs -> f x (fold-back f init xs)
-      end
+  val persistent ~rec filter p ys =
+    match ys with
+    | []      -> []
+    | x :: xs -> if p x then x :: filter p xs else filter p xs
+    end
 
-    val persistent ~rec filter p ys =
-      match ys with
-      | []      -> []
-      | x :: xs -> if p x then x :: filter p xs else filter p xs
-      end
+  val persistent ~rec assoc eq a ys =
+    match ys with
+    | []           -> None
+    | (x, y) :: xs -> if eq a x then Some(y) else assoc eq a xs
+    end
 
-    val persistent ~rec assoc eq a ys =
-      match ys with
-      | []           -> None
-      | (x, y) :: xs -> if eq a x then Some(y) else assoc eq a xs
-      end
+  val persistent ~reverse xs =
+    fold (fun acc x -> x :: acc) [] xs
 
-    val persistent ~reverse xs =
-      fold (fun acc x -> x :: acc) [] xs
+  val persistent ~rec append xs1 xs2 =
+    match xs1 with
+    | []      -> xs2
+    | x :: xs -> x :: append xs xs2
+    end
 
-    val persistent ~rec append xs1 xs2 =
-      match xs1 with
-      | []      -> xs2
-      | x :: xs -> x :: append xs xs2
-      end
+  val persistent ~concat xs =
+    fold-back append [] xs
 
-    val persistent ~concat xs =
-      fold-back append [] xs
-
-    val persistent ~fold-adjacent f =
-      let rec aux left-opt acc xs =
-        match xs with
-        | [] ->
-            acc
-        | head :: [] ->
-            f acc head left-opt None
-        | head :: ((right :: _) as tail) ->
-            let acc-new = f acc head left-opt (Some(right)) in
-            aux (Some(head)) acc-new tail
-        end
-      in
-      aux None
-
-    val persistent ~fold-indexed-adjacent f init xs =
-      let (_, acc) =
-        xs |> fold-adjacent (fun (i, acc) x left-opt right-opt -> (
-          (i + 1, f acc i x left-opt right-opt)
-        )) (0, init)
-      in
-      acc
-
-    val persistent ~map-adjacent f xs =
-      xs |> fold-adjacent (fun acc x left-opt right-opt -> (
-        f x left-opt right-opt :: acc
-      )) [] |> reverse
-
-    val persistent ~map-indexed-adjacent f xs =
-      xs |> fold-indexed-adjacent (fun acc i x left-opt right-opt -> (
-        f i x left-opt right-opt :: acc
-      )) [] |> reverse
-
-    val persistent ~length xs =
-      fold-back (fun _ i -> i + 1) 0 xs
-
-    val persistent ~nth lst =
-      let rec aux i n xs =
-        match xs with
-        | []           -> None
-        | head :: tail -> if n == i then Some(head) else aux (i + 1) n tail
-        end
-      in
-      aux 0 lst
-
-
-    val persistent ~is-empty xs =
+  val persistent ~fold-adjacent f =
+    let rec aux left-opt acc xs =
       match xs with
-      | []     -> true
-      | _ :: _ -> false
+      | [] ->
+          acc
+      | head :: [] ->
+          f acc head left-opt None
+      | head :: ((right :: _) as tail) ->
+          let acc-new = f acc head left-opt (Some(right)) in
+          aux (Some(head)) acc-new tail
       end
+    in
+    aux None
+
+  val persistent ~fold-indexed-adjacent f init xs =
+    let (_, acc) =
+      xs |> fold-adjacent (fun (i, acc) x left-opt right-opt -> (
+        (i + 1, f acc i x left-opt right-opt)
+      )) (0, init)
+    in
+    acc
+
+  val persistent ~map-adjacent f xs =
+    xs |> fold-adjacent (fun acc x left-opt right-opt -> (
+      f x left-opt right-opt :: acc
+    )) [] |> reverse
+
+  val persistent ~map-indexed-adjacent f xs =
+    xs |> fold-indexed-adjacent (fun acc i x left-opt right-opt -> (
+      f i x left-opt right-opt :: acc
+    )) [] |> reverse
+
+  val persistent ~length xs =
+    fold-back (fun _ i -> i + 1) 0 xs
+
+  val persistent ~nth lst =
+    let rec aux i n xs =
+      match xs with
+      | []           -> None
+      | head :: tail -> if n == i then Some(head) else aux (i + 1) n tail
+      end
+    in
+    aux 0 lst
 
 
-    val persistent ~map-with-ends f xs =
-      fold-adjacent (fun acc x prev next -> (
-        let is-first = Option.is-none prev in
-        let is-last = Option.is-none next in
-        let y = f is-first is-last x in
-        y :: acc
-      )) [] xs |> reverse
+  val persistent ~is-empty xs =
+    match xs with
+    | []     -> true
+    | _ :: _ -> false
+    end
 
-  end
+
+  val persistent ~map-with-ends f xs =
+    fold-adjacent (fun acc x prev next -> (
+      let is-first = Option.is-none prev in
+      let is-last = Option.is-none next in
+      let y = f is-first is-last x in
+      y :: acc
+    )) [] xs |> reverse
+
+end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/list.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/list.satyg
@@ -2,20 +2,21 @@ use Option
 
 module List :> sig
   val persistent ~map 'a 'b : ('a -> 'b) -> list 'a -> list 'b
-  val persistent ~mapi 'a 'b : (int -> 'a -> 'b) -> list 'a -> list 'b
+  val persistent ~map-indexed 'a 'b : (int -> 'a -> 'b) -> list 'a -> list 'b
   val persistent ~iter 'a : ('a -> unit) -> list 'a -> unit
-  val persistent ~iteri 'a : (int -> 'a -> unit) -> list 'a -> unit
-  val persistent ~fold-left 'a 'b : ('a -> 'b -> 'a) -> 'a -> list 'b -> 'a
-  val persistent ~fold-lefti 'a 'b : (int -> 'a -> 'b -> 'a) -> 'a -> list 'b -> 'a
-  val persistent ~fold-right 'a 'b : ('a -> 'b -> 'b) -> 'b -> list 'a -> 'b
+  val persistent ~iter-indexed 'a : (int -> 'a -> unit) -> list 'a -> unit
+  val persistent ~fold 'a 'b : ('a -> 'b -> 'a) -> 'a -> list 'b -> 'a
+  val persistent ~fold-indexed 'a 'b : ('a -> int -> 'b -> 'a) -> 'a -> list 'b -> 'a
+  val persistent ~fold-back 'a 'b : ('a -> 'b -> 'b) -> 'b -> list 'a -> 'b
   val persistent ~filter 'a : ('a -> bool) -> list 'a -> list 'a
   val persistent ~assoc 'a 'b : ('a -> 'a -> bool) -> 'a -> list ('a * 'b) -> option 'b
   val persistent ~reverse 'a : list 'a -> list 'a
   val persistent ~append 'a : list 'a -> list 'a -> list 'a
   val persistent ~concat 'a : list (list 'a) -> list 'a
-  val persistent ~fold-left-adjacent 'a 'b : ('a -> 'b -> option 'b -> option 'b -> 'a) -> 'a -> list 'b -> 'a
+  val persistent ~fold-adjacent 'a 'b : ('a -> 'b -> option 'b -> option 'b -> 'a) -> 'a -> list 'b -> 'a
+  val persistent ~fold-indexed-adjacent 'a 'b : ('a -> int -> 'b -> option 'b -> option 'b -> 'a) -> 'a -> list 'b -> 'a
   val persistent ~map-adjacent 'a 'b : ('a -> option 'a -> option 'a -> 'b) -> list 'a -> list 'b
-  val persistent ~mapi-adjacent 'a 'b : (int -> 'a -> option 'a -> option 'a -> 'b) -> list 'a -> list 'b
+  val persistent ~map-indexed-adjacent 'a 'b : (int -> 'a -> option 'a -> option 'a -> 'b) -> list 'a -> list 'b
   val persistent ~length 'a : list 'a -> int
   val persistent ~nth 'a : int -> list 'a -> option 'a
   val persistent ~is-empty 'a : list 'a -> bool
@@ -28,8 +29,7 @@ end = struct
       | x :: xs -> (f x) :: map f xs
       end
 
-
-    val persistent ~mapi f =
+    val persistent ~map-indexed f =
       let rec aux i f ys =
         match ys with
         | []      -> []
@@ -38,15 +38,13 @@ end = struct
       in
       aux 0 f
 
-
     val persistent ~rec iter f ys =
       match ys with
       | []      -> ()
       | x :: xs -> let () = f x in iter f xs
       end
 
-
-    val persistent ~iteri f =
+    val persistent ~iter-indexed f =
       let rec aux i f ys =
         match ys with
         | []      -> ()
@@ -55,30 +53,26 @@ end = struct
       in
       aux 0 f
 
-
-    val persistent ~rec fold-left f init ys =
+    val persistent ~rec fold f init ys =
       match ys with
       | []      -> init
-      | x :: xs -> fold-left f (f init x) xs
+      | x :: xs -> fold f (f init x) xs
       end
 
-
-    val persistent ~fold-lefti f =
-      let rec aux i f init ys =
+    val persistent ~fold-indexed f =
+      let rec aux i f acc ys =
         match ys with
-        | []      -> init
-        | x :: xs -> aux (i + 1) f (f i init x) xs
+        | []      -> acc
+        | x :: xs -> aux (i + 1) f (f acc i x) xs
         end
       in
       aux 0 f
 
-
-    val persistent ~rec fold-right f init ys =
+    val persistent ~rec fold-back f init ys =
       match ys with
       | []      -> init
-      | x :: xs -> f x (fold-right f init xs)
+      | x :: xs -> f x (fold-back f init xs)
       end
-
 
     val persistent ~rec filter p ys =
       match ys with
@@ -86,64 +80,58 @@ end = struct
       | x :: xs -> if p x then x :: filter p xs else filter p xs
       end
 
-
     val persistent ~rec assoc eq a ys =
       match ys with
       | []           -> None
       | (x, y) :: xs -> if eq a x then Some(y) else assoc eq a xs
       end
 
+    val persistent ~reverse xs =
+      fold (fun acc x -> x :: acc) [] xs
 
-    val persistent ~reverse lst =
-      fold-left (fun acc x -> x :: acc) [] lst
-
-
-    val persistent ~rec append lst1 lst2 =
-      match lst1 with
-      | []      -> lst2
-      | x :: xs -> x :: append xs lst2
+    val persistent ~rec append xs1 xs2 =
+      match xs1 with
+      | []      -> xs2
+      | x :: xs -> x :: append xs xs2
       end
 
+    val persistent ~concat xs =
+      fold-back append [] xs
 
-    val persistent ~concat lst = fold-right append [] lst
-
-
-    val persistent ~fold-left-adjacent f =
-      let rec aux leftopt init lst =
-        match lst with
+    val persistent ~fold-adjacent f =
+      let rec aux left-opt acc xs =
+        match xs with
         | [] ->
-            init
-
+            acc
         | head :: [] ->
-            let initnew = f init head leftopt None in
-            initnew
-
+            f acc head left-opt None
         | head :: ((right :: _) as tail) ->
-            let initnew = f init head leftopt (Some(right)) in
-            aux (Some(head)) initnew tail
+            let acc-new = f acc head left-opt (Some(right)) in
+            aux (Some(head)) acc-new tail
         end
       in
       aux None
 
-
-    val persistent ~map-adjacent f lst =
-        lst |> fold-left-adjacent (fun acc x leftopt rightopt -> (
-          f x leftopt rightopt :: acc
-        )) [] |> reverse
-
-
-    val persistent ~mapi-adjacent f lst =
+    val persistent ~fold-indexed-adjacent f init xs =
       let (_, acc) =
-        lst |> fold-left-adjacent (fun (i, acc) x leftopt rightopt -> (
-          (i + 1, f i x leftopt rightopt :: acc)
-        )) (0, [])
+        xs |> fold-adjacent (fun (i, acc) x left-opt right-opt -> (
+          (i + 1, f acc i x left-opt right-opt)
+        )) (0, init)
       in
-        reverse acc
+      acc
 
+    val persistent ~map-adjacent f xs =
+      xs |> fold-adjacent (fun acc x left-opt right-opt -> (
+        f x left-opt right-opt :: acc
+      )) [] |> reverse
 
-    val persistent ~length lst =
-      fold-right (fun _ i -> i + 1) 0 lst
+    val persistent ~map-indexed-adjacent f xs =
+      xs |> fold-indexed-adjacent (fun acc i x left-opt right-opt -> (
+        f i x left-opt right-opt :: acc
+      )) [] |> reverse
 
+    val persistent ~length xs =
+      fold-back (fun _ i -> i + 1) 0 xs
 
     val persistent ~nth lst =
       let rec aux i n xs =
@@ -163,7 +151,7 @@ end = struct
 
 
     val persistent ~map-with-ends f xs =
-      fold-left-adjacent (fun acc x prev next -> (
+      fold-adjacent (fun acc x prev next -> (
         let is-first = Option.is-none prev in
         let is-last = Option.is-none next in
         let y = f is-first is-last x in

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/list.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/list.satyg
@@ -3,6 +3,7 @@ use Option
 
 module List :> sig
   type t 'a = list 'a
+  val ~lift 'a : ('a -> code 'a) -> list 'a -> code (list 'a)
   val persistent ~compare 'a : ('a -> 'a -> ordering) -> list 'a -> list 'a -> ordering
   val persistent ~equal 'a : ('a -> 'a -> bool) -> list 'a -> list 'a -> bool
   val persistent ~fold 'a 'b : ('a -> 'b -> 'a) -> 'a -> list 'b -> 'a
@@ -31,6 +32,12 @@ module List :> sig
 end = struct
 
   type t 'a = list 'a
+
+  val ~rec lift lf xs =
+    match xs with
+    | []      -> &[]
+    | x :: xs -> &(~(lf x) :: ~(lift lf xs))
+    end
 
   val persistent ~rec compare comp xs1 xs2 =
     match (xs1, xs2) with

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/logo.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/logo.satyh
@@ -1,0 +1,45 @@
+use open Pervasives
+
+module Logo :> sig
+  val \SATySFi : inline []
+  val \LaTeX : inline []
+  val \TeX : inline []
+end = struct
+
+  val inline ctx \SATySFi =
+    let size = get-font-size ctx in
+    let f = read-inline ctx in
+    let fd = ctx |> set-manual-rising (0pt -' (size *' 0.25)) |> read-inline in
+    let ib =
+      f {SAT} ++ kern (size *' 0.15) ++ fd {Y} ++ f {SF} ++ kern (size *' 0.05) ++ fd {I}
+    in
+    script-guard Latin (no-break ib)
+
+  val inline ctx \LaTeX =
+    let size = get-font-size ctx in
+    let f = read-inline ctx in
+    let fA = ctx |> set-font-size (size *' 0.7)
+                 |> set-manual-rising (size *' 0.2)
+                 |> read-inline
+    in
+    let fE = ctx |> set-manual-rising (0pt -' (size *' 0.25))
+                 |> read-inline
+    in
+    let ib =
+      f {L} ++ kern (size *' 0.2) ++ fA {A}
+        ++ f {T} ++ kern (size *' 0.125) ++ fE {E} ++ f {X}
+    in
+    script-guard Latin (no-break ib)
+
+  val inline ctx \TeX =
+    let size = get-font-size ctx in
+    let f = read-inline ctx in
+    let fE = ctx |> set-manual-rising (0pt -' (size *' 0.25))
+                 |> read-inline
+    in
+    let ib =
+      f {T} ++ kern (size *' 0.125) ++ fE {E} ++ f {X}
+    in
+    script-guard Latin (no-break ib)
+
+end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/logo.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/logo.satyh
@@ -1,4 +1,4 @@
-use open Pervasives
+use open Inline
 
 module Logo :> sig
   val \SATySFi : inline []

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
@@ -169,28 +169,89 @@ module Map
         match map with
         | Empty ->
             (true, singleton k v)
-        | Node(r) ->
-            match Key.compare k r#key with
+        | Node(n) ->
+            match Key.compare k n#key with
             | Equal ->
-                (false, Node(| r with data = v |))
+                (false, Node(| n with data = v |))
             | Less ->
-                let (enlarged, left-new) = aux r#left in
+                let (enlarged, left-new) = aux n#left in
                 if enlarged then
-                  (true, rebalance left-new r#key r#data r#right)
+                  (true, rebalance left-new n#key n#data n#right)
                 else
-                  (false, Node(| r with left = left-new |))
+                  (false, Node(| n with left = left-new |))
             | Greater ->
-                let (enlarged, right-new) = aux r#right in
+                let (enlarged, right-new) = aux n#right in
                 if enlarged then
-                  (true, rebalance r#left r#key r#data right-new)
+                  (true, rebalance n#left n#key n#data right-new)
                 else
-                  (false, Node(| r with right = right-new |))
+                  (false, Node(| n with right = right-new |))
             end
         end
       in
       (fun map -> (
         let (_, map-new) = aux map in
         map-new
+      ))
+
+    val trim-minimum =
+      let rec aux n =
+        match n#left with
+        | Empty ->
+            ((n#key, n#data), n#right)
+            % Since `n` is balanced,
+            % `n#right` has 0 or 1 node.
+        | Node(nL) ->
+            let (kv-min, tL) = aux nL in
+            (kv-min, rebalance tL n#key n#data n#right)
+        end
+      in
+      (fun t -> (
+        match t with
+        | Empty   -> None
+        | Node(n) -> Some(aux n)
+        end
+      ))
+
+    % Merges two trees `t1` and `t2`,
+    % where the maximum key in `t1` is less than the minimum key in `t2`
+    % and the difference of height between `t1` and `t2` is less than 2.
+    val merge-separated t1 t2 =
+      match trim-minimum t2 with
+      | None                       -> t1
+      | Some(((k, v), t2-removed)) -> rebalance t1 k v t2-removed
+      end
+
+    val remove k =
+      let rec aux map =
+        match map with
+        | Empty ->
+            None
+        | Node(n) ->
+            match Key.compare k n#key with
+            | Equal ->
+                Some(merge-separated n#left n#right)
+            | Less ->
+                match aux n#left with
+                | None ->
+                    None
+                | Some(left-new) ->
+                    Some(rebalance left-new n#key n#data n#right)
+                end
+            | Greater ->
+                match aux n#right with
+                | None ->
+                    None
+                | Some(right-new) ->
+                    Some(rebalance n#left n#key n#data right-new)
+                end
+            end
+        end
+      in
+      (fun map -> (
+        match aux map with
+        | None          -> map
+        | Some(map-new) -> map-new
+        end
       ))
 
   end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
@@ -1,0 +1,93 @@
+use open Basic
+use Int
+
+module Map = struct
+
+  module Make = fun(Key : Ord) -> struct
+
+    type t 'a =
+      | Empty
+      | Node of (|
+          key    : Key.t,
+          data   : 'a,
+          left   : t 'a,
+          right  : t 'a,
+          height : int,
+        |)
+
+    val get-height map =
+      match map with
+      | Empty   -> 0
+      | Node(r) -> r#height
+      end
+
+    val empty =
+      Empty
+
+    val singleton k v =
+      Node(|
+        key    = k,
+        data   = v,
+        left   = Empty,
+        right  = Empty,
+        height = 1,
+      |)
+
+    val rebalance left k v right =
+      let left-height = get-height left in
+      let right-height = get-height right in
+      if left-height >= right-height + 2 then
+        match left with
+        | Node(left-node) ->
+            () % TODO: rebalance
+        | Empty ->
+            abort-with-message `Map, rebalance, empty left`
+        end
+      else if left-height + 2 <= right-height then
+        match right with
+        | Node(right-node) ->
+            () % TODO: rebalance
+        | Empty ->
+            abort-with-message `Map, rebalance, empty right`
+        end
+      else
+        Node(|
+          key    = k,
+          data   = v,
+          left   = left,
+          right  = right,
+          height = (Int.max left-height right-height) + 1,
+        |)
+
+    val add k v =
+      let rec aux map =
+        match map with
+        | Empty ->
+            (true, singleton k v)
+        | Node(r) ->
+            match Key.compare k r#key with
+            | Equal ->
+                (false, Node(| r with data = v |))
+            | Less ->
+                let (enlarged, left-new) = aux r#left in
+                if enlarged then
+                  (true, rebalance left-new r#key r#data r#right)
+                else
+                  (false, Node(| r with left = left-new |))
+            | Greater ->
+                let (enlarged, right-new) = aux r#right in
+                if enlarged then
+                  (true, rebalance r#left r#key r#data right-new)
+                else
+                  (false, Node(| r with right = right-new |))
+            end
+        end
+      in
+      (fun map -> (
+        let (_, map-new) = aux map in
+        map-new
+      ))
+
+  end
+
+end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
@@ -1,13 +1,18 @@
 use open Basic
 use Int
+use List
 
 module Map :> sig
   module Make : (Key : Ord) -> sig
     type t :: o -> o
-    val empty 'a : t 'a
-    val singleton 'a : Key.t -> 'a -> t 'a
-    val add 'a : Key.t -> 'a -> t 'a -> t 'a
-    val remove 'a : Key.t -> t 'a -> t 'a
+    val empty 'v : t 'v
+    val singleton 'v : Key.t -> 'v -> t 'v
+    val add 'v : Key.t -> 'v -> t 'v -> t 'v
+    val remove 'v : Key.t -> t 'v -> t 'v
+    val fold 'a 'v : ('a -> Key.t -> 'v -> 'a) -> 'a -> t 'v -> 'a
+    val to-descending-list 'v : t 'v -> list (Key.t * 'v)
+    val to-ascending-list 'v : t 'v -> list (Key.t * 'v)
+    val from-list 'v : list (Key.t * 'v) -> t 'v
   end
 end = struct
 
@@ -252,6 +257,30 @@ end = struct
         | Some(map-new) -> map-new
         end
       ))
+
+    val fold f =
+      let rec aux acc map =
+        match map with
+        | Empty ->
+            acc
+        | Node(n) ->
+            let acc = aux acc n#left in
+            let acc = f acc n#key n#data in
+            let acc = aux acc n#right in
+            acc
+        end
+      in
+      aux
+
+    val to-descending-list map =
+      fold (fun acc k v -> (k, v) :: acc) [] map
+
+    val to-ascending-list map =
+      List.reverse (to-descending-list map)
+
+    % TODO: make this more efficient
+    val from-list kvs =
+      List.fold (fun map (k, v) -> add k v map) empty kvs
 
   end
 

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
@@ -1,16 +1,15 @@
 use open Basic
 use Int
 
-module Map
-%:> sig
-%  module Make : (Key : Ord) -> sig
-%    type t :: o -> o
-%    val empty 'a : t 'a
-%    val singleton 'a : Key.t -> 'a -> t 'a
-%    val add 'a : Key.t -> 'a -> t 'a -> t 'a
-%  end
-%end
-= struct
+module Map :> sig
+  module Make : (Key : Ord) -> sig
+    type t :: o -> o
+    val empty 'a : t 'a
+    val singleton 'a : Key.t -> 'a -> t 'a
+    val add 'a : Key.t -> 'a -> t 'a -> t 'a
+    val remove 'a : Key.t -> t 'a -> t 'a
+  end
+end = struct
 
   module Make = fun(Key : Ord) -> struct
 

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
@@ -33,31 +33,81 @@ module Map = struct
         height = 1,
       |)
 
-    val rebalance left k v right =
-      let left-height = get-height left in
-      let right-height = get-height right in
-      if left-height >= right-height + 2 then
-        match left with
-        | Node(left-node) ->
-            () % TODO: rebalance
+    val build-node tL k v tR =
+      Node(|
+        key = k,
+        data = v,
+        left = tL,
+        right = tR,
+        height = Int.max (get-height tL) (get-height tR) + 1,
+      |)
+
+    %% Rebalances a tree after inserting or removing one element.
+    val rebalance tL k v tR =
+      let hL = get-height tL in
+      let hR = get-height tR in
+      if hL == hR + 2 then
+        match tL with
+        | Node(nL) ->
+            let tLL = nL#left in
+            let tLR = nL#right in
+            let hLL = get-height tLL in
+            let hLR = get-height tLR in
+            if hLL > hLR then
+              %     N             L
+              %    / \           / \
+              %   L   R  ====>  LL  N
+              %  / \  |         |  / \
+              % LL LR |         | LR  R
+              % |   | |         | |   |
+              % |   | #         | |   |
+              % |   |           | |   |
+              % |   o           x o   #
+              % |
+              % x
+              build-node tLL nL#key nL#data (build-node tLR k v tR)
+            else
+              % Actually, we can assume `hLL < hLR` here, although we do not utilize it.
+              % This is because, if `hLL == hLR`,
+              % it means at least two elements were modified in a balanced tree before rebalancing
+              % and thereby contradicts the invariant (i.e., that any use-space maps are balanced).
+              match tLR with
+              | Node(nLR) ->
+                  let tLRL = nLR#left in
+                  let tLRR = nLR#right in
+                  let hLRL = get-height tLRL in
+                  let hLRR = get-height tLRR in
+                  %        N                 LR
+                  %      /   \             /    \
+                  %    L       R  ====>  L        N
+                  %   / \      |        / \      / \
+                  % LL   LR    |      LL  LRL  LRR  R
+                  % |   /  \   |      |    |    |   |
+                  % | LRL  LRR #      |    |    |   |
+                  % |  |    |         |    |    |   |
+                  % |  |    |         |    x    x   #
+                  % |  |    |         |
+                  % y  x    x         y
+                  build-node
+                    (build-node tLL nL#key nL#data tLRL)
+                    nLR#key
+                    nLR#data
+                    (build-node tLRR k v tR)
+              | Empty ->
+                  abort-with-message `Map, rebalance, empty left`
+              end
         | Empty ->
             abort-with-message `Map, rebalance, empty left`
         end
-      else if left-height + 2 <= right-height then
-        match right with
-        | Node(right-node) ->
+      else if hL + 2 == hR then
+        match tR with
+        | Node(nR) ->
             () % TODO: rebalance
         | Empty ->
             abort-with-message `Map, rebalance, empty right`
         end
       else
-        Node(|
-          key    = k,
-          data   = v,
-          left   = left,
-          right  = right,
-          height = (Int.max left-height right-height) + 1,
-        |)
+        build-node tL k v tR
 
     val add k v =
       let rec aux map =

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
@@ -9,9 +9,13 @@ module Map :> sig
     val singleton 'v : Key.t -> 'v -> t 'v
     val add 'v : Key.t -> 'v -> t 'v -> t 'v
     val remove 'v : Key.t -> t 'v -> t 'v
+    val find 'v : Key.t -> t 'v -> option 'v
+    val map-with-key 'u 'v : (Key.t -> 'u -> 'v) -> t 'u -> t 'v
+    val map 'u 'v : ('u -> 'v) -> t 'u -> t 'v
     val fold 'a 'v : ('a -> Key.t -> 'v -> 'a) -> 'a -> t 'v -> 'a
-    val to-descending-list 'v : t 'v -> list (Key.t * 'v)
-    val to-ascending-list 'v : t 'v -> list (Key.t * 'v)
+    val fold-back 'a 'v : ('a -> Key.t -> 'v -> 'a) -> 'a -> t 'v -> 'a
+    val to-list 'v : t 'v -> list (Key.t * 'v)
+    val to-list-reversed 'v : t 'v -> list (Key.t * 'v)
     val from-list 'v : list (Key.t * 'v) -> t 'v
   end
 end = struct
@@ -28,8 +32,8 @@ end = struct
           height : int,
         |)
 
-    val get-height map =
-      match map with
+    val get-height mp =
+      match mp with
       | Empty   -> 0
       | Node(r) -> r#height
       end
@@ -141,7 +145,7 @@ end = struct
               % and thereby contradicts the invariant (i.e., that any use-space maps are balanced).
               match tRL with
               | Empty ->
-                  abort-with-message `Map, rebalance, empty left-right`
+                  abort-with-message `Map, rebalance, empty right-left`
               | Node(nRL) ->
                   let tRLL = nRL#left in
                   let tRLR = nRL#right in
@@ -169,8 +173,8 @@ end = struct
         build-node tL k v tR
 
     val add k v =
-      let rec aux map =
-        match map with
+      let rec aux mp =
+        match mp with
         | Empty ->
             (true, singleton k v)
         | Node(n) ->
@@ -192,9 +196,9 @@ end = struct
             end
         end
       in
-      (fun map -> (
-        let (_, map-new) = aux map in
-        map-new
+      (fun mp -> (
+        let (_, mp-new) = aux mp in
+        mp-new
       ))
 
     val trim-minimum =
@@ -226,8 +230,8 @@ end = struct
       end
 
     val remove k =
-      let rec aux map =
-        match map with
+      let rec aux mp =
+        match mp with
         | Empty ->
             None
         | Node(n) ->
@@ -251,16 +255,51 @@ end = struct
             end
         end
       in
-      (fun map -> (
-        match aux map with
-        | None          -> map
-        | Some(map-new) -> map-new
+      (fun mp -> (
+        match aux mp with
+        | None          -> mp
+        | Some(mp-new) -> mp-new
         end
       ))
 
+    val find k =
+      let rec aux mp =
+        match mp with
+        | Empty ->
+            None
+        | Node(n) ->
+            match Key.compare k n#key with
+            | Equal   -> Some(n#data)
+            | Less    -> aux n#left
+            | Greater -> aux n#right
+            end
+        end
+      in
+      aux
+
+    val map-with-key f =
+      let rec aux mp =
+        match mp with
+        | Empty ->
+            Empty
+        | Node(n) ->
+            Node(|
+              key    = n#key,
+              data   = f n#key n#data,
+              left   = aux n#left,
+              right  = aux n#right,
+              height = n#height,
+            |)
+        end
+      in
+      aux
+
+    val map f mp =
+      map-with-key (fun _ -> f) mp
+
     val fold f =
-      let rec aux acc map =
-        match map with
+      let rec aux acc mp =
+        match mp with
         | Empty ->
             acc
         | Node(n) ->
@@ -272,15 +311,29 @@ end = struct
       in
       aux
 
-    val to-descending-list map =
-      fold (fun acc k v -> (k, v) :: acc) [] map
+    val fold-back f =
+      let rec aux acc mp =
+        match mp with
+        | Empty ->
+            acc
+        | Node(n) ->
+            let acc = aux acc n#right in
+            let acc = f acc n#key n#data in
+            let acc = aux acc n#left in
+            acc
+        end
+      in
+      aux
 
-    val to-ascending-list map =
-      List.reverse (to-descending-list map)
+    val to-list mp =
+      fold-back (fun acc k v -> (k, v) :: acc) [] mp
+
+    val to-list-reversed mp =
+      fold (fun acc k v -> (k, v) :: acc) [] mp
 
     % TODO: make this more efficient
     val from-list kvs =
-      List.fold (fun map (k, v) -> add k v map) empty kvs
+      List.fold (fun mp (k, v) -> add k v mp) empty kvs
 
   end
 

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
@@ -1,7 +1,16 @@
 use open Basic
 use Int
 
-module Map = struct
+module Map
+%:> sig
+%  module Make : (Key : Ord) -> sig
+%    type t :: o -> o
+%    val empty 'a : t 'a
+%    val singleton 'a : Key.t -> 'a -> t 'a
+%    val add 'a : Key.t -> 'a -> t 'a -> t 'a
+%  end
+%end
+= struct
 
   module Make = fun(Key : Ord) -> struct
 
@@ -48,6 +57,8 @@ module Map = struct
       let hR = get-height tR in
       if hL == hR + 2 then
         match tL with
+        | Empty ->
+            abort-with-message `Map, rebalance, empty left`
         | Node(nL) ->
             let tLL = nL#left in
             let tLR = nL#right in
@@ -72,6 +83,8 @@ module Map = struct
               % it means at least two elements were modified in a balanced tree before rebalancing
               % and thereby contradicts the invariant (i.e., that any use-space maps are balanced).
               match tLR with
+              | Empty ->
+                  abort-with-message `Map, rebalance, empty left-right`
               | Node(nLR) ->
                   let tLRL = nLR#left in
                   let tLRR = nLR#right in
@@ -93,18 +106,60 @@ module Map = struct
                     nLR#key
                     nLR#data
                     (build-node tLRR k v tR)
-              | Empty ->
-                  abort-with-message `Map, rebalance, empty left`
               end
-        | Empty ->
-            abort-with-message `Map, rebalance, empty left`
         end
       else if hL + 2 == hR then
         match tR with
-        | Node(nR) ->
-            () % TODO: rebalance
         | Empty ->
             abort-with-message `Map, rebalance, empty right`
+        | Node(nR) ->
+            let tRL = nR#left in
+            let tRR = nR#right in
+            let hRL = get-height tRL in
+            let hRR = get-height tRR in
+            if hRL < hRR then
+              %   N             R
+              %  / \           / \
+              % L   R  ====>  N  RR
+              % |  / \       / \  |
+              % | RL RR     L  RL |
+              % | |   |     |   | |
+              % # |   |     |   | |
+              %   |   |     |   | |
+              %   o   |     #   o x
+              %       |
+              %       x
+              build-node (build-node tL k v tRL) nR#key nR#data tRR
+            else
+              % Actually, we can assume `hRL > hRR` here, although we do not utilize it.
+              % This is because, if `hRL == hRR`,
+              % it means at least two elements were modified in a balanced tree before rebalancing
+              % and thereby contradicts the invariant (i.e., that any use-space maps are balanced).
+              match tRL with
+              | Empty ->
+                  abort-with-message `Map, rebalance, empty left-right`
+              | Node(nRL) ->
+                  let tRLL = nRL#left in
+                  let tRLR = nRL#right in
+                  let hRLL = get-height tRLL in
+                  let hRLR = get-height tRLR in
+                  %     N                 RL
+                  %   /   \             /    \
+                  % L       R  ====>  N        R
+                  % |      / \       / \      / \
+                  % |    RL   RR    L  RLL  RLR  RR
+                  % |   /  \   |    |    |    |   |
+                  % # RLL  RLR |    |    |    |   |
+                  %    |    |  |    |    |    |   |
+                  %    |    |  |    #    x    x   |
+                  %    |    |  |                  |
+                  %    x    x  y                  y
+                  build-node
+                    (build-node tL k v tRLL)
+                    nRL#key
+                    nRL#data
+                    (build-node tRLR nR#key nR#data tRR)
+              end
         end
       else
         build-node tL k v tR

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/option.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/option.satyg
@@ -5,8 +5,9 @@ module Option :> sig
   val persistent ~compare 'a : ('a -> 'a -> ordering) -> option 'a -> option 'a -> ordering
   val persistent ~equal 'a : ('a -> 'a -> bool) -> option 'a -> option 'a -> bool
   val persistent ~map 'a 'b : ('a -> 'b) -> option 'a -> option 'b
-  val persistent ~from 'a : 'a -> option 'a -> 'a
+  val persistent ~pure 'a : 'a -> option 'a
   val persistent ~bind 'a 'b : option 'a -> ('a -> option 'b) -> option 'b
+  val persistent ~from 'a : 'a -> option 'a -> 'a
   val persistent ~is-none 'a : option 'a -> bool
 end = struct
 
@@ -33,16 +34,19 @@ end = struct
     | Some(v) -> Some(f v)
     end
 
-  val persistent ~from a opt =
-    match opt with
-    | None    -> a
-    | Some(v) -> v
-    end
+  val persistent ~pure v =
+    Some(v)
 
   val persistent ~bind opt f =
     match opt with
     | None    -> None
     | Some(v) -> f v
+    end
+
+  val persistent ~from a opt =
+    match opt with
+    | None    -> a
+    | Some(v) -> v
     end
 
   val persistent ~is-none opt =

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/option.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/option.satyg
@@ -2,6 +2,7 @@ use open Basic
 
 module Option :> sig
   type t 'a = option 'a
+  val ~lift 'a : ('a -> code 'a) -> option 'a -> code (option 'a)
   val persistent ~compare 'a : ('a -> 'a -> ordering) -> option 'a -> option 'a -> ordering
   val persistent ~equal 'a : ('a -> 'a -> bool) -> option 'a -> option 'a -> bool
   val persistent ~map 'a 'b : ('a -> 'b) -> option 'a -> option 'b
@@ -12,6 +13,12 @@ module Option :> sig
 end = struct
 
   type t 'a = option 'a
+
+  val ~lift lf opt =
+    match opt with
+    | None    -> &(None)
+    | Some(v) -> &(Some(~(lf v)))
+    end
 
   val persistent ~compare comp opt1 opt2 =
     match (opt1, opt2) with

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/option.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/option.satyg
@@ -1,10 +1,31 @@
+use open Basic
 
 module Option :> sig
+  type t 'a = option 'a
+  val persistent ~compare 'a : ('a -> 'a -> ordering) -> option 'a -> option 'a -> ordering
+  val persistent ~equal 'a : ('a -> 'a -> bool) -> option 'a -> option 'a -> bool
   val persistent ~map 'a 'b : ('a -> 'b) -> option 'a -> option 'b
   val persistent ~from 'a : 'a -> option 'a -> 'a
   val persistent ~bind 'a 'b : option 'a -> ('a -> option 'b) -> option 'b
   val persistent ~is-none 'a : option 'a -> bool
 end = struct
+
+  type t 'a = option 'a
+
+  val persistent ~compare comp opt1 opt2 =
+    match (opt1, opt2) with
+    | (None, None)         -> Equal
+    | (None, Some(_))      -> Less
+    | (Some(_), None)      -> Greater
+    | (Some(v1), Some(v2)) -> comp v1 v2
+    end
+
+  val persistent ~equal eq opt1 opt2 =
+    match (opt1, opt2) with
+    | (None, None)         -> true
+    | (Some(v1), Some(v2)) -> eq v1 v2
+    | _                    -> false
+    end
 
   val persistent ~map f opt =
     match opt with
@@ -15,7 +36,7 @@ end = struct
   val persistent ~from a opt =
     match opt with
     | None    -> a
-    | Some(a) -> a
+    | Some(v) -> v
     end
 
   val persistent ~bind opt f =

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/path.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/path.satyh
@@ -1,0 +1,140 @@
+use open Basic
+use Length
+use List
+use Arith
+
+module Path :> sig
+  val rectangle : point -> point -> path
+  val rectangle-round : length -> point -> point -> path
+  val rectangle-round-left : length -> point -> point -> path
+  val rectangle-round-left-lower : length -> point -> point -> path
+  val rectangle-round-left-upper : length -> point -> point -> path
+  val rectangle-round-right : length -> point -> point -> path
+  val poly-line : point -> list point -> path
+  val polygon : point -> list point -> path
+  val line : point -> point -> path
+  val circle : point -> length -> path
+  val linear-transform : float -> float -> float -> float -> path -> path
+  val shift : length * length -> path -> path
+  val rotate : point -> float -> path -> path
+  val scale : point -> float -> float -> path -> path
+end = struct
+
+  val rectangle (x1, y1) (x2, y2) =
+    start-path (x1, y1)
+      |> line-to (x1, y2)
+      |> line-to (x2, y2)
+      |> line-to (x2, y1)
+      |> close-with-line
+
+  val rectangle-round r (xA, yA) (xB, yB) =
+    let t = r *' 0.4 in
+    let x1 = Length.min xA xB in
+    let x2 = Length.max xA xB in
+    let y1 = Length.min yA yB in
+    let y2 = Length.max yA yB in
+    start-path                                 (x1, y1 +' r)
+      |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
+      |> line-to                               (x2 -' r, y1)
+      |> bezier-to (x2 -' t, y1) (x2, y1 +' t) (x2, y1 +' r)
+      |> line-to                               (x2, y2 -' r)
+      |> bezier-to (x2, y2 -' t) (x2 -' t, y2) (x2 -' r, y2)
+      |> line-to                               (x1 +' r, y2)
+      |> bezier-to (x1 +' t, y2) (x1, y2 -' t) (x1, y2 -' r)
+      |> close-with-line
+
+  val rectangle-round-left r (xA, yA) (xB, yB) =
+    let t = r *' 0.4 in
+    let x1 = Length.min xA xB in
+    let x2 = Length.max xA xB in
+    let y1 = Length.min yA yB in
+    let y2 = Length.max yA yB in
+    start-path                                 (x1, y1 +' r)
+      |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
+      |> line-to                               (x2, y1)
+      |> line-to                               (x2, y2)
+      |> line-to                               (x1 +' r, y2)
+      |> bezier-to (x1 +' t, y2) (x1, y2 -' t) (x1, y2 -' r)
+      |> close-with-line
+
+  val rectangle-round-left-lower r (xA, yA) (xB, yB) =
+    let t = r *' 0.4 in
+    let x1 = Length.min xA xB in
+    let x2 = Length.max xA xB in
+    let y1 = Length.min yA yB in
+    let y2 = Length.max yA yB in
+    start-path                                 (x1, y1 +' r)
+      |> bezier-to (x1, y1 +' t) (x1 +' t, y1) (x1 +' r, y1)
+      |> line-to                               (x2, y1)
+      |> line-to                               (x2, y2)
+      |> line-to                               (x1, y2)
+      |> close-with-line
+
+  val rectangle-round-left-upper r (xA, yA) (xB, yB) =
+    let t = r *' 0.4 in
+    let x1 = Length.min xA xB in
+    let x2 = Length.max xA xB in
+    let y1 = Length.min yA yB in
+    let y2 = Length.max yA yB in
+    start-path                                 (x1, y1)
+      |> line-to                               (x2, y1)
+      |> line-to                               (x2, y2)
+      |> line-to                               (x1 +' r, y2)
+      |> bezier-to (x1 +' t, y2) (x1, y2 -' t) (x1, y1 -' t)
+      |> close-with-line
+
+  val rectangle-round-right r (xA, yA) (xB, yB) =
+    let t = r *' 0.4 in
+    let x1 = Length.min xA xB in
+    let x2 = Length.max xA xB in
+    let y1 = Length.min yA yB in
+    let y2 = Length.max yA yB in
+    start-path                                 (x1, y1)
+      |> line-to                               (x2 -' r, y1)
+      |> bezier-to (x2 -' t, y1) (x2, y1 +' t) (x2, y1 +' r)
+      |> line-to                               (x2, y2 -' r)
+      |> bezier-to (x2, y2 -' t) (x2 -' t, y2) (x2 -' r, y2)
+      |> line-to                               (x1, y2)
+      |> close-with-line
+
+  val poly-line pt-init pts =
+    pts |> List.fold (fun acc pt -> (
+      acc |> line-to pt
+    )) (start-path pt-init) |> terminate-path
+
+  val polygon pt-init pts =
+    pts |> List.fold (fun acc pt -> (
+      acc |> line-to pt
+    )) (start-path pt-init) |> close-with-line
+
+  val line pt1 pt2 =
+    start-path pt1 |> line-to pt2 |> terminate-path
+
+  val circle (cx, cy) r =
+    let t = r *' 0.55228 in
+    start-path (cx -' r, cy)
+      |> bezier-to (cx -' r, cy +' t) (cx -' t, cy +' r) (cx, cy +' r)
+      |> bezier-to (cx +' t, cy +' r) (cx +' r, cy +' t) (cx +' r, cy)
+      |> bezier-to (cx +' r, cy -' t) (cx +' t, cy -' r) (cx, cy -' r)
+      |> close-with-bezier (cx -' t, cy -' r) (cx -' r, cy -' t)
+
+  val linear-transform =
+    linear-transform-path
+
+  val shift =
+    shift-path
+
+  val rotate centpt angle path =
+    let (centx, centy) = centpt in
+    let rad = angle *. Arith.pi /. 180. in
+    path |> shift (0pt -' centx, 0pt -' centy)
+         |> linear-transform (cos rad) (0. -. (sin rad)) (sin rad) (cos rad)
+         |> shift centpt
+
+  val scale centpt scalex scaley path =
+    let (centx, centy) = centpt in
+    path |> shift (0pt -' centx, 0pt -' centy)
+         |> linear-transform scalex 0. 0. scaley
+         |> shift centpt
+
+end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/pervasives.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/pervasives.satyh
@@ -1,10 +1,5 @@
 module Pervasives = struct
 
-  type point = length * length
-
-  type paren = length -> length -> context -> inline-boxes * (length -> length)
-
-
   val get-natural-width ib =
     let (wid, _, _) = get-natural-metrics ib in
     wid

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/pervasives.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/pervasives.satyh
@@ -28,57 +28,6 @@ module Pervasives = struct
     no-break (read-inline ctx inner)
 
 
-  val inline ctx \SATySFi =
-    let size = get-font-size ctx in
-    let f = read-inline ctx in
-    let fd = ctx |> set-manual-rising (0pt -' (size *' 0.25)) |> read-inline in
-    let ib =
-      f {SAT} ++ kern (size *' 0.15) ++ fd {Y} ++ f {SF} ++ kern (size *' 0.05) ++ fd {I}
-    in
-      script-guard Latin (no-break ib)
-
-
-  val inline ctx \LaTeX =
-    let size = get-font-size ctx in
-    let f = read-inline ctx in
-    let fA = ctx |> set-font-size (size *' 0.7)
-                 |> set-manual-rising (size *' 0.2)
-                 |> read-inline
-    in
-    let fE = ctx |> set-manual-rising (0pt -' (size *' 0.25))
-                 |> read-inline
-    in
-    let ib =
-      f {L} ++ kern (size *' 0.2) ++ fA {A}
-        ++ f {T} ++ kern (size *' 0.125) ++ fE {E} ++ f {X}
-    in
-      script-guard Latin (no-break ib)
-
-
-  val inline ctx \TeX =
-    let size = get-font-size ctx in
-    let f = read-inline ctx in
-    let fE = ctx |> set-manual-rising (0pt -' (size *' 0.25))
-                 |> read-inline
-    in
-    let ib =
-      f {T} ++ kern (size *' 0.125) ++ fE {E} ++ f {X}
-    in
-      script-guard Latin (no-break ib)
-
-
-  val length-max len1 len2 =
-    if len1 <' len2 then len2 else len1
-
-
-  val length-min len1 len2 =
-    if len1 <' len2 then len1 else len2
-
-
-  val length-abs len =
-    if len <' 0pt then 0pt -' len else len
-
-
   val inline ctx \fil =
     discretionary 0 inline-nil inline-fil inline-nil
 
@@ -89,13 +38,6 @@ module Pervasives = struct
 
   val mandatory-break ctx =
     discretionary 0 (inline-skip (get-text-width ctx *' 2.)) inline-fil inline-nil
-
-
-  val destruct-option default opt =
-    match opt with
-    | None    -> default
-    | Some(v) -> v
-    end
 
 
   val math-pi = 3.1415926536

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/ref.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/ref.satyg
@@ -1,8 +1,12 @@
 module Ref :> sig
-  val increment : ref int -> unit
+  val persistent ~increment : ref int -> unit
+  val persistent ~decrement : ref int -> unit
 end = struct
 
-  val increment r =
+  val persistent ~increment r =
     r <- !r + 1
+
+  val persistent ~decrement r =
+    r <- !r - 1
 
 end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/ref.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/ref.satyg
@@ -1,0 +1,8 @@
+module Ref :> sig
+  val increment : ref int -> unit
+end = struct
+
+  val increment r =
+    r <- !r + 1
+
+end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/set.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/set.satyg
@@ -1,0 +1,59 @@
+use open Basic
+use List
+use Map
+
+module Set :> sig
+  module Make : (Elem : Ord) -> sig
+    type t :: o
+    val empty : t
+    val add : Elem.t -> t -> t
+    val remove : Elem.t -> t -> t
+    val is-member : Elem.t -> t -> bool
+    val fold 'a : ('a -> Elem.t -> 'a) -> 'a -> t -> 'a
+    val fold-back 'a : ('a -> Elem.t -> 'a) -> 'a -> t -> 'a
+    val to-list : t -> list Elem.t
+    val to-list-reversed : t -> list Elem.t
+    val from-list : list Elem.t -> t
+  end
+end = struct
+
+  module Make = fun(Elem : Ord) -> struct
+
+    module Impl = Map.Make Elem
+
+    type t = Impl.t unit
+
+    val empty =
+      Impl.empty
+
+    val add e =
+      Impl.add e ()
+
+    val remove e =
+      Impl.remove e
+
+    val is-member e s =
+      match Impl.find e s with
+      | None    -> false
+      | Some(_) -> true
+      end
+
+    val fold f acc s =
+      Impl.fold (fun acc e () -> f acc e) acc s
+
+    val fold-back f acc s =
+      Impl.fold-back (fun acc e () -> f acc e) acc s
+
+    val to-list s =
+      Impl.fold-back (fun acc e () -> e :: acc) [] s
+
+    val to-list-reversed s =
+      Impl.fold (fun acc e () -> e :: acc) [] s
+
+    % TODO: more efficient implementation
+    val from-list es =
+      Impl.from-list (List.map (fun e -> (e, ())) es)
+
+  end
+
+end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -20,20 +20,21 @@ module Stdlib :> sig
   end
   module List : sig
     val persistent ~map 'a 'b : ('a -> 'b) -> list 'a -> list 'b
-    val persistent ~mapi 'a 'b : (int -> 'a -> 'b) -> list 'a -> list 'b
+    val persistent ~map-indexed 'a 'b : (int -> 'a -> 'b) -> list 'a -> list 'b
     val persistent ~iter 'a : ('a -> unit) -> list 'a -> unit
-    val persistent ~iteri 'a : (int -> 'a -> unit) -> list 'a -> unit
-    val persistent ~fold-left 'a 'b : ('a -> 'b -> 'a) -> 'a -> list 'b -> 'a
-    val persistent ~fold-lefti 'a 'b : (int -> 'a -> 'b -> 'a) -> 'a -> list 'b -> 'a
-    val persistent ~fold-right 'a 'b : ('a -> 'b -> 'b) -> 'b -> list 'a -> 'b
+    val persistent ~iter-indexed 'a : (int -> 'a -> unit) -> list 'a -> unit
+    val persistent ~fold 'a 'b : ('a -> 'b -> 'a) -> 'a -> list 'b -> 'a
+    val persistent ~fold-indexed 'a 'b : ('a -> int -> 'b -> 'a) -> 'a -> list 'b -> 'a
+    val persistent ~fold-back 'a 'b : ('a -> 'b -> 'b) -> 'b -> list 'a -> 'b
     val persistent ~filter 'a : ('a -> bool) -> list 'a -> list 'a
     val persistent ~assoc 'a 'b : ('a -> 'a -> bool) -> 'a -> list ('a * 'b) -> option 'b
     val persistent ~reverse 'a : list 'a -> list 'a
     val persistent ~append 'a : list 'a -> list 'a -> list 'a
     val persistent ~concat 'a : list (list 'a) -> list 'a
-    val persistent ~fold-left-adjacent 'a 'b : ('a -> 'b -> option 'b -> option 'b -> 'a) -> 'a -> list 'b -> 'a
+    val persistent ~fold-adjacent 'a 'b : ('a -> 'b -> option 'b -> option 'b -> 'a) -> 'a -> list 'b -> 'a
+    val persistent ~fold-indexed-adjacent 'a 'b : ('a -> int -> 'b -> option 'b -> option 'b -> 'a) -> 'a -> list 'b -> 'a
     val persistent ~map-adjacent 'a 'b : ('a -> option 'a -> option 'a -> 'b) -> list 'a -> list 'b
-    val persistent ~mapi-adjacent 'a 'b : (int -> 'a -> option 'a -> option 'a -> 'b) -> list 'a -> list 'b
+    val persistent ~map-indexed-adjacent 'a 'b : (int -> 'a -> option 'a -> option 'a -> 'b) -> list 'a -> list 'b
     val persistent ~length 'a : list 'a -> int
     val persistent ~nth 'a : int -> list 'a -> option 'a
     val persistent ~is-empty 'a : list 'a -> bool

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -1,4 +1,5 @@
 use Basic
+use Int
 use Option
 use List
 use Length
@@ -21,6 +22,18 @@ module Stdlib :> sig
   type ordering = Less | Equal | Greater
   type point = length * length
   type paren = length -> length -> context -> inline-boxes * (length -> length)
+  signature Ord = sig
+    type t :: o
+    val compare : t -> t -> ordering
+  end
+  module Int : sig
+    type t = int
+    val ~lift : int -> code int
+    val persistent ~compare : int -> int -> ordering
+    val persistent ~equal : int -> int -> bool
+    val persistent ~max : int -> int -> int
+    val persistent ~min : int -> int -> int
+  end
   module Option : sig
     type t 'a = option 'a
     val ~lift 'a : ('a -> code 'a) -> option 'a -> code (option 'a)
@@ -181,6 +194,7 @@ module Stdlib :> sig
   end
 end = struct
   include Basic
+  module Int = Int
   module Option = Option
   module List = List
   module Length = Length

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -22,6 +22,7 @@ module Stdlib :> sig
   type paren = length -> length -> context -> inline-boxes * (length -> length)
   module Option : sig
     type t 'a = option 'a
+    val ~lift 'a : ('a -> code 'a) -> option 'a -> code (option 'a)
     val persistent ~compare 'a : ('a -> 'a -> ordering) -> option 'a -> option 'a -> ordering
     val persistent ~equal 'a : ('a -> 'a -> bool) -> option 'a -> option 'a -> bool
     val persistent ~map 'a 'b : ('a -> 'b) -> option 'a -> option 'b
@@ -32,6 +33,7 @@ module Stdlib :> sig
   end
   module List : sig
     type t 'a = list 'a
+    val ~lift 'a : ('a -> code 'a) -> list 'a -> code (list 'a)
     val persistent ~compare 'a : ('a -> 'a -> ordering) -> list 'a -> list 'a -> ordering
     val persistent ~equal 'a : ('a -> 'a -> bool) -> list 'a -> list 'a -> bool
     val persistent ~fold 'a 'b : ('a -> 'b -> 'a) -> 'a -> list 'b -> 'a
@@ -60,6 +62,7 @@ module Stdlib :> sig
   end
   module Length : sig
     type t = length
+    val ~lift : length -> code length
     val persistent ~max : length -> length -> length
     val persistent ~min : length -> length -> length
     val persistent ~abs : length -> length
@@ -72,21 +75,25 @@ module Stdlib :> sig
   module Inline : sig
     val get-natural-advance : inline-boxes -> length
     val kern : length -> inline-boxes
-    val \hskip : inline [length]
+    val \skip : inline [length]
     val no-break : inline-boxes -> inline-boxes
     val \no-break : inline [inline-text]
     val \fil : inline []
     val \fil-both : inline []
     val mandatory-break : context -> inline-boxes
+    val \mandatory-break : inline []
   end
   module Block : sig
     val form-paragraph : context -> inline-boxes -> block-boxes
+    val +skip : block [length]
+    val +clear-page : block []
   end
   module Arith : sig
-    val pi : float
+    val persistent ~pi : float
   end
   module Ref : sig
-    val increment : ref int -> unit
+    val persistent ~increment : ref int -> unit
+    val persistent ~decrement : ref int -> unit
   end
   module Geom : sig
     val atan2-point : point -> point -> float

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -1,3 +1,4 @@
+use Basic
 use Option
 use List
 use Pervasives
@@ -12,13 +13,23 @@ use HDecoSet
 use VDecoSet
 
 module Stdlib :> sig
+  % Basic
+  type ordering = Less | Equal | Greater
+  type point = length * length
+  type paren = length -> length -> context -> inline-boxes * (length -> length)
   module Option : sig
+    type t 'a = option 'a
+    val persistent ~compare 'a : ('a -> 'a -> ordering) -> option 'a -> option 'a -> ordering
+    val persistent ~equal 'a : ('a -> 'a -> bool) -> option 'a -> option 'a -> bool
     val persistent ~map 'a 'b : ('a -> 'b) -> option 'a -> option 'b
     val persistent ~from 'a : 'a -> option 'a -> 'a
     val persistent ~bind 'a 'b : option 'a -> ('a -> option 'b) -> option 'b
     val persistent ~is-none 'a : option 'a -> bool
   end
   module List : sig
+    type t 'a = list 'a
+    val persistent ~compare 'a : ('a -> 'a -> ordering) -> list 'a -> list 'a -> ordering
+    val persistent ~equal 'a : ('a -> 'a -> bool) -> list 'a -> list 'a -> bool
     val persistent ~map 'a 'b : ('a -> 'b) -> list 'a -> list 'b
     val persistent ~map-indexed 'a 'b : (int -> 'a -> 'b) -> list 'a -> list 'b
     val persistent ~iter 'a : ('a -> unit) -> list 'a -> unit
@@ -52,8 +63,6 @@ module Stdlib :> sig
     val \TeX : inline []
   end
   module Pervasives : sig
-    type point = length * length
-    type paren = length -> length -> context -> inline-boxes * (length -> length)
     val get-natural-width : inline-boxes -> length
     val form-paragraph : context -> inline-boxes -> block-boxes
     val kern : length -> inline-boxes
@@ -67,7 +76,6 @@ module Stdlib :> sig
     val increment : ref int -> unit
   end
   module Geom : sig
-    type point = Pervasives.point %TODO (enhance): remove this
     val atan2-point : point -> point -> float
     val div-perp : point -> point -> float -> length -> point
   end
@@ -90,7 +98,6 @@ module Stdlib :> sig
     val purple  : color
   end
   module Gr : sig
-    type point = Pervasives.point  %TODO (enhance): erase this
     val rectangle : point -> point -> path
     val rectangle-round : length -> point -> point -> path
     val rectangle-round-left : length -> point -> point -> path
@@ -145,6 +152,7 @@ module Stdlib :> sig
     val quote-round : length -> length -> color -> deco-set
   end
 end = struct
+  include Basic
   module Option = Option
   module List = List
   module Length = Length

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -78,10 +78,14 @@ module Stdlib :> sig
   module Map : sig
     module Make : (Key : Ord) -> sig
       type t :: o -> o
-      val empty 'a : t 'a
-      val singleton 'a : Key.t -> 'a -> t 'a
-      val add 'a : Key.t -> 'a -> t 'a -> t 'a
-      val remove 'a : Key.t -> t 'a -> t 'a
+      val empty 'v : t 'v
+      val singleton 'v : Key.t -> 'v -> t 'v
+      val add 'v : Key.t -> 'v -> t 'v -> t 'v
+      val remove 'v : Key.t -> t 'v -> t 'v
+      val fold 'a 'v : ('a -> Key.t -> 'v -> 'a) -> 'a -> t 'v -> 'a
+      val to-descending-list 'v : t 'v -> list (Key.t * 'v)
+      val to-ascending-list 'v : t 'v -> list (Key.t * 'v)
+      val from-list 'v : list (Key.t * 'v) -> t 'v
     end
   end
   module Length : sig

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -1,9 +1,12 @@
 use Basic
 use Option
 use List
-use Pervasives
 use Length
 use Logo
+use Inline
+use Block
+use Arith
+use Ref
 use Geom
 use Color
 use Gr
@@ -66,9 +69,8 @@ module Stdlib :> sig
     val \LaTeX : inline []
     val \TeX : inline []
   end
-  module Pervasives : sig
-    val get-natural-width : inline-boxes -> length
-    val form-paragraph : context -> inline-boxes -> block-boxes
+  module Inline : sig
+    val get-natural-advance : inline-boxes -> length
     val kern : length -> inline-boxes
     val \hskip : inline [length]
     val no-break : inline-boxes -> inline-boxes
@@ -76,7 +78,14 @@ module Stdlib :> sig
     val \fil : inline []
     val \fil-both : inline []
     val mandatory-break : context -> inline-boxes
-    val math-pi : float
+  end
+  module Block : sig
+    val form-paragraph : context -> inline-boxes -> block-boxes
+  end
+  module Arith : sig
+    val pi : float
+  end
+  module Ref : sig
     val increment : ref int -> unit
   end
   module Geom : sig
@@ -161,7 +170,10 @@ end = struct
   module List = List
   module Length = Length
   module Logo = Logo
-  module Pervasives = Pervasives
+  module Inline = Inline
+  module Block = Block
+  module Arith = Arith
+  module Ref = Ref
   module Geom = Geom
   module Color = Color
   module Gr = Gr

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -9,6 +9,7 @@ use Arith
 use Ref
 use Geom
 use Color
+use Path
 use Gr
 use PaperSize
 use Deco
@@ -117,7 +118,7 @@ module Stdlib :> sig
     val pink    : color
     val purple  : color
   end
-  module Gr : sig
+  module Path : sig
     val rectangle : point -> point -> path
     val rectangle-round : length -> point -> point -> path
     val rectangle-round-left : length -> point -> point -> path
@@ -128,14 +129,18 @@ module Stdlib :> sig
     val polygon : point -> list point -> path
     val line : point -> point -> path
     val circle : point -> length -> path
+    val linear-transform : float -> float -> float -> float -> path -> path
+    val shift : length * length -> path -> path
+    val rotate : point -> float -> path -> path
+    val scale : point -> float -> float -> path -> path
+  end
+  module Gr : sig
     val empty : graphics
     val text-centering : point -> inline-boxes -> graphics
     val text-leftward : point -> inline-boxes -> graphics
     val text-rightward : point -> inline-boxes -> graphics
     val arrow : length -> color -> length -> length -> length -> point -> point -> graphics
     val dashed-arrow : length -> length * length * length -> color -> length -> length -> length -> point -> point -> graphics
-    val rotate-path : point -> float -> path -> path
-    val scale-path : point -> float -> float -> path -> path
     val rotate-graphics : point -> float -> graphics -> graphics
     val scale-graphics : point -> float -> float -> graphics -> graphics
   end
@@ -183,6 +188,7 @@ end = struct
   module Ref = Ref
   module Geom = Geom
   module Color = Color
+  module Path = Path
   module Gr = Gr
   module PaperSize = PaperSize
   module Deco = Deco

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -22,34 +22,38 @@ module Stdlib :> sig
     val persistent ~compare 'a : ('a -> 'a -> ordering) -> option 'a -> option 'a -> ordering
     val persistent ~equal 'a : ('a -> 'a -> bool) -> option 'a -> option 'a -> bool
     val persistent ~map 'a 'b : ('a -> 'b) -> option 'a -> option 'b
-    val persistent ~from 'a : 'a -> option 'a -> 'a
+    val persistent ~pure 'a : 'a -> option 'a
     val persistent ~bind 'a 'b : option 'a -> ('a -> option 'b) -> option 'b
+    val persistent ~from 'a : 'a -> option 'a -> 'a
     val persistent ~is-none 'a : option 'a -> bool
   end
   module List : sig
     type t 'a = list 'a
     val persistent ~compare 'a : ('a -> 'a -> ordering) -> list 'a -> list 'a -> ordering
     val persistent ~equal 'a : ('a -> 'a -> bool) -> list 'a -> list 'a -> bool
-    val persistent ~map 'a 'b : ('a -> 'b) -> list 'a -> list 'b
-    val persistent ~map-indexed 'a 'b : (int -> 'a -> 'b) -> list 'a -> list 'b
-    val persistent ~iter 'a : ('a -> unit) -> list 'a -> unit
-    val persistent ~iter-indexed 'a : (int -> 'a -> unit) -> list 'a -> unit
     val persistent ~fold 'a 'b : ('a -> 'b -> 'a) -> 'a -> list 'b -> 'a
     val persistent ~fold-indexed 'a 'b : ('a -> int -> 'b -> 'a) -> 'a -> list 'b -> 'a
     val persistent ~fold-back 'a 'b : ('a -> 'b -> 'b) -> 'b -> list 'a -> 'b
-    val persistent ~filter 'a : ('a -> bool) -> list 'a -> list 'a
-    val persistent ~assoc 'a 'b : ('a -> 'a -> bool) -> 'a -> list ('a * 'b) -> option 'b
-    val persistent ~reverse 'a : list 'a -> list 'a
-    val persistent ~append 'a : list 'a -> list 'a -> list 'a
-    val persistent ~concat 'a : list (list 'a) -> list 'a
     val persistent ~fold-adjacent 'a 'b : ('a -> 'b -> option 'b -> option 'b -> 'a) -> 'a -> list 'b -> 'a
     val persistent ~fold-indexed-adjacent 'a 'b : ('a -> int -> 'b -> option 'b -> option 'b -> 'a) -> 'a -> list 'b -> 'a
+    val persistent ~reverse 'a : list 'a -> list 'a
+    val persistent ~map 'a 'b : ('a -> 'b) -> list 'a -> list 'b
+    val persistent ~map-indexed 'a 'b : (int -> 'a -> 'b) -> list 'a -> list 'b
+    val persistent ~map-with-ends 'a 'b : (bool -> bool -> 'a -> 'b) -> list 'a -> list 'b
     val persistent ~map-adjacent 'a 'b : ('a -> option 'a -> option 'a -> 'b) -> list 'a -> list 'b
     val persistent ~map-indexed-adjacent 'a 'b : (int -> 'a -> option 'a -> option 'a -> 'b) -> list 'a -> list 'b
+    val persistent ~append 'a : list 'a -> list 'a -> list 'a
+    val persistent ~concat 'a : list (list 'a) -> list 'a
+    val persistent ~pure 'a : 'a -> list 'a
+    val persistent ~bind 'a 'b : list 'a -> ('a -> list 'b) -> list 'b
+    val persistent ~iter 'a : ('a -> unit) -> list 'a -> unit
+    val persistent ~iter-indexed 'a : (int -> 'a -> unit) -> list 'a -> unit
+    val persistent ~filter 'a : ('a -> bool) -> list 'a -> list 'a
+    val persistent ~filter-map 'a 'b : ('a -> option 'b) -> list 'a -> list 'b
+    val persistent ~assoc 'a 'b : ('a -> 'a -> bool) -> 'a -> list ('a * 'b) -> option 'b
     val persistent ~length 'a : list 'a -> int
     val persistent ~nth 'a : int -> list 'a -> option 'a
     val persistent ~is-empty 'a : list 'a -> bool
-    val persistent ~map-with-ends 'a 'b : (bool -> bool -> 'a -> 'b) -> list 'a -> list 'b
   end
   module Length : sig
     type t = length

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -2,6 +2,7 @@ use Basic
 use Int
 use Option
 use List
+use Map
 use Length
 use Logo
 use Inline
@@ -73,6 +74,15 @@ module Stdlib :> sig
     val persistent ~length 'a : list 'a -> int
     val persistent ~nth 'a : int -> list 'a -> option 'a
     val persistent ~is-empty 'a : list 'a -> bool
+  end
+  module Map : sig
+    module Make : (Key : Ord) -> sig
+      type t :: o -> o
+      val empty 'a : t 'a
+      val singleton 'a : Key.t -> 'a -> t 'a
+      val add 'a : Key.t -> 'a -> t 'a -> t 'a
+      val remove 'a : Key.t -> t 'a -> t 'a
+    end
   end
   module Length : sig
     type t = length
@@ -197,6 +207,7 @@ end = struct
   module Int = Int
   module Option = Option
   module List = List
+  module Map = Map
   module Length = Length
   module Logo = Logo
   module Inline = Inline

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -1,6 +1,8 @@
 use Option
 use List
 use Pervasives
+use Length
+use Logo
 use Geom
 use Color
 use Gr
@@ -37,6 +39,17 @@ module Stdlib :> sig
     val persistent ~is-empty 'a : list 'a -> bool
     val persistent ~map-with-ends 'a 'b : (bool -> bool -> 'a -> 'b) -> list 'a -> list 'b
   end
+  module Length : sig
+    type t = length
+    val persistent ~max : length -> length -> length
+    val persistent ~min : length -> length -> length
+    val persistent ~abs : length -> length
+  end
+  module Logo : sig
+    val \SATySFi : inline []
+    val \LaTeX : inline []
+    val \TeX : inline []
+  end
   module Pervasives : sig
     type point = length * length
     type paren = length -> length -> context -> inline-boxes * (length -> length)
@@ -46,16 +59,9 @@ module Stdlib :> sig
     val \hskip : inline [length]
     val no-break : inline-boxes -> inline-boxes
     val \no-break : inline [inline-text]
-    val \SATySFi : inline []
-    val \LaTeX : inline []
-    val \TeX : inline []
-    val length-max : length -> length -> length
-    val length-min : length -> length -> length
-    val length-abs : length -> length
     val \fil : inline []
     val \fil-both : inline []
     val mandatory-break : context -> inline-boxes
-    val destruct-option 'a : 'a -> option 'a -> 'a
     val math-pi : float
     val increment : ref int -> unit
   end
@@ -140,6 +146,8 @@ module Stdlib :> sig
 end = struct
   module Option = Option
   module List = List
+  module Length = Length
+  module Logo = Logo
   module Pervasives = Pervasives
   module Geom = Geom
   module Color = Color

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -53,7 +53,7 @@ module Stdlib :> sig
     val persistent ~equal 'a : ('a -> 'a -> bool) -> list 'a -> list 'a -> bool
     val persistent ~fold 'a 'b : ('a -> 'b -> 'a) -> 'a -> list 'b -> 'a
     val persistent ~fold-indexed 'a 'b : ('a -> int -> 'b -> 'a) -> 'a -> list 'b -> 'a
-    val persistent ~fold-back 'a 'b : ('a -> 'b -> 'b) -> 'b -> list 'a -> 'b
+    val persistent ~fold-back 'a 'b : ('a -> 'b -> 'b) -> list 'a -> 'b -> 'b
     val persistent ~fold-adjacent 'a 'b : ('a -> 'b -> option 'b -> option 'b -> 'a) -> 'a -> list 'b -> 'a
     val persistent ~fold-indexed-adjacent 'a 'b : ('a -> int -> 'b -> option 'b -> option 'b -> 'a) -> 'a -> list 'b -> 'a
     val persistent ~reverse 'a : list 'a -> list 'a

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -82,9 +82,13 @@ module Stdlib :> sig
       val singleton 'v : Key.t -> 'v -> t 'v
       val add 'v : Key.t -> 'v -> t 'v -> t 'v
       val remove 'v : Key.t -> t 'v -> t 'v
+      val find 'v : Key.t -> t 'v -> option 'v
+      val map 'u 'v : ('u -> 'v) -> t 'u -> t 'v
+      val map-with-key 'u 'v : (Key.t -> 'u -> 'v) -> t 'u -> t 'v
       val fold 'a 'v : ('a -> Key.t -> 'v -> 'a) -> 'a -> t 'v -> 'a
-      val to-descending-list 'v : t 'v -> list (Key.t * 'v)
-      val to-ascending-list 'v : t 'v -> list (Key.t * 'v)
+      val fold-back 'a 'v : ('a -> Key.t -> 'v -> 'a) -> 'a -> t 'v -> 'a
+      val to-list 'v : t 'v -> list (Key.t * 'v)
+      val to-list-reversed 'v : t 'v -> list (Key.t * 'v)
       val from-list 'v : list (Key.t * 'v) -> t 'v
     end
   end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -3,6 +3,7 @@ use Int
 use Option
 use List
 use Map
+use Set
 use Length
 use Logo
 use Inline
@@ -90,6 +91,20 @@ module Stdlib :> sig
       val to-list 'v : t 'v -> list (Key.t * 'v)
       val to-list-reversed 'v : t 'v -> list (Key.t * 'v)
       val from-list 'v : list (Key.t * 'v) -> t 'v
+    end
+  end
+  module Set : sig
+    module Make : (Elem : Ord) -> sig
+      type t :: o
+      val empty : t
+      val add : Elem.t -> t -> t
+      val remove : Elem.t -> t -> t
+      val is-member : Elem.t -> t -> bool
+      val fold 'a : ('a -> Elem.t -> 'a) -> 'a -> t -> 'a
+      val fold-back 'a : ('a -> Elem.t -> 'a) -> 'a -> t -> 'a
+      val to-list : t -> list Elem.t
+      val to-list-reversed : t -> list Elem.t
+      val from-list : list Elem.t -> t
     end
   end
   module Length : sig
@@ -216,6 +231,7 @@ end = struct
   module Option = Option
   module List = List
   module Map = Map
+  module Set = Set
   module Length = Length
   module Logo = Logo
   module Inline = Inline

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -10,7 +10,7 @@ use Ref
 use Geom
 use Color
 use Path
-use Gr
+use Graphics
 use PaperSize
 use Deco
 use HDecoSet
@@ -134,15 +134,18 @@ module Stdlib :> sig
     val rotate : point -> float -> path -> path
     val scale : point -> float -> float -> path -> path
   end
-  module Gr : sig
+  module Graphics : sig
+    val overlay : list graphics -> graphics
+    val shift : length * length -> graphics -> graphics
+    val linear-transform : float -> float -> float -> float -> graphics -> graphics
+    val rotate : point -> float -> graphics -> graphics
+    val scale : point -> float -> float -> graphics -> graphics
     val empty : graphics
     val text-centering : point -> inline-boxes -> graphics
     val text-leftward : point -> inline-boxes -> graphics
     val text-rightward : point -> inline-boxes -> graphics
     val arrow : length -> color -> length -> length -> length -> point -> point -> graphics
     val dashed-arrow : length -> length * length * length -> color -> length -> length -> length -> point -> point -> graphics
-    val rotate-graphics : point -> float -> graphics -> graphics
-    val scale-graphics : point -> float -> float -> graphics -> graphics
   end
   module PaperSize : sig
     val persistent ~a0 : length * length
@@ -189,7 +192,7 @@ end = struct
   module Geom = Geom
   module Color = Color
   module Path = Path
-  module Gr = Gr
+  module Graphics = Graphics
   module PaperSize = PaperSize
   module Deco = Deco
   module HDecoSet = HDecoSet

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/vdecoset.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/vdecoset.satyh
@@ -1,5 +1,6 @@
 use Color
 use Gr
+use Path
 
 module VDecoSet :> sig
   val empty : deco-set
@@ -13,59 +14,56 @@ end = struct
     let deco _ _ _ _ = Gr.empty in
     (deco, deco, deco, deco)
 
-
   val simple-frame-stroke t scolor =
     let strokef = stroke t scolor in
     let decoS (x, y) w h d =
-      strokef (Gr.rectangle (x, y -' d) (x +' w, y +' h))
+      strokef (Path.rectangle (x, y -' d) (x +' w, y +' h))
     in
     let decoH (x, y) w h d =
-      strokef (Gr.poly-line (x, y -' d) [ (x, y +' h), (x +' w, y +' h), (x +' w, y -' d) ])
+      strokef (Path.poly-line (x, y -' d) [ (x, y +' h), (x +' w, y +' h), (x +' w, y -' d) ])
     in
     let decoM (x, y) w h d =
       unite-graphics [
-        strokef (Gr.line (x, y -' d) (x, y +' h)),
-        strokef (Gr.line (x +' w, y -' d) (x +' w, y +' h)),
+        strokef (Path.line (x, y -' d) (x, y +' h)),
+        strokef (Path.line (x +' w, y -' d) (x +' w, y +' h)),
       ]
     in
     let decoT (x, y) w h d =
-      strokef (Gr.poly-line (x, y +' h) [ (x, y -' d), (x +' w, y -' d), (x +' w, y +' h) ])
+      strokef (Path.poly-line (x, y +' h) [ (x, y -' d), (x +' w, y -' d), (x +' w, y +' h) ])
     in
     (decoS, decoH, decoM, decoT)
-
 
   val simple-frame t scolor fcolor =
     let strokef = stroke t scolor in
     let gr-back x y w d h =
-      fill fcolor (Gr.rectangle (x, y -' d) (x +' w, y +' h))
+      fill fcolor (Path.rectangle (x, y -' d) (x +' w, y +' h))
     in
     let decoS (x, y) w h d =
       unite-graphics [
         gr-back x y w d h,
-        strokef (Gr.rectangle (x, y -' d) (x +' w, y +' h)),
+        strokef (Path.rectangle (x, y -' d) (x +' w, y +' h)),
       ]
     in
     let decoH (x, y) w h d =
       unite-graphics [
         gr-back x y w d h,
-        strokef (Gr.poly-line (x, y -' d) [(x, y +' h), (x +' w, y +' h), (x +' w, y -' d),])
+        strokef (Path.poly-line (x, y -' d) [(x, y +' h), (x +' w, y +' h), (x +' w, y -' d),])
       ]
     in
     let decoM (x, y) w h d =
       unite-graphics [
         gr-back x y w d h,
-        strokef (Gr.line (x, y -' d) (x, y +' h)),
-        strokef (Gr.line (x +' w, y -' d) (x +' w, y +' h)),
+        strokef (Path.line (x, y -' d) (x, y +' h)),
+        strokef (Path.line (x +' w, y -' d) (x +' w, y +' h)),
       ]
     in
     let decoT (x, y) w h d =
       unite-graphics [
         gr-back x y w d h,
-        strokef (Gr.poly-line (x, y +' h) [(x, y -' d), (x +' w, y -' d), (x +' w, y +' h)])
+        strokef (Path.poly-line (x, y +' h) [(x, y -' d), (x +' w, y -' d), (x +' w, y +' h)])
       ]
     in
     (decoS, decoH, decoM, decoT)
-
 
   val paper =
     let xshift = 2pt in
@@ -75,7 +73,7 @@ end = struct
     let thk = 0.5pt in
     let shadowL (x, y) w h d =
       fill shadow-color
-        (Gr.polygon (x +' w, y +' h) [
+        (Path.polygon (x +' w, y +' h) [
             (x +' w +' xshift, y +' h -' yshift),
             (x +' w +' xshift, y -' d -' yshift),
             (x +' xshift, y -' d -' yshift),
@@ -85,7 +83,7 @@ end = struct
     in
     let shadowI (x, y) w h d =
       fill shadow-color
-        (Gr.polygon (x +' w, y -' d) [
+        (Path.polygon (x +' w, y -' d) [
           (x +' w +' xshift, y -' d),
           (x +' w +' xshift, y +' h -' yshift),
           (x +' w, y +' h),
@@ -94,14 +92,14 @@ end = struct
     let decoS (x, y) w h d =
       unite-graphics [
         shadowL (x, y) w h d,
-        stroke thk edge-color (Gr.rectangle (x, y -' d) (x +' w, y +' h)),
+        stroke thk edge-color (Path.rectangle (x, y -' d) (x +' w, y +' h)),
       ]
     in
     let decoH (x, y) w h d =
       unite-graphics [
         shadowI (x, y) w h d,
         stroke thk edge-color
-          (Gr.poly-line (x, y -' d) [
+          (Path.poly-line (x, y -' d) [
             (x, y +' h),
             (x +' w, y +' h),
             (x +' w, y -' d),
@@ -111,15 +109,15 @@ end = struct
     let decoM (x, y) w h d =
       unite-graphics [
         shadowI (x, y) w h d,
-        stroke thk edge-color (Gr.line (x, y -' d) (x, y +' h)),
-        stroke thk edge-color (Gr.line (x +' w, y -' d) (x +' w, y +' h)),
+        stroke thk edge-color (Path.line (x, y -' d) (x, y +' h)),
+        stroke thk edge-color (Path.line (x +' w, y -' d) (x +' w, y +' h)),
       ]
     in
     let decoT (x, y) w h d =
       unite-graphics [
         shadowL (x, y) w h d,
         stroke thk edge-color
-          (Gr.poly-line (x, y +' h) [
+          (Path.poly-line (x, y +' h) [
             (x, y -' d),
             (x +' w, y -' d),
             (x +' w, y +' h),
@@ -128,19 +126,18 @@ end = struct
     in
     (decoS, decoH, decoM, decoT)
 
-
   val quote-round qw r color =
     let decoS (x, y) _ h d =
-      fill color (Gr.rectangle-round-left r (x, y -' d) (x +' qw, y +' h))
+      fill color (Path.rectangle-round-left r (x, y -' d) (x +' qw, y +' h))
     in
     let decoH (x, y) _ h d =
-      fill color (Gr.rectangle-round-left-upper r (x, y -' d) (x +' qw, y +' h))
+      fill color (Path.rectangle-round-left-upper r (x, y -' d) (x +' qw, y +' h))
     in
     let decoM (x, y) _ h d =
-      fill color (Gr.rectangle (x, y -' d) (x +' qw, y +' h))
+      fill color (Path.rectangle (x, y -' d) (x +' qw, y +' h))
     in
     let decoT (x, y) _ h d =
-      fill color (Gr.rectangle-round-left-lower r (x, y -' d) (x +' qw, y +' h))
+      fill color (Path.rectangle-round-left-lower r (x, y -' d) (x +' qw, y +' h))
     in
     (decoS, decoH, decoM, decoT)
 

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/vdecoset.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/vdecoset.satyh
@@ -1,5 +1,5 @@
 use Color
-use Gr
+use Graphics
 use Path
 
 module VDecoSet :> sig
@@ -11,7 +11,7 @@ module VDecoSet :> sig
 end = struct
 
   val empty =
-    let deco _ _ _ _ = Gr.empty in
+    let deco _ _ _ _ = Graphics.empty in
     (deco, deco, deco, deco)
 
   val simple-frame-stroke t scolor =

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/test/list-test.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/test/list-test.satyg
@@ -1,5 +1,5 @@
-use List
 use package Testing
+use List
 
 module ListTest = struct
 
@@ -8,14 +8,15 @@ module ListTest = struct
     val equal m n = (m == n)
     val show = arabic
   end
-  module TEM = Testing.Equality.Make
-  module IntEquality = TEM IntTarget
+  module IntEquality = Testing.Equality.Make IntTarget
 
   #[test]
-  val fold-left-test =
+  val fold-test =
     let input = [3, 1, 4, 1, 5, 9, 2] in
-    let expected = 24 in
-    let got = List.fold-left ( + ) 0 input in
+    let expected = 25 in
+    let got = List.fold ( + ) 0 input in
     IntEquality.assert-equal expected got
+
+  % TODO: add more tests
 
 end

--- a/src/frontend/closedFileDependencyResolver.ml
+++ b/src/frontend/closedFileDependencyResolver.ml
@@ -15,7 +15,7 @@ let main (utlibs : (abs_path * untyped_library_file) list) : ((abs_path * untype
   (* Add vertices: *)
   let* (graph, entryacc) =
     utlibs |> foldM (fun (graph, entryacc) (abspath, utlib) ->
-      let (_attrs, _header, ((_, modnm), _, _)) = utlib in
+      let (_attrs, _header, ((_, modnm), _, _rng_struct, _utbinds)) = utlib in
       let* (graph, vertex) =
         match graph |> SourceModuleDependencyGraph.add_vertex modnm (abspath, utlib) with
         | Error(((abspath_prev, _utlib_prev), _vertex_prev)) ->

--- a/src/frontend/errorReporting.ml
+++ b/src/frontend/errorReporting.ml
@@ -455,7 +455,8 @@ let make_type_error_message = function
   | MissingRequiredConstructorName(rng, ctornm, _centry) ->
       [
         NormalLine(Printf.sprintf "at %s:" (Range.to_string rng));
-        NormalLine(Printf.sprintf "missing required constructor '%s' (TODO (enhance): detailed report)" ctornm);
+        NormalLine(Printf.sprintf "missing required constructor '%s'" ctornm);
+        (* TODO (enhance): consider displaying `centry` *)
       ]
 
   | MissingRequiredTypeName(rng, tynm, arity) ->
@@ -467,13 +468,15 @@ let make_type_error_message = function
   | MissingRequiredModuleName(rng, modnm, _modsig) ->
       [
         NormalLine(Printf.sprintf "at %s:" (Range.to_string rng));
-        NormalLine(Printf.sprintf "missing required module '%s' (TODO (enhance): detailed report)" modnm);
+        NormalLine(Printf.sprintf "missing required module '%s'" modnm);
+        (* TODO (enhance): consider displaying `modsig` *)
       ]
 
   | MissingRequiredSignatureName(rng, signm, _absmodsig) ->
       [
         NormalLine(Printf.sprintf "at %s:" (Range.to_string rng));
-        NormalLine(Printf.sprintf "missing required signature '%s' (TODO (enhance): detailed report)" signm);
+        NormalLine(Printf.sprintf "missing required signature '%s'" signm);
+        (* TODO (enhance): consider displaying absmodsig *)
       ]
 
   | NotASubtypeAboutValue(rng, x, pty1, pty2) ->

--- a/src/frontend/moduleTypechecker.ml
+++ b/src/frontend/moduleTypechecker.ml
@@ -952,7 +952,7 @@ and typecheck_binding (config : typecheck_config) (tyenv : Typeenv.t) (utbind : 
       return (binds, (OpaqueIDMap.empty, ssig))
 
 
-let main (config : typecheck_config) (tyenv : Typeenv.t) (absmodsig_opt : (signature abstracted) option) (utbinds : untyped_binding list) : (StructSig.t abstracted * binding list) ok =
+let main (config : typecheck_config) (tyenv : Typeenv.t) (absmodsig_opt : (signature abstracted) option) (rng_struct : Range.t) (utbinds : untyped_binding list) : (StructSig.t abstracted * binding list) ok =
   let open ResultMonad in
   match absmodsig_opt with
   | None ->
@@ -960,8 +960,7 @@ let main (config : typecheck_config) (tyenv : Typeenv.t) (absmodsig_opt : (signa
 
   | Some(absmodsig) ->
       let* ((_, ssig), binds) = typecheck_binding_list config tyenv utbinds in
-      let rng = Range.dummy "main_bindings" in (* TODO (error): give appropriate ranges *)
-      let* (quant, modsig) = coerce_signature rng (ConcStructure(ssig)) absmodsig in
+      let* (quant, modsig) = coerce_signature rng_struct (ConcStructure(ssig)) absmodsig in
       let ssig =
         match modsig with
         | ConcFunctor(_)      -> assert false

--- a/src/frontend/moduleTypechecker.mli
+++ b/src/frontend/moduleTypechecker.mli
@@ -5,4 +5,4 @@ open TypeError
 
 val typecheck_signature : typecheck_config -> Typeenv.t -> untyped_signature -> (signature abstracted, type_error) result
 
-val main : typecheck_config -> Typeenv.t -> (signature abstracted) option -> untyped_binding list -> (StructSig.t abstracted * binding list, type_error) result
+val main : typecheck_config -> Typeenv.t -> (signature abstracted) option -> Range.t -> untyped_binding list -> (StructSig.t abstracted * binding list, type_error) result

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -371,8 +371,8 @@ main:
       { raise (ParseError(EmptyInputFile(rng))) }
 ;
 main_lib:
-  | MODULE; modident=UPPER; utsig_opt=option(sig_annot); EXACT_EQ; STRUCT; utbinds=list(bind); END
-      { (modident, utsig_opt, utbinds) }
+  | MODULE; modident=UPPER; utsig_opt=option(sig_annot); EXACT_EQ; tok1=STRUCT; utbinds=list(bind); tok2=END
+      { (modident, utsig_opt, Range.unite tok1 tok2, utbinds) }
 ;
 headerelem:
   | USE; PACKAGE; opening=optional_open; mod_chain=mod_chain

--- a/src/frontend/staticEnv.mli
+++ b/src/frontend/staticEnv.mli
@@ -21,9 +21,12 @@ and functor_signature = {
   opaques  : quantifier;
   domain   : signature;
   codomain : signature abstracted;
-  closure  : (module_name ranged * untyped_module * type_environment) option;
+  closure  : functor_closure option;
 }
 [@@deriving show]
+
+and functor_closure =
+  (module_name ranged * untyped_module * type_environment)
 
 type value_entry = {
   val_name  : EvalVarID.t option;
@@ -85,6 +88,16 @@ module Typeenv : sig
   val find_signature : signature_name -> t -> (signature abstracted) option
 
   val fold_value : (var_name -> value_entry -> 'a -> 'a) -> t -> 'a -> 'a
+
+  (* This might be heavy. TODO: remove this by adopting Bochao–Ohori style static interpratation *)
+  val map :
+    v:(var_name -> value_entry -> value_entry) ->
+    a:(macro_name -> macro_entry -> macro_entry) ->
+    c:(constructor_name -> constructor_entry -> constructor_entry) ->
+    t:(type_name -> type_entry -> type_entry) ->
+    m:(module_name -> module_entry -> module_entry) ->
+    s:(signature_name -> signature abstracted -> signature abstracted) ->
+    t -> t
 
 end
 

--- a/src/frontend/types.cppo.ml
+++ b/src/frontend/types.cppo.ml
@@ -605,7 +605,7 @@ and untyped_attribute =
 [@@deriving show { with_path = false; }]
 
 type untyped_library_file =
-  untyped_attribute list * header_element list * (module_name ranged * untyped_signature option * untyped_binding list)
+  untyped_attribute list * header_element list * (module_name ranged * untyped_signature option * Range.t * untyped_binding list)
 [@@deriving show { with_path = false; }]
 
 type untyped_document_file =

--- a/test/parsing/parser.expected
+++ b/test/parsing/parser.expected
@@ -5,6 +5,7 @@
 (UTLibraryFile
    ([], [],
     (((Range.Normal </path/to/nx.saty:1.8-10>), "Nx"), None,
+     (Range.Normal </path/to/nx.saty:1.13-43.4>),
      [((Range.Normal </path/to/nx.saty:3.3-6>),
        (UTBindValue ([], Stage1,
           (UTNonRec
@@ -791,6 +792,7 @@
 (UTLibraryFile
    ([], [],
     (((Range.Normal </path/to/variants.saty:1.8-16>), "Variants"), None,
+     (Range.Normal </path/to/variants.saty:1.19-6.4>),
      [((Range.Normal </path/to/variants.saty:3.3-7>),
        (UTBindType
           [(((Range.Normal </path/to/variants.saty:3.8-9>), "t"), [],
@@ -828,6 +830,7 @@
 (UTLibraryFile
    ([], [],
     (((Range.Normal </path/to/txprod.saty:1.8-14>), "Txprod"), None,
+     (Range.Normal </path/to/txprod.saty:1.17-6.4>),
      [((Range.Normal </path/to/txprod.saty:3.3-7>),
        (UTBindType
           [(((Range.Normal </path/to/txprod.saty:3.8-9>), "t"), [],
@@ -866,6 +869,7 @@
 (UTLibraryFile
    ([], [],
     (((Range.Normal </path/to/txlist.saty:1.8-14>), "Txlist"), None,
+     (Range.Normal </path/to/txlist.saty:1.17-8.4>),
      [((Range.Normal </path/to/txlist.saty:3.3-7>),
        (UTBindType
           [(((Range.Normal </path/to/txlist.saty:3.8-9>), "t"), [],
@@ -923,6 +927,7 @@
 (UTLibraryFile
    ([], [],
     (((Range.Normal </path/to/txrecord.saty:1.8-16>), "Txrecord"), None,
+     (Range.Normal </path/to/txrecord.saty:1.19-8.4>),
      [((Range.Normal </path/to/txrecord.saty:3.3-7>),
        (UTBindType
           [(((Range.Normal </path/to/txrecord.saty:3.8-9>), "t"), [],
@@ -980,6 +985,7 @@
 (UTLibraryFile
    ([], [],
     (((Range.Normal </path/to/pats.saty:1.8-12>), "Pats"), None,
+     (Range.Normal </path/to/pats.saty:1.15-13.4>),
      [((Range.Normal </path/to/pats.saty:3.3-6>),
        (UTBindValue ([], Stage1,
           (UTNonRec
@@ -1019,6 +1025,7 @@
 (UTLibraryFile
    ([], [],
     (((Range.Normal </path/to/pattuple.saty:1.8-16>), "Pattuple"), None,
+     (Range.Normal </path/to/pattuple.saty:1.19-8.4>),
      [((Range.Normal </path/to/pattuple.saty:3.3-6>),
        (UTBindValue ([], Stage1,
           (UTNonRec
@@ -1048,6 +1055,7 @@
 (UTLibraryFile
    ([], [],
     (((Range.Normal </path/to/patlist.saty:1.8-15>), "Patlist"), None,
+     (Range.Normal </path/to/patlist.saty:1.18-10.4>),
      [((Range.Normal </path/to/patlist.saty:3.3-6>),
        (UTBindValue ([], Stage1,
           (UTNonRec
@@ -1106,6 +1114,7 @@
 (UTLibraryFile
    ([], [],
     (((Range.Normal </path/to/sxlist.saty:1.8-14>), "Sxlist"), None,
+     (Range.Normal </path/to/sxlist.saty:1.17-6.4>),
      [((Range.Normal </path/to/sxlist.saty:3.3-6>),
        (UTBindValue ([], Stage1,
           (UTNonRec
@@ -1124,6 +1133,7 @@
 (UTLibraryFile
    ([], [],
     (((Range.Normal </path/to/mathlist.saty:1.8-16>), "Mathlist"), None,
+     (Range.Normal </path/to/mathlist.saty:1.19-21.4>),
      [((Range.Normal </path/to/mathlist.saty:3.3-6>),
        (UTBindValue ([], Stage1,
           (UTNonRec
@@ -1398,6 +1408,7 @@
 (UTLibraryFile
    ([], [],
     (((Range.Normal </path/to/toplevel.saty:1.8-16>), "Toplevel"), None,
+     (Range.Normal </path/to/toplevel.saty:1.19-9.4>),
      [((Range.Normal </path/to/toplevel.saty:3.3-7>),
        (UTBindType
           [(((Range.Normal </path/to/toplevel.saty:3.8-9>), "t"), [],

--- a/tests/clip.saty
+++ b/tests/clip.saty
@@ -1,7 +1,6 @@
 use package open Stdlib
+use package open Stdlib.Logo
 use open Head of `head`
-
-let open Pervasives in
 
 let inline ctx \do-fill wid f =
   let ib = use-image-by-width (load-image `images/peppers-rgb.jpg`) wid in

--- a/tests/head.satyh
+++ b/tests/head.satyh
@@ -304,16 +304,14 @@ module Head = struct
     in
     (decoS, decoH, decoM, decoT)
 
-
   val simple-deco =
     let (simple-deco, _, _, _) = simple-decoset in
     simple-deco
 
-
   val screen-decoset size ib-heading-raw =
     let lskip = size *' 0.125 in
     let ib-heading = inline-skip lskip ++ ib-heading-raw ++ inline-skip lskip in
-    let hwid = Pervasives.get-natural-width ib-heading in
+    let hwid = Inline.get-natural-advance ib-heading in
     let lshift = 10pt in
     let frame-stroke = stroke 1pt black in
     let decoS (x, y) wid hgt dpt =
@@ -345,7 +343,6 @@ module Head = struct
     let br = read-inline ctx inner in
     (inline-frame-breakable pads simple-decoset br)
 
-
   val paddings = (5pt, 5pt, 5pt, 5pt)
 
   val inline ctx \frame-inner it =
@@ -357,8 +354,7 @@ module Head = struct
   val inline ctx \frame-fixed wid it =
     inline-frame-fixed wid paddings simple-deco (read-inline ctx it)
 
-
-  val (+++>) = List.fold-left (+++)
+  val (+++>) = List.fold (+++)
 
   val item-indent = 16pt
 
@@ -378,7 +374,7 @@ module Head = struct
 
   val rec item (ctx : context) (depth : int) (Item(parent, children) : itemize) =
     let br-bullet = (inline-graphics 8pt 8pt 0pt bullet) ++ (inline-skip 8pt) in
-    let bullet-width = Pervasives.get-natural-width br-bullet in
+    let bullet-width = Inline.get-natural-advance br-bullet in
     let parent-indent = item-indent *' (float depth) in
     let br-parent =
       embed-block-top ctx ((get-text-width ctx) -' parent-indent -' bullet-width) (fun ctx ->
@@ -430,7 +426,7 @@ module Head = struct
         form-paragraph ctx ((inline-skip indent) ++ br-pbox)
       ))
     in
-      block-nil +++> bclst
+    block-nil +++> bclst
 
   val block ctx +description pairlst =
     description ctx pairlst
@@ -456,11 +452,11 @@ module Head = struct
     let chgt = 4pt in
     let r1 = 6pt in
     let r2 = 3pt in
-      inline-graphics wid 12pt 0pt (fun (x, y) -> (
-        let cx = x +' wid *' 0.5 in
-        let cy = y +' chgt in
-        fill (RGB(0.8, 0.5, 0.)) (donut-path (cx, cy) r1 r2)
-      ))
+    inline-graphics wid 12pt 0pt (fun (x, y) -> (
+      let cx = x +' wid *' 0.5 in
+      let cy = y +' chgt in
+      fill (RGB(0.8, 0.5, 0.)) (donut-path (cx, cy) r1 r2)
+    ))
 
   val inline ctx \donuts =
     let r1 = 6pt in
@@ -474,27 +470,7 @@ module Head = struct
       ]
     ))
 
-
   val kern len = inline-skip (0pt -' len)
-
-  val inline ctx \latex =
-    let size = get-font-size ctx in
-    let f = read-inline ctx in
-    let fA = ctx |> set-font-size (size *' 0.7)
-                 |> set-manual-rising (size *' 0.2)
-                 |> read-inline
-    in
-    let fE = ctx |> set-manual-rising (0pt -' (size *' 0.25))
-                 |> read-inline
-    in
-      f {L} ++ kern (size *' 0.2) ++ fA {A}
-        ++ f {T} ++ kern (size *' 0.125) ++ fE {E} ++ f {X}
-
-  val inline ctx \satysfi =
-    let size = get-font-size ctx in
-    let f = read-inline ctx in
-    let fd = ctx |> set-manual-rising (0pt -' (size *' 0.25)) |> read-inline in
-     f {SAT} ++ kern (size *' 0.15) ++ fd {Y} ++ f {SF} ++ kern (size *' 0.05) ++ fd {I}
 
   val inline ctx \raw-font-size font-size inner =
     read-inline (ctx |> set-font-size font-size) inner
@@ -512,7 +488,7 @@ module Head = struct
           |> close-with-line
       in
       let br = read-inline ctx {Sample Text} in
-      let wid-text = Pervasives.get-natural-width br in
+      let wid-text = Inline.get-natural-advance br in
       unite-graphics [
         draw-text (x, y) br,
         draw-text (x +' wid *' 0.5 -' wid-text *' 0.5, y +' 50pt) br,
@@ -571,16 +547,14 @@ module Head = struct
       use-image-by-width img wid
   end
 
-
   val inline ctx \fil =
     inline-fil
-
 
   val block ctx +code code =
     let pads = (5pt, 5pt, 5pt, 5pt) in
     block-frame-breakable ctx pads simple-decoset (fun ctx -> (
       let fontsize = get-font-size ctx in
-      let charwid = Pervasives.get-natural-width (read-inline ctx {0}) in
+      let charwid = Inline.get-natural-advance (read-inline ctx {0}) in
       let ctx-code =
         ctx |> set-latin-font font-latin-mono
             |> set-space-ratio (charwid /' fontsize) 0.08 0.16
@@ -588,7 +562,7 @@ module Head = struct
 
       let lst = split-into-lines code in
       let ib-code =
-        lst |> List.fold-left-adjacent (fun ibacc (i, s) _ optnext -> (
+        lst |> List.fold-adjacent (fun ibacc (i, s) _ optnext -> (
   %        let () = display-message (`+code: (` ^ (arabic i) ^ `)` ^ s) in
           let ib-last =
             match optnext with
@@ -607,14 +581,12 @@ module Head = struct
       line-break true true ctx ib-code
     ))
 
-
   val inline ctx \ruby itmain itruby =
     let fontsize = get-font-size ctx in
     let ctx-ruby = ctx |> set-font-size (fontsize *' 0.5) in
     let ibmain = inline-fil ++ (read-inline ctx itmain) ++ inline-fil in
     let ibruby = inline-fil ++ (read-inline ctx-ruby itruby) ++ inline-fil in
     line-stack-bottom [ibruby, ibmain]
-
 
   val inline ctx \ruby-both itmain itrubyT itrubyB =
     let fontsize = get-font-size ctx in

--- a/tests/local-fixed/show-value/src/show-value.satyh
+++ b/tests/local-fixed/show-value/src/show-value.satyh
@@ -2,5 +2,5 @@ use package open Stdlib
 
 module ShowValue = struct
   val inline \int-sum ns =
-    embed-string (arabic (List.fold-left (+) 0 ns))
+    embed-string (arabic (List.fold (+) 0 ns))
 end

--- a/tests/math-typefaces.saty
+++ b/tests/math-typefaces.saty
@@ -1,9 +1,8 @@
 use package open Stdlib
+use package open Stdlib.Logo
 use package open Math
 use package open Itemize
 use package open StdJaReport
-
-let open Pervasives in
 
 let block ctx +test-math-style name style =
   let it = embed-string name in

--- a/tests/refactor1.saty
+++ b/tests/refactor1.saty
@@ -7,15 +7,7 @@ use package FontLatinModernMath
 let font-latin-roman = (FontJunicode.normal, 1., 0.) in
 let font-cjk-mincho = (FontIpaEx.mincho, 0.88, 0.) in
 
-
-%let rec fold-left f i l =
-%  match l with
-%  | []      -> i
-%  | x :: xs -> fold-left f (f i x) xs
-%  end
-%in
-
-let sum = List.fold-left (+) 0 [3, 1, 4, 1, 5, 9, 2] in
+let sum = List.fold (+) 0 [3, 1, 4, 1, 5, 9, 2] in
 
 let f t y =
   if t == 0 then y else t + 2
@@ -27,8 +19,6 @@ let g p q =
   end
 in
 let s = arabic sum ^ `,` ^ arabic (f 0 42) ^ `,` ^ arabic (f 1 42) ^ `,` ^ arabic (g 0 42) ^ `,` ^ arabic (g 1 42) in
-
-%let inline ctx \math m = embed-math ctx (read-math ctx m) in
 let ctx =
   get-initial-context 400pt (command \math)
     |> set-font Kana           font-cjk-mincho
@@ -37,7 +27,7 @@ let ctx =
     |> set-font OtherScript    font-latin-roman
     |> set-math-font FontLatinModernMath.main
 in
-let paper-size = (210mm, 297mm) in %A4
+let paper-size = PaperSize.a4 in
 let pagecontf _ = (| text-origin = (20pt, 20pt), text-height = 600pt, |) in
 let pagepartsf _ = (| header-origin = (0pt, 0pt), header-content = block-nil, footer-origin = (0pt, 0pt), footer-content = block-nil, |) in
 


### PR DESCRIPTION
- Refine `Stdlib`’s interface
  * `List.fold-left` → `List.fold`, `List.fold-right` → `List.fold-back`, `List.mapi` → `List.mapi`, etc.
  * Decompose `Pervasives` into `Logo`, `Inline`, `Block`, `Ref`, etc.
  * Add `Map`, `Set`, etc.
- Fix signature matching about functor signatures
- Improve error reports about code positions on the failure of signature matching