### PR TITLE
Modify cache file organization and add subcommand `saphe cache list`

### DIFF
--- a/bin-saphe/saphe.ml
+++ b/bin-saphe/saphe.ml
@@ -7,6 +7,10 @@ let init_library fpath_in =
   SapheMain.init_library ~fpath_in
 
 
+let cache_list () =
+  SapheMain.cache_list ()
+
+
 let update fpath_in =
   SapheMain.update ~fpath_in
 
@@ -185,6 +189,19 @@ let command_test : unit Cmdliner.Cmd.t =
     )
 
 
+let command_cache_list : unit Cmdliner.Cmd.t =
+  let open Cmdliner in
+  Cmd.v (Cmd.info "list")
+    Term.(const cache_list $ const ())
+
+
+let command_cache : unit Cmdliner.Cmd.t =
+  let open Cmdliner in
+  Cmd.group (Cmd.info "cache") [
+    command_cache_list;
+  ]
+
+
 let () =
   let open Cmdliner in
   let info : Cmd.info =
@@ -197,6 +214,7 @@ let () =
       command_solve;
       command_build;
       command_test;
+      command_cache;
     ]
   in
   Stdlib.exit (Cmd.eval (Cmd.group info subcommands))

--- a/src-saphe/configError.ml
+++ b/src-saphe/configError.ml
@@ -168,3 +168,7 @@ type config_error =
       from_filename : SemanticVersion.t;
       from_content  : SemanticVersion.t;
     }
+  | CannotReadDirectory of {
+      path    : abs_path;
+      message : string;
+    }

--- a/src-saphe/constant.ml
+++ b/src-saphe/constant.ml
@@ -45,6 +45,10 @@ let lock_tarball_cache_directory ~store_root:(absdir_store_root : abs_path) (reg
   append_to_abs_directory absdir_store_root (Printf.sprintf "cache/locks/%s" registry_hash_value)
 
 
+let external_resource_cache_directory ~store_root:(absdir_store_root : abs_path) (registry_hash_value : registry_hash_value) : abs_path =
+  append_to_abs_directory absdir_store_root (Printf.sprintf "cache/external_resources/%s" registry_hash_value)
+
+
 let store_root_config_path ~store_root:(absdir_store_root : abs_path) : abs_path =
   append_to_abs_directory absdir_store_root "saphe-store-root.yaml"
 

--- a/src-saphe/constant.ml
+++ b/src-saphe/constant.ml
@@ -38,9 +38,7 @@ let registered_lock_envelope_config ~(store_root : abs_path) (reglock : Register
 
 
 let registry_root_directory_path ~store_root:(absdir_store_root : abs_path) (registry_hash_value : registry_hash_value) : abs_path =
-  make_abs_path (Filename.concat
-    (get_abs_path_string absdir_store_root)
-    (Printf.sprintf "registries/%s" registry_hash_value))
+  append_to_abs_directory absdir_store_root (Printf.sprintf "registries/%s" registry_hash_value)
 
 
 let lock_tarball_cache_directory ~store_root:(absdir_store_root : abs_path) (registry_hash_value : registry_hash_value) : abs_path =
@@ -48,7 +46,7 @@ let lock_tarball_cache_directory ~store_root:(absdir_store_root : abs_path) (reg
 
 
 let store_root_config_path ~store_root:(absdir_store_root : abs_path) : abs_path =
-  make_abs_path (Filename.concat (get_abs_path_string absdir_store_root) "saphe-store-root.yaml")
+  append_to_abs_directory absdir_store_root "saphe-store-root.yaml"
 
 
 let package_registry_config_path ~registry_dir:(absdir_registry_repo : abs_path) : abs_path =
@@ -64,7 +62,7 @@ let release_config_extension =
 
 
 let library_package_config_path ~dir:(absdir_library : abs_path) : abs_path =
-  make_abs_path (Filename.concat (get_abs_path_string absdir_library) "saphe.yaml")
+  append_to_abs_directory absdir_library "saphe.yaml"
 
 
 let document_package_config_path ~doc:(abspath_doc : abs_path) : abs_path =
@@ -73,11 +71,11 @@ let document_package_config_path ~doc:(abspath_doc : abs_path) : abs_path =
 
 
 let library_lock_config_path ~dir:(absdir_library : abs_path) : abs_path =
-  make_abs_path (Filename.concat (get_abs_path_string absdir_library) "saphe.lock.yaml")
+  append_to_abs_directory absdir_library "saphe.lock.yaml"
 
 
 let library_deps_config_path ~dir:(absdir_library : abs_path) : abs_path =
-  make_abs_path (Filename.concat (get_abs_path_string absdir_library) "satysfi-deps.yaml")
+  append_to_abs_directory absdir_library "satysfi-deps.yaml"
 
 
 let document_lock_config_path ~doc:(abspath_doc : abs_path) : abs_path =

--- a/src-saphe/lockFetcher.ml
+++ b/src-saphe/lockFetcher.ml
@@ -49,7 +49,7 @@ let extract_external_zip ~(unzip_command : string) ~(zip : abs_path) ~(output_co
     err @@ FailedToExtractExternalZip{ exit_status; command }
 
 
-let fetch_registered_lock ~(wget_command : string) ~(tar_command : string) ~(unzip_command : string) ~store_root:(absdir_store_root : abs_path) (reglock : RegisteredLock.t) (source : implementation_source) : unit ok =
+let fetch_registered_lock ~(wget_command : string) ~(tar_command : string) ~store_root:(absdir_store_root : abs_path) (reglock : RegisteredLock.t) (source : implementation_source) : unit ok =
   let open ResultMonad in
   let RegisteredLock.{ registered_package_id; locked_version } = reglock in
   let RegisteredPackageId.{ registry_hash_value; package_name } = registered_package_id in
@@ -70,7 +70,7 @@ let fetch_registered_lock ~(wget_command : string) ~(tar_command : string) ~(unz
   (* If the lock has already been fetched: *)
     Logging.lock_already_installed lock_tarball_name absdir_lock;
     return ()
-  end else begin
+  end else
     match source with
     | NoSource ->
         return ()
@@ -112,81 +112,130 @@ let fetch_registered_lock ~(wget_command : string) ~(tar_command : string) ~(unz
             ~tar_command ~lock_name:lock_tarball_name ~tarball:abspath_tarball ~lock_root:absdir_lock
         in
 
-        (* Fetches external resources according to the package config: *)
-        let* PackageConfig.{ external_resources; _ } =
-          PackageConfig.load (Constant.library_package_config_path ~dir:absdir_lock)
-        in
-        let* () =
-          external_resources |> foldM (fun () (name, external_resource) ->
-            match external_resource with
-            | ExternalZip{ url; checksum = checksum_expected; extractions } ->
-                let absdir_external =
-                  append_to_abs_directory
-                    (Constant.external_resource_cache_directory ~store_root:absdir_store_root registry_hash_value)
-                    lock_tarball_name
-                in
-
-                (* Creates a directory for putting zips: *)
-                ShellCommand.mkdir_p (append_to_abs_directory absdir_external "archives");
-
-                (* Fetches the zip file: *)
-                let abspath_zip =
-                  append_to_abs_directory absdir_external (Printf.sprintf "archives/%s.zip" name)
-                in
-                let* () = fetch_external_zip ~wget_command ~url ~output:abspath_zip in
-
-                (* Checks the fetched file by using checksum: *)
-                let* () =
-                  let checksum_got = Digest.to_hex (Digest.file (get_abs_path_string abspath_zip)) in
-                  if String.equal checksum_got checksum_expected then
-                    return ()
-                  else
-                    err @@ ExternalZipChecksumMismatch{
-                      url;
-                      path     = abspath_zip;
-                      expected = checksum_expected;
-                      got      = checksum_got;
-                    }
-                in
-
-                (* Creates a directory for putting extracted files: *)
-                let absdir_extraction =
-                  append_to_abs_directory absdir_external (Printf.sprintf "extractions/%s" name)
-                in
-                ShellCommand.mkdir_p absdir_extraction;
-
-                (* Extracts the zip file: *)
-                let* () =
-                  extract_external_zip
-                    ~unzip_command ~zip:abspath_zip ~output_container_dir:absdir_extraction
-                in
-
-                (* Copies files: *)
-                let* () =
-                  extractions |> foldM (fun () extraction ->
-                    let { extracted_from; extracted_to } = extraction in
-                    let abspath_from =
-                      append_to_abs_directory absdir_extraction extracted_from
-                    in
-                    let abspath_to =
-                      append_to_abs_directory absdir_lock extracted_to
-                    in
-                    let ShellCommand.{ exit_status; command } =
-                      ShellCommand.cp ~from:abspath_from ~to_:abspath_to
-                    in
-                    if exit_status = 0 then
-                      return ()
-                    else
-                      err @@ FailedToCopyFile{ exit_status; command }
-                  ) ()
-                in
-
-                return ()
-          ) ()
-        in
-
         return ()
+
+
+let fetch_external_zip_if_nonexistent ~(wget_command : string) (abspath_zip : abs_path) ~(url : string) ~checksum:(checksum_expected : string) =
+  let open ResultMonad in
+  if file_exists abspath_zip then
+    (* Does nothing if the required zip file has already been fetched: *)
+    return ()
+  else begin
+    (* Creates a directory for putting zips: *)
+    ShellCommand.mkdir_p (dirname abspath_zip);
+
+    (* Fetches the zip file: *)
+    let* () = fetch_external_zip ~wget_command ~url ~output:abspath_zip in
+
+    (* Checks the fetched file by using checksum: *)
+    let checksum_got = Digest.to_hex (Digest.file (get_abs_path_string abspath_zip)) in
+    if String.equal checksum_got checksum_expected then
+      return ()
+    else
+      err @@ ExternalZipChecksumMismatch{
+        url;
+        path     = abspath_zip;
+        expected = checksum_expected;
+        got      = checksum_got;
+      }
   end
+
+
+type extraction_abs_path_pair = {
+  abspath_from : abs_path;
+  abspath_to   : abs_path;
+}
+
+
+let extract_external_zip_and_arrange_files_if_necessary ~(unzip_command : string) ~zip_path:(abspath_zip : abs_path) ~extraction_dir:(absdir_extraction : abs_path) ~destination_lock_dir:(absdir_lock : abs_path) (extractions : extraction list) =
+  let open ResultMonad in
+
+  let pairs =
+    extractions |> List.map (fun extraction ->
+      let { extracted_from; extracted_to } = extraction in
+      let abspath_from = append_to_abs_directory absdir_extraction extracted_from in
+      let abspath_to = append_to_abs_directory absdir_lock extracted_to in
+      { abspath_from; abspath_to }
+    )
+  in
+
+  if pairs |> List.for_all (fun { abspath_to; _ } -> file_exists abspath_to) then
+    return ()
+  else begin
+
+    (* Creates a directory for putting extracted files: *)
+    ShellCommand.mkdir_p absdir_extraction;
+
+    (* Extracts the zip file: *)
+    let* () =
+      extract_external_zip
+        ~unzip_command ~zip:abspath_zip ~output_container_dir:absdir_extraction
+    in
+
+    (* Copies files: *)
+    pairs |> foldM (fun () { abspath_from; abspath_to } ->
+      let ShellCommand.{ exit_status; command } =
+        ShellCommand.cp ~from:abspath_from ~to_:abspath_to
+      in
+      if exit_status = 0 then
+        return ()
+      else
+        err @@ FailedToCopyFile{ exit_status; command }
+    ) ()
+  end
+
+
+let fetch_external_resources ~(wget_command : string) ~(unzip_command : string) ~store_root:(absdir_store_root : abs_path) (reglock : RegisteredLock.t) =
+  let open ResultMonad in
+  let RegisteredLock.{ registered_package_id; locked_version } = reglock in
+  let RegisteredPackageId.{ registry_hash_value; package_name } = registered_package_id in
+  let lock_tarball_name = Constant.lock_tarball_name package_name locked_version in
+  let absdir_lock = Constant.registered_lock_directory ~store_root:absdir_store_root reglock in
+
+  (* Loads the package config: *)
+  let* PackageConfig.{ external_resources; _ } =
+    PackageConfig.load (Constant.library_package_config_path ~dir:absdir_lock)
+  in
+  let* () =
+    external_resources |> foldM (fun () (name, external_resource) ->
+      match external_resource with
+      | ExternalZip{ url; checksum; extractions } ->
+          let absdir_external =
+            append_to_abs_directory
+              (Constant.external_resource_cache_directory ~store_root:absdir_store_root registry_hash_value)
+              lock_tarball_name
+          in
+
+          (* Fetches the external zip file if nonexistent: *)
+          let abspath_zip =
+            append_to_abs_directory absdir_external (Printf.sprintf "archives/%s.zip" name)
+          in
+          let* () =
+            fetch_external_zip_if_nonexistent
+              ~wget_command
+              abspath_zip
+              ~url
+              ~checksum
+          in
+
+          (* Extracts the external zip file if some of the resulting files are nonexistent: *)
+          let absdir_extraction =
+            append_to_abs_directory absdir_external (Printf.sprintf "extractions/%s" name)
+          in
+          let* () =
+            extract_external_zip_and_arrange_files_if_necessary
+              ~unzip_command
+              ~zip_path:abspath_zip
+              ~extraction_dir:absdir_extraction
+              ~destination_lock_dir:absdir_lock
+              extractions
+          in
+
+          return ()
+    ) ()
+  in
+
+  return ()
 
 
 let main ~(wget_command : string) ~(tar_command : string) ~(unzip_command : string) ~(store_root : abs_path) (impl_spec : implementation_spec) : unit ok =
@@ -194,13 +243,23 @@ let main ~(wget_command : string) ~(tar_command : string) ~(unzip_command : stri
   let ImplSpec{ lock; source } = impl_spec in
   match lock with
   | Lock.Registered(reglock) ->
-      fetch_registered_lock
-        ~wget_command
-        ~tar_command
-        ~unzip_command
-        ~store_root
-        reglock
-        source
+      let* () =
+        fetch_registered_lock
+          ~wget_command
+          ~tar_command
+          ~store_root
+          reglock
+          source
+      in
+      let* () =
+        fetch_external_resources
+          ~wget_command
+          ~unzip_command
+          ~store_root
+          reglock
+      in
+      return ()
 
   | Lock.LocalFixed(_) ->
+      (* TODO: Use `fetch_external_resources` here *)
       return ()

--- a/src-saphe/lockFetcher.ml
+++ b/src-saphe/lockFetcher.ml
@@ -123,14 +123,13 @@ let fetch_registered_lock ~(wget_command : string) ~(tar_command : string) ~(unz
 
                 (* Creates a directory for putting zips: *)
                 let absdir_external =
-                  make_abs_path (Filename.concat (get_abs_path_string absdir_lock_tarball_cache) lock_tarball_name)
+                  append_to_abs_directory absdir_lock_tarball_cache lock_tarball_name
                 in
                 ShellCommand.mkdir_p absdir_external;
 
                 (* Fetches the zip file: *)
                 let abspath_zip =
-                  make_abs_path
-                    (Filename.concat (get_abs_path_string absdir_external) (Printf.sprintf "%s.zip" name))
+                  append_to_abs_directory absdir_external (Printf.sprintf "%s.zip" name)
                 in
                 let* () = fetch_external_zip ~wget_command ~url ~output:abspath_zip in
 
@@ -159,12 +158,10 @@ let fetch_registered_lock ~(wget_command : string) ~(tar_command : string) ~(unz
                   extractions |> foldM (fun () extraction ->
                     let { extracted_from; extracted_to } = extraction in
                     let abspath_from =
-                      make_abs_path
-                        (Filename.concat (get_abs_path_string absdir_external) extracted_from)
+                      append_to_abs_directory absdir_external extracted_from
                     in
                     let abspath_to =
-                      make_abs_path
-                        (Filename.concat (get_abs_path_string absdir_lock) extracted_to)
+                      append_to_abs_directory absdir_lock extracted_to
                     in
                     let ShellCommand.{ exit_status; command } =
                       ShellCommand.cp ~from:abspath_from ~to_:abspath_to

--- a/src-saphe/lockFetcher.ml
+++ b/src-saphe/lockFetcher.ml
@@ -66,7 +66,7 @@ let fetch_registered_lock ~(wget_command : string) ~(tar_command : string) ~(unz
   ShellCommand.mkdir_p absdir_lock;
 
   let abspath_config = Constant.library_package_config_path ~dir:absdir_lock in
-  if Sys.file_exists (get_abs_path_string abspath_config) then begin
+  if file_exists abspath_config then begin
   (* If the lock has already been fetched: *)
     Logging.lock_already_installed lock_tarball_name absdir_lock;
     return ()
@@ -78,13 +78,11 @@ let fetch_registered_lock ~(wget_command : string) ~(tar_command : string) ~(unz
     | TarGzip{ url; checksum } ->
         (* Synchronously fetches a tarball (if non-existent): *)
         let abspath_tarball =
-          make_abs_path
-            (Filename.concat
-              (get_abs_path_string absdir_lock_tarball_cache)
-              (Printf.sprintf "%s.tar.gz" lock_tarball_name))
+          append_to_abs_directory absdir_lock_tarball_cache
+            (Printf.sprintf "%s.tar.gz" lock_tarball_name)
         in
         let* () =
-          if Sys.file_exists (get_abs_path_string abspath_tarball) then begin
+          if file_exists abspath_tarball then begin
             Logging.lock_cache_exists lock_tarball_name abspath_tarball;
             return ()
           end else begin

--- a/src-saphe/lockFetcher.ml
+++ b/src-saphe/lockFetcher.ml
@@ -76,7 +76,7 @@ let fetch_registered_lock ~(wget_command : string) ~(tar_command : string) ~(unz
         return ()
 
     | TarGzip{ url; checksum } ->
-        (* Synchronously fetches a tarball: *)
+        (* Synchronously fetches a tarball (if non-existent): *)
         let abspath_tarball =
           make_abs_path
             (Filename.concat
@@ -114,7 +114,7 @@ let fetch_registered_lock ~(wget_command : string) ~(tar_command : string) ~(unz
             ~tar_command ~lock_name:lock_tarball_name ~tarball:abspath_tarball ~lock_root:absdir_lock
         in
 
-        (* Fetches external sources according to the package config: *)
+        (* Fetches external resources according to the package config: *)
         let* PackageConfig.{ external_resources; _ } =
           PackageConfig.load (Constant.library_package_config_path ~dir:absdir_lock)
         in

--- a/src-saphe/packageRegistryFetcher.ml
+++ b/src-saphe/packageRegistryFetcher.ml
@@ -24,7 +24,7 @@ let main ~(do_update : bool) ~(git_command : string) (absdir_registry_repo : abs
   let abspath_registry_config = Constant.package_registry_config_path ~registry_dir:absdir_registry_repo in
   match registry_remote with
   | GitRegistry{ url; branch } ->
-      if Sys.file_exists (get_abs_path_string abspath_registry_config) then
+      if file_exists abspath_registry_config then
         if do_update then
           let ShellCommand.{ exit_status; command } =
             ShellCommand.run_git_pull ~git_command ~repo_dir:absdir_registry_repo ~url ~branch

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -1429,18 +1429,18 @@ let cache_list () =
       let res = readdir absdir_external_resource_cache in
       continue_if_ok res (fun dirs ->
         dirs |> List.sort String.compare |> List.iter (fun dir ->
-          let abspath =
-            append_to_abs_directory
-              (append_to_abs_directory absdir_external_resource_cache dir)
-              "archives"
-          in
+          let abspath = append_to_abs_directory absdir_external_resource_cache dir in
+          let abspath_archives = append_to_abs_directory abspath "archives" in
           if is_directory abspath then
-            let res = readdir abspath in
-            continue_if_ok res (fun archive_filenames ->
-              archive_filenames |> List.sort String.compare |> List.iter (fun archive_filename ->
-                Printf.printf "  - %s\n" archive_filename
+            if is_directory abspath_archives then
+              let res = readdir abspath_archives in
+              continue_if_ok res (fun archive_filenames ->
+                archive_filenames |> List.sort String.compare |> List.iter (fun archive_filename ->
+                  Printf.printf "  - %s\n" archive_filename
+                )
               )
-            )
+            else
+              () (* TODO (error): report that `archives` is not a directory *)
           else
             () (* TODO (warning): warn the existence of (non-directory) files *)
         )
@@ -1456,18 +1456,18 @@ let cache_list () =
       let res = readdir absdir_external_resource_cache in
       continue_if_ok res (fun dirs ->
         dirs |> List.sort String.compare |> List.iter (fun dir ->
-          let abspath =
-            append_to_abs_directory
-              (append_to_abs_directory absdir_external_resource_cache dir)
-              "extractions"
-          in
+          let abspath = append_to_abs_directory absdir_external_resource_cache dir in
+          let abspath_extractions = append_to_abs_directory abspath "extractions" in
           if is_directory abspath then
-            let res = readdir abspath in
-            continue_if_ok res (fun extraction_dirs ->
-              extraction_dirs |> List.sort String.compare |> List.iter (fun extraction_dir ->
-                Printf.printf "  - %s\n" extraction_dir
+            if is_directory abspath_extractions then
+              let res = readdir abspath_extractions in
+              continue_if_ok res (fun extraction_dirs ->
+                extraction_dirs |> List.sort String.compare |> List.iter (fun extraction_dir ->
+                  Printf.printf "  - %s\n" extraction_dir
+                )
               )
-            )
+            else
+              () (* TODO (error): report that `extractions` is not a directory *)
           else
             () (* TODO (warning): warn the existence of (non-directory) files *)
         )

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -1430,20 +1430,23 @@ let cache_list () =
 
       | Ok(dirs) ->
           dirs |> List.sort String.compare |> List.iter (fun dir ->
-            let res =
-              readdir
-                (append_to_abs_directory
-                  (append_to_abs_directory absdir_external_resource_cache dir)
-                  "archives")
+            let abspath =
+              append_to_abs_directory
+                (append_to_abs_directory absdir_external_resource_cache dir)
+                "archives"
             in
-            match res with
-            | Error(_) ->
-                ()
+            if is_directory abspath then
+              let res = readdir abspath in
+              match res with
+              | Error(_) ->
+                  ()
 
-            | Ok(archive_filenames) ->
-                archive_filenames |> List.sort String.compare |> List.iter (fun filename ->
-                  Printf.printf "  - %s\n" filename
-                )
+              | Ok(archive_filenames) ->
+                  archive_filenames |> List.sort String.compare |> List.iter (fun archive_filename ->
+                    Printf.printf "  - %s\n" archive_filename
+                  )
+            else
+              () (* TODO (warning): warn the existence of (non-directory) files *)
           )
     ) registries ();
 

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -709,7 +709,7 @@ let write_initial_file (abspath : abs_path) ~(data : string) =
 
 let assert_nonexistence (abspath : abs_path) =
   let open ResultMonad in
-  if Sys.file_exists (get_abs_path_string abspath) then
+  if file_exists abspath then
     err @@ FileAlreadyExists{ path = abspath }
   else
     return ()

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -1435,14 +1435,20 @@ let cache_list () =
             if is_directory abspath_archives then
               let res = readdir abspath_archives in
               continue_if_ok res (fun archive_filenames ->
-                archive_filenames |> List.sort String.compare |> List.iter (fun archive_filename ->
-                  Printf.printf "  - %s\n" archive_filename
-                )
+                match archive_filenames with
+                | [] ->
+                    ()
+
+                | _ :: _ ->
+                    Printf.printf "  - %s\n" dir;
+                    archive_filenames |> List.sort String.compare |> List.iter (fun archive_filename ->
+                      Printf.printf "    - %s\n" archive_filename
+                    )
               )
             else
               () (* TODO (error): report that `archives` is not a directory *)
           else
-            () (* TODO (warning): warn the existence of (non-directory) files *)
+            () (* TODO (warning): warn the existence of (non-directory) files, if any *)
         )
       )
     ) registries ();
@@ -1462,14 +1468,20 @@ let cache_list () =
             if is_directory abspath_extractions then
               let res = readdir abspath_extractions in
               continue_if_ok res (fun extraction_dirs ->
-                extraction_dirs |> List.sort String.compare |> List.iter (fun extraction_dir ->
-                  Printf.printf "  - %s\n" extraction_dir
-                )
+                match extraction_dirs with
+                | [] ->
+                    ()
+
+                | _ :: _ ->
+                    Printf.printf "  - %s\n" dir;
+                    extraction_dirs |> List.sort String.compare |> List.iter (fun extraction_dir ->
+                      Printf.printf "    - %s\n" extraction_dir
+                    )
               )
             else
               () (* TODO (error): report that `extractions` is not a directory *)
           else
-            () (* TODO (warning): warn the existence of (non-directory) files *)
+            () (* TODO (warning): warn the existence of (non-directory) files, if any *)
         )
       )
     ) registries ();

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -1394,7 +1394,14 @@ let cache_list () =
 
     let StoreRootConfig.{ registries } = store_root_config in
     RegistryHashValueMap.fold (fun registry_hash_value (GitRegistry { url; branch }) () ->
-      Printf.printf "- %s (Git repository URL: %s, branch: %s)\n" registry_hash_value url branch
+      Printf.printf "- %s (Git URL: %s, branch: %s)\n" registry_hash_value url branch;
+      let absdir_lock_tarball_cache =
+        Constant.lock_tarball_cache_directory ~store_root:absdir_store_root registry_hash_value
+      in
+      let filenames = readdir absdir_lock_tarball_cache in
+      filenames |> List.sort String.compare |> List.iter (fun filename ->
+        Printf.printf "  - %s\n" filename
+      )
     ) registries ();
 
     return ()

--- a/src-saphe/sapheMain.mli
+++ b/src-saphe/sapheMain.mli
@@ -1,0 +1,31 @@
+
+val version : string
+
+val init_document : fpath_in:string -> unit
+
+val init_library : fpath_in:string -> unit
+
+val solve : fpath_in:string -> unit
+
+val update : fpath_in:string -> unit
+
+val build :
+  fpath_in:string ->
+  fpath_out_opt:(string option) ->
+  text_mode_formats_str_opt:(string option) ->
+  page_number_limit:int ->
+  debug_show_bbox:bool ->
+  debug_show_space:bool ->
+  debug_show_block_bbox:bool ->
+  debug_show_block_space:bool ->
+  debug_show_overfull:bool ->
+  type_check_only:bool ->
+  bytecomp:bool ->
+  unit
+
+val test :
+  fpath_in:string ->
+  text_mode_formats_str_opt:(string option) ->
+  unit
+
+val cache_list : unit -> unit

--- a/src-util/myUtil.ml
+++ b/src-util/myUtil.ml
@@ -81,6 +81,10 @@ let basename (abspath : abs_path) : string =
   Filename.basename (get_abs_path_string abspath)
 
 
+let readdir (absdir : abs_path) : string list =
+  Sys.readdir (get_abs_path_string absdir) |> Array.to_list
+
+
 let read_file (abspath : abs_path) : (string, string) result =
   let open ResultMonad in
   try

--- a/src-util/myUtil.ml
+++ b/src-util/myUtil.ml
@@ -113,6 +113,10 @@ let is_directory (abspath : abs_path) : bool =
   Sys.is_directory (get_abs_path_string abspath)
 
 
+let file_exists (abspath : abs_path) : bool =
+  Sys.file_exists (get_abs_path_string abspath)
+
+
 let encode_yaml (yaml : Yaml.value) : string =
   match Yaml.to_string ~encoding:`Utf8 ~layout_style:`Block ~scalar_style:`Plain yaml with
   | Ok(data) -> data

--- a/src-util/myUtil.ml
+++ b/src-util/myUtil.ml
@@ -81,8 +81,13 @@ let basename (abspath : abs_path) : string =
   Filename.basename (get_abs_path_string abspath)
 
 
-let readdir (absdir : abs_path) : string list =
-  Sys.readdir (get_abs_path_string absdir) |> Array.to_list
+let readdir (absdir : abs_path) : (string list, string) result =
+  let open ResultMonad in
+  try
+    return (Sys.readdir (get_abs_path_string absdir) |> Array.to_list)
+  with
+  | Sys_error(s) ->
+      err s
 
 
 let read_file (abspath : abs_path) : (string, string) result =

--- a/src-util/myUtil.ml
+++ b/src-util/myUtil.ml
@@ -110,7 +110,12 @@ let write_file (abspath : abs_path) (data : string) : (unit, string) result =
 
 
 let is_directory (abspath : abs_path) : bool =
-  Sys.is_directory (get_abs_path_string abspath)
+  try
+    Sys.is_directory (get_abs_path_string abspath)
+  with
+  | Sys_error(_) ->
+      false
+        (* Exceptions are raised when `dirname abspath` is not a directory. *)
 
 
 let file_exists (abspath : abs_path) : bool =

--- a/src-util/myUtil.mli
+++ b/src-util/myUtil.mli
@@ -36,6 +36,8 @@ val dirname : abs_path -> abs_path
 
 val basename : abs_path -> string
 
+val readdir : abs_path -> string list
+
 val is_directory : abs_path -> bool
 
 val encode_yaml : Yaml.value -> string

--- a/src-util/myUtil.mli
+++ b/src-util/myUtil.mli
@@ -36,7 +36,7 @@ val dirname : abs_path -> abs_path
 
 val basename : abs_path -> string
 
-val readdir : abs_path -> string list
+val readdir : abs_path -> (string list, string) result
 
 val is_directory : abs_path -> bool
 

--- a/src-util/myUtil.mli
+++ b/src-util/myUtil.mli
@@ -40,6 +40,8 @@ val readdir : abs_path -> (string list, string) result
 
 val is_directory : abs_path -> bool
 
+val file_exists : abs_path -> bool
+
 val encode_yaml : Yaml.value -> string
 
 val read_file : abs_path -> (string, string) result

--- a/src/frontend/configError.ml
+++ b/src/frontend/configError.ml
@@ -86,3 +86,7 @@ type config_error =
   | MarkdownClassNotFound
   | NoMarkdownConversion
   | MarkdownError             of MarkdownParser.error
+  | CannotReadDirectory of {
+      path    : abs_path;
+      message : string;
+    }

--- a/src/frontend/envelopeReader.ml
+++ b/src/frontend/envelopeReader.ml
@@ -9,7 +9,7 @@ type 'a ok = ('a, config_error) result
 
 
 let listup_sources_in_directory (extensions : string list) (absdir_src : abs_path) : abs_path list =
-  let filenames = Sys.readdir (get_abs_path_string absdir_src) |> Array.to_list in
+  let filenames = readdir absdir_src in
   filenames |> List.filter_map (fun filename ->
     if extensions |> List.exists (fun suffix -> Core.String.is_suffix filename ~suffix) then
       Some(make_abs_path (Filename.concat (get_abs_path_string absdir_src) filename))

--- a/src/frontend/envelopeReader.ml
+++ b/src/frontend/envelopeReader.ml
@@ -8,14 +8,21 @@ open ConfigError
 type 'a ok = ('a, config_error) result
 
 
-let listup_sources_in_directory (extensions : string list) (absdir_src : abs_path) : abs_path list =
-  let filenames = readdir absdir_src in
-  filenames |> List.filter_map (fun filename ->
-    if extensions |> List.exists (fun suffix -> Core.String.is_suffix filename ~suffix) then
-      Some(make_abs_path (Filename.concat (get_abs_path_string absdir_src) filename))
-    else
-      None
-  )
+let listup_sources_in_directory (extensions : string list) (absdir_src : abs_path) : (abs_path list) ok =
+  let open ResultMonad in
+  let* filenames =
+    readdir absdir_src
+      |> Result.map_error (fun message -> CannotReadDirectory{ path = absdir_src; message })
+  in
+  let abspaths =
+    filenames |> List.filter_map (fun filename ->
+      if extensions |> List.exists (fun suffix -> Core.String.is_suffix filename ~suffix) then
+        Some(make_abs_path (Filename.concat (get_abs_path_string absdir_src) filename))
+      else
+        None
+    )
+  in
+  return abspaths
 
 
 let main (display_config : Logging.config) ~(use_test_files : bool) ~(extensions : string list) ~envelope_config:(abspath_envelope_config : abs_path) : (EnvelopeConfig.t * untyped_envelope) ok =
@@ -28,14 +35,18 @@ let main (display_config : Logging.config) ~(use_test_files : bool) ~(extensions
     match config.envelope_contents with
     | Library{ main_module_name; source_directories; test_directories; _ } ->
         let absdirs_src = source_directories |> List.map (append_to_abs_directory absdir_envelope) in
-        let abspaths_src = absdirs_src |> List.map (listup_sources_in_directory extensions) |> List.concat in
-        let abspaths =
+        let* abspaths_src =
+          absdirs_src |> mapM (listup_sources_in_directory extensions) |> Result.map List.concat
+        in
+        let* abspaths =
           if use_test_files then
             let absdirs_test = test_directories |> List.map (append_to_abs_directory absdir_envelope) in
-            let abspaths_test = absdirs_test |> List.map (listup_sources_in_directory extensions) |> List.concat in
-            List.append abspaths_src abspaths_test
+            let* abspaths_test =
+              absdirs_test |> mapM (listup_sources_in_directory extensions) |> Result.map List.concat
+            in
+            return @@ List.append abspaths_src abspaths_test
           else
-            abspaths_src
+            return abspaths_src
         in
         let* acc =
           abspaths |> foldM (fun acc abspath_src ->

--- a/src/frontend/errorReporting.ml
+++ b/src/frontend/errorReporting.ml
@@ -862,6 +862,12 @@ let make_config_error_message (display_config : Logging.config) : config_error -
             ]
       end
 
+  | CannotReadDirectory{ path; message } ->
+      make_error_message Interface [
+        NormalLine(Printf.sprintf "cannot read directory '%s':" (get_abs_path_string path));
+        DisplayLine(message);
+      ]
+
 
 let make_font_error_message (display_config : Logging.config) = function
   | FailedToReadFont(abspath, msg) ->


### PR DESCRIPTION
- Add subcommand `$ saphe cache list` for displaying cache files and directories
  * Purge operations are not yet implemented
- Modify how to arrange cache files under `~/.saphe/cache`
  * Before:
    - `~/.saphe/cache/locks/{RegHashValue}/{PkgName}.{Version}.tar.gz`
    - `~/.saphe/cache/locks/{RegHashValue}/{PkgName}.{Version}/{ResourceName}.zip`
    - `~/.saphe/cache/locks/{RegHashValue}/{PkgName}.{Version}/` (Content names may clash)
  * After:
    - `~/.saphe/cache/locks/{RegHashValue}/{PkgName}.{Version}.tar.gz` (Remains the same)
    - `~/.saphe/cache/external_resources/{RegHashValue}/{PkgName}.{Version}/archives/{ResourceName}.zip`
    - `~/.saphe/cache/external_resources/{RegHashValue}/{PkgName}.{Version}/extractions/{ResourceName}/`