### PR TITLE
Refine dump files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@
 /temp/*.zip
 /temp/tarballs/
 *.pdf
-*.satysfi-aux
+*.satysfi-aux.yaml
 /saphe
 /satysfi

--- a/bin/satysfi.ml
+++ b/bin/satysfi.ml
@@ -19,6 +19,7 @@ let build_document
   fpath_deps
   text_mode_formats_str_opt
   page_number_limit
+  max_repeats
   show_full_path
   debug_show_bbox
   debug_show_space
@@ -35,6 +36,7 @@ let build_document
     ~fpath_deps
     ~text_mode_formats_str_opt
     ~page_number_limit
+    ~max_repeats
     ~show_full_path
     ~debug_show_bbox
     ~debug_show_space
@@ -91,6 +93,12 @@ let flag_page_number_limit : int Cmdliner.Term.t =
   let open Cmdliner in
   let doc = "Set the page number limit (default: 10000)" in
   Arg.(value (opt int 10000 (info [ "page-number-limit" ] ~docv:"INT" ~doc)))
+
+
+let flag_max_repeats : int Cmdliner.Term.t =
+  let open Cmdliner in
+  let doc = "Set the limit of iteration for resolving cross-references (default: 4)" in
+  Arg.(value (opt int 4 (info [ "max-repeats" ] ~docv:"INT" ~doc)))
 
 
 let make_boolean_flag_spec ~(flags : string list) ~(doc : string) : bool Cmdliner.Term.t =
@@ -156,6 +164,7 @@ let command_build_document =
       $ flag_deps
       $ flag_text_mode
       $ flag_page_number_limit
+      $ flag_max_repeats
       $ flag_full_path
       $ flag_debug_show_bbox
       $ flag_debug_show_space

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -32,4 +32,4 @@ all:: $(TARGETS)
 promote:: $(EXPECTED_LOCKS)
 
 clean:
-	rm -f *.pdf *.satysfi-aux *.saphe.lock.yaml *.satysfi-deps.yaml
+	rm -f *.pdf *.satysfi-aux.yaml *.saphe.lock.yaml *.satysfi-deps.yaml

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -34,7 +34,7 @@ all:: $(TARGETS)
 promote:: $(EXPECTED_LOCKS)
 
 clean:
-	rm -f *.pdf *.satysfi-aux *.saphe.lock.yaml *.satysfi-deps.yaml
+	rm -f *.pdf *.satysfi-aux.yaml *.saphe.lock.yaml *.satysfi-deps.yaml
 
 doc-primitives.pdf: local-math.satyh local.satyh paren.satyh
 doc-lang.pdf: local-math.satyh

--- a/src-saphe/constant.ml
+++ b/src-saphe/constant.ml
@@ -97,4 +97,4 @@ let default_output_path ~doc:(abspath_doc : abs_path) : abs_path =
 
 let dump_path ~doc:(abspath_doc : abs_path) : abs_path =
   let path_without_extension = Filename.remove_extension (get_abs_path_string abspath_doc) in
-  make_abs_path (Printf.sprintf "%s.satysfi-aux" path_without_extension)
+  make_abs_path (Printf.sprintf "%s.satysfi-aux.yaml" path_without_extension)

--- a/src/backend/buildDocument.ml
+++ b/src/backend/buildDocument.ml
@@ -134,8 +134,8 @@ let build_document ~(max_repeats : int) (transform : syntactic_value -> 'a) (res
         return document
   in
   let* document = aux 1 in
-  CrossRef.write_dump_file abspath_dump;
   output abspath_out document;
+  let* () = CrossRef.write_dump_file abspath_dump in
   Logging.end_output display_config abspath_out;
   return ()
 

--- a/src/backend/buildDocument.mli
+++ b/src/backend/buildDocument.mli
@@ -8,6 +8,7 @@ val main :
   output_mode ->
   HandlePdf.config ->
   page_number_limit:int ->
+  max_repeats:int ->
   Logging.config ->
   is_bytecomp_mode:bool ->
   environment ->

--- a/src/backend/crossRef.ml
+++ b/src/backend/crossRef.ml
@@ -22,7 +22,7 @@ let main_hash_table = CrossRefHashTable.create 32
 let read_assoc (assoc : (string * YS.json) list) : unit =
   assoc |> List.iter (fun (key, vjson) ->
     let value = vjson |> YS.Util.to_string in
-    CrossRefHashTable.add main_hash_table key value
+    CrossRefHashTable.replace main_hash_table key value
   )
 
 
@@ -81,7 +81,7 @@ let register (key : string) (value : string) =
   match CrossRefHashTable.find_opt main_hash_table key with
   | None ->
       changed := true;
-      CrossRefHashTable.add main_hash_table key value
+      CrossRefHashTable.replace main_hash_table key value
 
   | Some(value_old) ->
       if String.equal value value_old then
@@ -89,7 +89,7 @@ let register (key : string) (value : string) =
       else
         begin
           changed := true;
-          CrossRefHashTable.add main_hash_table key value
+          CrossRefHashTable.replace main_hash_table key value
         end
 
 

--- a/src/backend/crossRef.mli
+++ b/src/backend/crossRef.mli
@@ -3,12 +3,15 @@ open MyUtil
 
 val initialize : abs_path -> bool
 
+val reset : unit -> unit
+
 type answer =
   | NeedsAnotherTrial
   | CanTerminate of string list
-  | CountMax
 
-val needs_another_trial : abs_path -> answer
+val judge_termination : unit -> answer
+
+val write_dump_file : abs_path -> unit
 
 val register : string -> string -> unit
 

--- a/src/backend/crossRef.mli
+++ b/src/backend/crossRef.mli
@@ -1,7 +1,8 @@
 
 open MyUtil
+open ConfigError
 
-val initialize : abs_path -> bool
+val initialize : abs_path -> (bool, config_error) result
 
 val reset : unit -> unit
 
@@ -11,7 +12,7 @@ type answer =
 
 val judge_termination : unit -> answer
 
-val write_dump_file : abs_path -> unit
+val write_dump_file : abs_path -> (unit, config_error) result
 
 val register : string -> string -> unit
 

--- a/src/frontend/configError.ml
+++ b/src/frontend/configError.ml
@@ -80,6 +80,8 @@ type config_error =
   | DepsConfigError           of abs_path * yaml_error
   | EnvelopeConfigNotFound    of abs_path
   | EnvelopeConfigError       of abs_path * yaml_error
+  | DumpFileError             of abs_path * yaml_error
+  | CannotWriteDumpFile       of abs_path
   | DependedEnvelopeNotFound  of envelope_name
   | MarkdownClassNotFound
   | NoMarkdownConversion

--- a/src/frontend/errorReporting.ml
+++ b/src/frontend/errorReporting.ml
@@ -821,6 +821,18 @@ let make_config_error_message (display_config : Logging.config) : config_error -
         DisplayLine(get_abs_path_string abspath_envelope_config);
       ] (make_yaml_error_message e))
 
+  | DumpFileError(abspath_dump, e) ->
+      make_error_message Interface (List.append [
+        NormalLine("failed to load a dump file (just removing it will remedy this):");
+        DisplayLine(get_abs_path_string abspath_dump);
+      ] (make_yaml_error_message e))
+
+  | CannotWriteDumpFile(abspath_dump) ->
+      make_error_message Interface [
+        NormalLine("cannot write a dump file:");
+        DisplayLine(get_abs_path_string abspath_dump);
+      ]
+
   | DependedEnvelopeNotFound(envelope_name) ->
       make_error_message Interface [
         NormalLine(Printf.sprintf "unknown depended envelope '%s'" envelope_name);

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -224,6 +224,7 @@ let build_document
     ~(fpath_deps : string)
     ~(text_mode_formats_str_opt : string option)
     ~(page_number_limit : int)
+    ~(max_repeats : int)
     ~(show_full_path : bool)
     ~(debug_show_bbox : bool)
     ~(debug_show_space : bool)
@@ -312,6 +313,7 @@ let open ResultMonad in
         display_config
         pdf_config
         ~page_number_limit
+        ~max_repeats
         ~is_bytecomp_mode
         output_mode
         ~run_tests:false

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -278,7 +278,7 @@ let open ResultMonad in
     Logging.target_file display_config abspath_out;
 
     (* Initializes the dump file: *)
-    let dump_file_exists = CrossRef.initialize abspath_dump in
+    let* dump_file_exists = CrossRef.initialize abspath_dump in
     Logging.dump_file display_config ~already_exists:dump_file_exists abspath_dump;
 
     (* Typechecks each depended envelope in the topological order: *)

--- a/src/frontend/main.mli
+++ b/src/frontend/main.mli
@@ -15,6 +15,7 @@ val build_document :
   fpath_deps:string ->
   text_mode_formats_str_opt:(string option) ->
   page_number_limit:int ->
+  max_repeats:int ->
   show_full_path:bool ->
   debug_show_bbox:bool ->
   debug_show_space:bool ->

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -67,7 +67,7 @@ promote::
 	(cd md; make promote)
 
 clean:: clean-init
-	rm -f *.saphe.lock.yaml *.satysfi-deps.yaml *.satysfi-aux *.pdf
+	rm -f *.saphe.lock.yaml *.satysfi-deps.yaml *.satysfi-aux.yaml *.pdf
 
 clean::
 	(cd images; make clean)
@@ -76,9 +76,9 @@ clean::
 
 clean-init::
 	rm -f $(INIT_DOC).saty $(INIT_DOC).saphe.yaml
-	rm -f $(INIT_DOC).saphe.lock.yaml $(INIT_DOC).satysfi-deps.yaml $(INIT_DOC).satysfi-aux $(INIT_DOC).pdf
+	rm -f $(INIT_DOC).saphe.lock.yaml $(INIT_DOC).satysfi-deps.yaml $(INIT_DOC).satysfi-aux.yaml $(INIT_DOC).pdf
 	rm -f $(INIT_MD).md $(INIT_MD).saphe.yaml
-	rm -f $(INIT_MD).saphe.lock.yaml $(INIT_MD).satysfi-deps.yaml $(INIT_MD).satysfi-aux $(INIT_MD).pdf
+	rm -f $(INIT_MD).saphe.lock.yaml $(INIT_MD).satysfi-deps.yaml $(INIT_MD).satysfi-aux.yaml $(INIT_MD).pdf
 	rm -rf $(INIT_LIB)
 	rm -f $(LOCAL_FIXED).saphe.lock.yaml
 

--- a/tests/images/Makefile
+++ b/tests/images/Makefile
@@ -32,4 +32,4 @@ all:: $(TARGETS)
 promote:: $(EXPECTED_LOCKS)
 
 clean:
-	rm -f *.pdf *.satysfi-aux *.saphe.lock.yaml *.satysfi-deps.yaml
+	rm -f *.pdf *.satysfi-aux.yaml *.saphe.lock.yaml *.satysfi-deps.yaml

--- a/tests/md/Makefile
+++ b/tests/md/Makefile
@@ -32,4 +32,4 @@ all:: $(TARGETS)
 promote:: $(EXPECTED_LOCKS)
 
 clean:
-	rm -f *.pdf *.satysfi-aux *.saphe.lock.yaml *.satysfi-deps.yaml
+	rm -f *.pdf *.satysfi-aux.yaml *.saphe.lock.yaml *.satysfi-deps.yaml

--- a/tests/text_mode/Makefile
+++ b/tests/text_mode/Makefile
@@ -32,6 +32,6 @@ all:: $(TARGETS)
 promote:: $(EXPECTED_LOCKS)
 
 clean:
-	rm -f *.pdf *.dvi *.log *.fls *.fdb_latexmk *.synctex.gz *.tex *.satysfi-aux *.saphe.lock.yaml *.satysfi-deps.yaml
+	rm -f *.pdf *.dvi *.log *.fls *.fdb_latexmk *.synctex.gz *.tex *.satysfi-aux.yaml *.saphe.lock.yaml *.satysfi-deps.yaml
 
 test.saty: head.satyh-latex


### PR DESCRIPTION
- Replace YOJSON `foo.satysfi-aux` with YAML `foo.satysfi-aux.yaml` for the dump file format
- Fix a bug about key duplication
- Add option `--max-repeats` for specifying the maximum number of iteration for resolving cross-references