### PR TITLE
Refactor `sapheMain.ml`

### DIFF
--- a/src-saphe/configError.ml
+++ b/src-saphe/configError.ml
@@ -25,6 +25,10 @@ type yaml_error =
   | NotASemanticVersion    of YamlDecoder.context * string
   | NotAVersionRequirement of YamlDecoder.context * string
   | InvalidPackageName     of YamlDecoder.context * string
+  | InvalidRegistryHashValue of {
+      context : YamlDecoder.context;
+      got     : registry_hash_value;
+    }
   | DuplicateRegistryHashValue of {
       context             : YamlDecoder.context;
       registry_hash_value : registry_hash_value;

--- a/src-saphe/configUtil.ml
+++ b/src-saphe/configUtil.ml
@@ -23,6 +23,15 @@ let package_name_decoder : package_name ConfigDecoder.t =
     failure (fun yctx -> InvalidPackageName(yctx, package_name))
 
 
+let registry_hash_value_decoder : registry_hash_value ConfigDecoder.t =
+  let open ConfigDecoder in
+  string >>= fun registry_hash_value ->
+  if Core.String.for_all registry_hash_value ~f:Core.Char.is_hex_digit then
+    succeed registry_hash_value
+  else
+    failure (fun context -> InvalidRegistryHashValue{ got = registry_hash_value; context })
+
+
 let version_decoder : SemanticVersion.t ConfigDecoder.t =
   let open ConfigDecoder in
   string >>= fun s_version ->
@@ -98,11 +107,11 @@ let registry_spec_decoder : (registry_local_name * registry_remote) ConfigDecode
 
 let name_decoder : string ConfigDecoder.t =
   let open ConfigDecoder in
-  string >>= fun s ->
-  if s |> Core.String.to_list_rev |> List.exists (Char.equal '/') then
-    failure (fun context -> CannotBeUsedAsAName(context, s))
+  string >>= fun name ->
+  if Core.String.exists name ~f:(Char.equal '/') then
+    failure (fun context -> CannotBeUsedAsAName(context, name))
   else
-    succeed s
+    succeed name
 
 
 let make_registry_hash_value (registry_remote : registry_remote) : (registry_hash_value, config_error) result =

--- a/src-saphe/constant.ml
+++ b/src-saphe/constant.ml
@@ -9,6 +9,12 @@ let current_ecosystem_version =
   | None         -> assert false
 
 
+let satysfi_version_for_init =
+  match SemanticVersion.parse "0.1.0-alpha.1" with
+  | Some(semver) -> semver
+  | None         -> assert false
+
+
 let lock_tarball_name (package_name : package_name) (locked_version : SemanticVersion.t) : lock_name =
   Printf.sprintf "%s.%s" package_name (SemanticVersion.to_string locked_version)
 
@@ -28,7 +34,8 @@ let lock_directory ~(store_root : abs_path) (lock : Lock.t) : abs_path =
   | Lock.Registered(reglock)         -> registered_lock_directory ~store_root reglock
   | Lock.LocalFixed{ absolute_path } -> absolute_path
 
-(* Should be in sync with SATySFi *)
+
+(* Must be in sync with SATySFi *)
 let envelope_config_path ~dir:(absdir_library : abs_path) : abs_path =
   append_to_abs_directory absdir_library "satysfi-envelope.yaml"
 

--- a/src-saphe/errorReporting.ml
+++ b/src-saphe/errorReporting.ml
@@ -67,6 +67,9 @@ let make_yaml_error_lines : yaml_error -> line list = function
   | InvalidPackageName(yctx, s) ->
       [ NormalLine(Printf.sprintf "not a package name: '%s' %s" s (show_yaml_context yctx)) ]
 
+  | InvalidRegistryHashValue{ context = yctx; got } ->
+      [ NormalLine(Printf.sprintf "invalid string '%s' for registry hash value %s" got (show_yaml_context yctx))]
+
   | DuplicateRegistryHashValue{ context = yctx; registry_hash_value } ->
       [ NormalLine(Printf.sprintf "More than one definition for registry hash value '%s' %s" registry_hash_value (show_yaml_context yctx)) ]
 

--- a/src-saphe/errorReporting.ml
+++ b/src-saphe/errorReporting.ml
@@ -1,0 +1,401 @@
+
+open MyUtil
+open ConfigError
+
+
+type line =
+  | NormalLine  of string
+  | DisplayLine of string
+
+
+let report_error (lines : line list) : unit =
+  print_string "! ";
+  lines |> List.fold_left (fun (is_first : bool) (line : line) ->
+    begin
+      match line with
+      | NormalLine(s) ->
+          if is_first then
+            print_endline s
+          else
+            print_endline ("    " ^ s)
+
+      | DisplayLine(s) ->
+          if is_first then
+            print_endline ("\n      " ^ s)
+          else
+            print_endline ("      " ^ s)
+    end;
+    false
+  ) true |> ignore
+
+
+let show_yaml_context (yctx : YamlDecoder.context) =
+  Printf.sprintf "(context: %s)" (YamlDecoder.show_yaml_context yctx)
+
+
+let make_yaml_error_lines : yaml_error -> line list = function
+  | ParseError(s) ->
+      [ NormalLine(Printf.sprintf "parse error: %s" s) ]
+
+  | FieldNotFound(yctx, field) ->
+      [ NormalLine(Printf.sprintf "field '%s' not found %s" field (show_yaml_context yctx)) ]
+
+  | NotAFloat(yctx) ->
+      [ NormalLine(Printf.sprintf "not a float value %s" (show_yaml_context yctx)) ]
+
+  | NotAString(yctx) ->
+      [ NormalLine(Printf.sprintf "not a string value %s" (show_yaml_context yctx)) ]
+
+  | NotABool(yctx) ->
+      [ NormalLine(Printf.sprintf "not a Boolean value %s" (show_yaml_context yctx)) ]
+
+  | NotAnArray(yctx) ->
+      [ NormalLine(Printf.sprintf "not an array %s" (show_yaml_context yctx)) ]
+
+  | NotAnObject(yctx) ->
+      [ NormalLine(Printf.sprintf "not an object %s" (show_yaml_context yctx)) ]
+
+  | BreaksVersionRequirement(yctx, requirement) ->
+      [ NormalLine(Printf.sprintf "breaks the requrement '%s' %s" (SemanticVersion.requirement_to_string requirement)(show_yaml_context yctx)) ]
+
+  | NotASemanticVersion(yctx, s) ->
+      [ NormalLine(Printf.sprintf "not a semantic version: '%s' %s" s (show_yaml_context yctx)) ]
+
+  | NotAVersionRequirement(yctx, s) ->
+      [ NormalLine(Printf.sprintf "not a version requirement: '%s' %s" s (show_yaml_context yctx)) ]
+
+  | InvalidPackageName(yctx, s) ->
+      [ NormalLine(Printf.sprintf "not a package name: '%s' %s" s (show_yaml_context yctx)) ]
+
+  | DuplicateRegistryHashValue{ context = yctx; registry_hash_value } ->
+      [ NormalLine(Printf.sprintf "More than one definition for registry hash value '%s' %s" registry_hash_value (show_yaml_context yctx)) ]
+
+  | CannotBeUsedAsAName(yctx, s) ->
+      [ NormalLine(Printf.sprintf "'%s' cannot be used as a name %s" s (show_yaml_context yctx)) ]
+
+  | UnsupportedRegistryFormat(format) ->
+      [ NormalLine(Printf.sprintf "unsupported registry format '%s'" format) ]
+
+  | NotACommand{ context = yctx; prefix = _; string = s } ->
+      [ NormalLine(Printf.sprintf "not a command: '%s' %s" s (show_yaml_context yctx)) ]
+
+  | BranchNotFound{ context = yctx; expected_tags; got_tags } ->
+      [
+        NormalLine(Printf.sprintf "expected tags not found; should contain exactly one of:");
+        DisplayLine(expected_tags |> String.concat ", ");
+        NormalLine("but only contains:");
+        DisplayLine(got_tags |> String.concat ", ");
+        NormalLine(Printf.sprintf "%s" (show_yaml_context yctx));
+      ]
+
+  | MoreThanOneBranchFound{ context = yctx; expected_tags; got_tags } ->
+      [
+        NormalLine(Printf.sprintf "more than one expected tag found:");
+        DisplayLine(got_tags |> String.concat ", ");
+        NormalLine("should be exactly one of:");
+        DisplayLine(expected_tags |> String.concat ", ");
+        NormalLine(Printf.sprintf "%s" (show_yaml_context yctx));
+      ]
+
+
+
+let report_config_error = function
+  | CannotDetermineStoreRoot{ envvar } ->
+      report_error [
+        NormalLine("cannot determine where the store root is;");
+        NormalLine(Printf.sprintf "set environment variable '%s'." envvar);
+      ]
+
+  | PackageDirectoryNotFound(candidate_paths) ->
+      let lines =
+        candidate_paths |> List.map (fun path ->
+          DisplayLine(Printf.sprintf "- %s" path)
+        )
+      in
+      report_error
+        (NormalLine("cannot find package directory. candidates:") :: lines)
+
+  | PackageConfigNotFound(abspath_package_config) ->
+      report_error [
+        NormalLine("cannot find a package config:");
+        DisplayLine(get_abs_path_string abspath_package_config);
+      ]
+
+  | PackageConfigError(abspath, e) ->
+      report_error (List.concat [
+        [ NormalLine(Printf.sprintf "in %s: package config error;" (get_abs_path_string abspath)) ];
+        make_yaml_error_lines e;
+      ])
+
+  | NotAPackageButADocument(abspath_package_config) ->
+      report_error [
+        NormalLine(Printf.sprintf "in %s:" (get_abs_path_string abspath_package_config));
+        NormalLine("this file is expected to be a config for a package,");
+        NormalLine("but is for a document.");
+      ]
+
+  | LockConfigNotFound(abspath) ->
+      report_error [
+        NormalLine("cannot find a lock config at:");
+        DisplayLine(get_abs_path_string abspath);
+      ]
+
+  | LockConfigError(abspath, e) ->
+      report_error (List.concat [
+        [ NormalLine(Printf.sprintf "in %s: lock config error;" (get_abs_path_string abspath)) ];
+        make_yaml_error_lines e;
+      ])
+
+  | RegistryConfigNotFound(abspath_registry_config) ->
+      report_error [
+        NormalLine("cannot find a registry config:");
+        DisplayLine(get_abs_path_string abspath_registry_config);
+      ]
+
+  | RegistryConfigError(abspath, e) ->
+      report_error (List.concat [
+        [ NormalLine(Printf.sprintf "in %s: registry config error;" (get_abs_path_string abspath)) ];
+        make_yaml_error_lines e;
+      ])
+
+  | ReleaseConfigNotFound(abspath_release_config) ->
+      report_error [
+        NormalLine("cannot find a release config:");
+        DisplayLine(get_abs_path_string abspath_release_config);
+      ]
+
+  | ReleaseConfigError(abspath, e) ->
+      report_error (List.concat [
+        [ NormalLine(Printf.sprintf "in %s: release config error;" (get_abs_path_string abspath)) ];
+        make_yaml_error_lines e;
+      ])
+
+  | StoreRootConfigNotFound(abspath) ->
+      report_error [
+        NormalLine("cannot find a store root config at:");
+        DisplayLine(get_abs_path_string abspath);
+      ]
+
+  | StoreRootConfigError(abspath, e) ->
+      report_error (List.concat [
+        [ NormalLine(Printf.sprintf "in %s: store root config error;" (get_abs_path_string abspath)) ];
+        make_yaml_error_lines e;
+      ])
+
+  | LockNameConflict(lock_name) ->
+      report_error [
+        NormalLine(Printf.sprintf "lock name conflict: '%s'" lock_name);
+      ]
+
+  | LockedPackageNotFound(libpath, candidates) ->
+      let lines =
+        candidates |> List.map (fun abspath ->
+          DisplayLine(Printf.sprintf "- %s" (get_abs_path_string abspath))
+        )
+      in
+      report_error
+        (NormalLine(Printf.sprintf "package '%s' not found. candidates:" (get_lib_path_string libpath)) :: lines)
+
+  | DependencyOnUnknownLock{ depending; depended } ->
+      report_error [
+        NormalLine(Printf.sprintf "unknown depended lock '%s' of '%s'." depended depending);
+      ]
+
+  | CannotFindLibraryFile(libpath, candidate_paths) ->
+      let lines =
+        candidate_paths |> List.map (fun abspath ->
+          DisplayLine(Printf.sprintf "- %s" (get_abs_path_string abspath))
+        )
+      in
+      report_error
+        (NormalLine(Printf.sprintf "cannot find '%s'. candidates:" (get_lib_path_string libpath)) :: lines)
+
+  | CannotSolvePackageConstraints ->
+      report_error [
+        NormalLine("cannot solve package constraints.");
+      ]
+
+  | FailedToFetchTarball{ lock_name; exit_status; command } ->
+      report_error [
+        NormalLine(Printf.sprintf "failed to fetch '%s' (exit status: %d). command:" lock_name exit_status);
+        DisplayLine(command);
+      ]
+
+  | FailedToExtractTarball{ lock_name; exit_status; command } ->
+      report_error [
+        NormalLine(Printf.sprintf "failed to extract the tarball of '%s' (exit status: %d). command:" lock_name exit_status);
+        DisplayLine(command);
+      ]
+
+  | FailedToFetchExternalZip{ url; exit_status; command } ->
+      report_error [
+        NormalLine(Printf.sprintf "failed to fetch file from '%s' (exit status: %d). command:" url exit_status);
+        DisplayLine(command);
+      ]
+
+  | ExternalZipChecksumMismatch{ url; path; expected; got } ->
+      report_error [
+        NormalLine("checksum mismatch of an external zip file.");
+        DisplayLine(Printf.sprintf "- fetched from: '%s'" url);
+        DisplayLine(Printf.sprintf "- path: '%s'" (get_abs_path_string path));
+        DisplayLine(Printf.sprintf "- expected: '%s'" expected);
+        DisplayLine(Printf.sprintf "- got: '%s'" got);
+      ]
+
+  | TarGzipChecksumMismatch{ lock_name; url; path; expected; got } ->
+      report_error [
+        NormalLine("checksum mismatch of a tarball.");
+        DisplayLine(Printf.sprintf "- lock name: '%s'" lock_name);
+        DisplayLine(Printf.sprintf "- fetched from: '%s'" url);
+        DisplayLine(Printf.sprintf "- path: '%s'" (get_abs_path_string path));
+        DisplayLine(Printf.sprintf "- expected: '%s'" expected);
+        DisplayLine(Printf.sprintf "- got: '%s'" got);
+      ]
+
+  | FailedToExtractExternalZip{ exit_status; command } ->
+      report_error [
+        NormalLine(Printf.sprintf "failed to extract a zip file (exit status: %d). command:" exit_status);
+        DisplayLine(command);
+      ]
+
+  | FailedToCopyFile{ exit_status; command } ->
+      report_error [
+        NormalLine(Printf.sprintf "failed to copy a file (exit status: %d). command:" exit_status);
+        DisplayLine(command);
+      ]
+
+  | PackageRegistryFetcherError(e) ->
+      begin
+        match e with
+        | FailedToFetchGitRegistry{ exit_status; command } ->
+            report_error [
+              NormalLine(Printf.sprintf "failed to fetch registry (exit status: %d). command:" exit_status);
+              DisplayLine(command);
+            ]
+
+        | FailedToUpdateGitRegistry{ exit_status; command } ->
+            report_error [
+              NormalLine(Printf.sprintf "failed to update registry (exit status: %d). command:" exit_status);
+              DisplayLine(command);
+            ]
+      end
+
+  | CanonicalRegistryUrlError(e) ->
+      begin
+        match e with
+        | ContainsQueryParameter{ url } ->
+            report_error [
+              NormalLine("registry URLs must not contain query parameters:");
+              DisplayLine(url);
+            ]
+
+        | NoUriScheme{ url } ->
+            report_error [
+              NormalLine("the registry URL does not contain a scheme:");
+              DisplayLine(url);
+            ]
+
+        | UnexpectedUrlScheme{ url; scheme } ->
+            report_error [
+              NormalLine(Printf.sprintf "unexpected scheme '%s' in a registry URL:" scheme);
+              DisplayLine(url);
+            ]
+      end
+
+  | CannotWriteEnvelopeConfig{ message; path } ->
+      report_error [
+        NormalLine(Printf.sprintf "cannot write an envelope config to '%s' (message: '%s')" (get_abs_path_string path) message);
+      ]
+
+  | CannotWriteLockConfig{ message; path } ->
+      report_error [
+        NormalLine(Printf.sprintf "cannot write a lock config to '%s' (message: '%s')" (get_abs_path_string path) message);
+      ]
+
+  | CannotWriteDepsConfig{ message; path } ->
+      report_error [
+        NormalLine(Printf.sprintf "cannot write a deps config to '%s' (message: '%s')" (get_abs_path_string path) message);
+      ]
+
+  | CannotWriteStoreRootConfig{ message; path } ->
+      report_error [
+        NormalLine(Printf.sprintf "cannot write a store root config to '%s' (message: '%s')" (get_abs_path_string path) message);
+      ]
+
+  | MultiplePackageDefinition{ package_name } ->
+      report_error [
+        NormalLine(Printf.sprintf "More than one definition for package '%s'." package_name)
+      ]
+
+  | DuplicateRegistryLocalName{ registry_local_name } ->
+      report_error [
+        NormalLine(Printf.sprintf "more than one definition for registry local name '%s'" registry_local_name)
+      ]
+
+  | UndefinedRegistryLocalName{ registry_local_name } ->
+      report_error [
+        NormalLine(Printf.sprintf "undefined registry local name '%s'" registry_local_name)
+      ]
+
+  | CannotTestDocument ->
+      report_error [
+        NormalLine("cannot run tests for documents (at least so far)");
+      ]
+
+  | FileAlreadyExists{ path } ->
+      report_error [
+        NormalLine(Printf.sprintf "file already exists: '%s'" (get_abs_path_string path));
+      ]
+
+  | InvalidExtensionForDocument{ path; extension } ->
+      report_error [
+        NormalLine(Printf.sprintf "invalid extension '%s' for a document: '%s'" extension (get_abs_path_string path));
+      ]
+
+  | FailedToWriteFile{ path; message } ->
+      report_error [
+        NormalLine(Printf.sprintf "failed to write file '%s':" (get_abs_path_string path));
+        DisplayLine(message);
+      ]
+
+  | NotALibraryLocalFixed{ dir = absdir_package } ->
+      report_error [
+        NormalLine(Printf.sprintf "the following local package is not a library:");
+        DisplayLine(get_abs_path_string absdir_package);
+      ]
+
+  | LocalFixedDoesNotSupportLanguageVersion{ dir = absdir_package; language_version; language_requirement } ->
+      let s_version = SemanticVersion.to_string language_version in
+      let s_req = SemanticVersion.requirement_to_string language_requirement in
+      report_error [
+        NormalLine(Printf.sprintf "the local package");
+        DisplayLine(get_abs_path_string absdir_package);
+        NormalLine(Printf.sprintf "requires the language version to be %s," s_req);
+        NormalLine(Printf.sprintf "but we are using %s." s_version);
+      ]
+
+  | PackageNameMismatchOfRelease{ path; from_filename; from_content } ->
+      report_error [
+        NormalLine(Printf.sprintf "the release config");
+        DisplayLine(get_abs_path_string path);
+        NormalLine("is inconsistent as package name;");
+        NormalLine(Printf.sprintf "its filename says the package name is '%s'," from_filename);
+        NormalLine(Printf.sprintf "but the content says '%s'." from_content);
+      ]
+
+  | PackageVersionMismatchOfRelease{ path; from_filename; from_content } ->
+      let s_version1 = SemanticVersion.to_string from_filename in
+      let s_version2 = SemanticVersion.to_string from_content in
+      report_error [
+        NormalLine(Printf.sprintf "the release config");
+        DisplayLine(get_abs_path_string path);
+        NormalLine("is inconsistent as package version;");
+        NormalLine(Printf.sprintf "its filename says the package version is '%s'," s_version1);
+        NormalLine(Printf.sprintf "but the content says '%s'." s_version2);
+      ]
+
+  | CannotReadDirectory{ path; message } ->
+      report_error [
+        NormalLine(Printf.sprintf "cannot read directory '%s':" (get_abs_path_string path));
+        DisplayLine(message);
+      ]

--- a/src-saphe/errorReporting.mli
+++ b/src-saphe/errorReporting.mli
@@ -1,0 +1,4 @@
+
+open ConfigError
+
+val report_config_error : config_error -> unit

--- a/src-saphe/initData.ml
+++ b/src-saphe/initData.ml
@@ -1,0 +1,131 @@
+
+let document_contents = Core.String.lstrip {string|
+use package open StdJaReport
+
+document (|
+  title = {The Title of Your Document},
+  author = {Your Name},
+|) '<
+  +chapter{First Chapter}<
+    +p{
+      Hello, world!
+    }
+  >
+>
+|string}
+
+
+let markdown_contents = Core.String.lstrip {string|
+<!-- MDJa -->
+<!-- (|
+  title = {The Title of Your Document},
+  author = {Your Name},
+|) -->
+# First Section
+
+Hello, world!
+|string}
+
+
+let document_package_config_contents = Core.String.lstrip (Printf.sprintf {string|
+saphe: "^%s"
+satysfi: "^%s"
+authors:
+  - "Your Name"
+registries:
+  - name: "default"
+    git:
+      url: "https://github.com/SATySFi/default-registry"
+      branch: "temp-dev-saphe"
+contents:
+  document: {}
+dependencies:
+  - used_as: "StdJaReport"
+    registered:
+      registry: "default"
+      name: "std-ja-report"
+      requirement: "^0.0.1"
+|string}
+  (SemanticVersion.to_string Constant.current_ecosystem_version)
+  (SemanticVersion.to_string Constant.satysfi_version_for_init))
+
+
+let markdown_package_config_contents = Core.String.lstrip (Printf.sprintf {string|
+saphe: "^%s"
+satysfi: "^%s"
+authors:
+  - "Your Name"
+registries:
+  - name: "default"
+    git:
+      url: "https://github.com/SATySFi/default-registry"
+      branch: "temp-dev-saphe"
+contents:
+  document: {}
+dependencies:
+  - used_as: "MDJa"
+    registered:
+      registry: "default"
+      name: "md-ja"
+      requirement: "^0.0.1"
+|string}
+  (SemanticVersion.to_string Constant.current_ecosystem_version)
+  (SemanticVersion.to_string Constant.satysfi_version_for_init))
+
+
+let library_package_config_contents = Core.String.lstrip (Printf.sprintf {string|
+saphe: "^%s"
+satysfi: "^%s"
+name: "your-library"
+authors:
+  - "Your Name"
+registries:
+  - name: "default"
+    git:
+      url: "https://github.com/SATySFi/default-registry"
+      branch: "temp-dev-saphe"
+contents:
+  library:
+    main_module: "Calc"
+    source_directories:
+    - "./src"
+    test_directories:
+    - "./test"
+dependencies:
+  - used_as: "Stdlib"
+    registered:
+      registry: "default"
+      name: "stdlib"
+      requirement: "^0.0.1"
+test_dependencies:
+  - used_as: "Testing"
+    registered:
+      registry: "default"
+      name: "testing"
+      requirement: "^0.0.1"
+|string}
+  (SemanticVersion.to_string Constant.current_ecosystem_version)
+  (SemanticVersion.to_string Constant.satysfi_version_for_init))
+
+
+let library_source_contents = Core.String.lstrip {string|
+module Calc :> sig
+  val succ : int -> int
+end = struct
+  val succ n = n + 1
+end
+|string}
+
+
+let library_test_contents = Core.String.lstrip {string|
+use package open Testing
+use Calc
+
+module CalcTest = struct
+
+  #[test]
+  val succ-test () =
+    assert-equal Equality.int 43 (Calc.succ 42)
+
+end
+|string}

--- a/src-saphe/lockConfig.ml
+++ b/src-saphe/lockConfig.ml
@@ -30,7 +30,7 @@ let lock_contents_decoder ~dir:(absdir_lock_config : abs_path) : Lock.t ConfigDe
   let open ConfigDecoder in
   branch [
     "registered" ==> begin
-      get "registry_hash_value" string >>= fun registry_hash_value -> (* TODO: validation *)
+      get "registry_hash_value" registry_hash_value_decoder >>= fun registry_hash_value ->
       get "package_name" package_name_decoder >>= fun package_name ->
       get "version" version_decoder >>= fun locked_version ->
       let registered_package_id = RegisteredPackageId.{ registry_hash_value; package_name } in
@@ -83,7 +83,7 @@ let lock_dependency_encoder (dep : lock_dependency) : Yaml.value =
 
 let lock_decoder ~(dir : abs_path) : locked_package ConfigDecoder.t =
   let open ConfigDecoder in
-  get "name" string >>= fun lock_name ->
+  get "name" string >>= fun lock_name -> (* Allow arbitrary strings, even ones containing slashes. *)
   get_or_else "dependencies" (list lock_dependency_decoder) [] >>= fun lock_dependencies ->
   get_or_else "test_only" bool false >>= fun test_only_lock ->
   lock_contents_decoder ~dir >>= fun lock_contents ->

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -10,404 +10,6 @@ let version =
     (SemanticVersion.to_string Constant.current_ecosystem_version)
 
 
-type line =
-  | NormalLine  of string
-  | DisplayLine of string
-
-
-let report_error (lines : line list) : unit =
-  print_string "! ";
-  lines |> List.fold_left (fun (is_first : bool) (line : line) ->
-    begin
-      match line with
-      | NormalLine(s) ->
-          if is_first then
-            print_endline s
-          else
-            print_endline ("    " ^ s)
-
-      | DisplayLine(s) ->
-          if is_first then
-            print_endline ("\n      " ^ s)
-          else
-            print_endline ("      " ^ s)
-    end;
-    false
-  ) true |> ignore
-
-
-let show_yaml_context (yctx : YamlDecoder.context) =
-  Printf.sprintf "(context: %s)" (YamlDecoder.show_yaml_context yctx)
-
-
-let make_yaml_error_lines : yaml_error -> line list = function
-  | ParseError(s) ->
-      [ NormalLine(Printf.sprintf "parse error: %s" s) ]
-
-  | FieldNotFound(yctx, field) ->
-      [ NormalLine(Printf.sprintf "field '%s' not found %s" field (show_yaml_context yctx)) ]
-
-  | NotAFloat(yctx) ->
-      [ NormalLine(Printf.sprintf "not a float value %s" (show_yaml_context yctx)) ]
-
-  | NotAString(yctx) ->
-      [ NormalLine(Printf.sprintf "not a string value %s" (show_yaml_context yctx)) ]
-
-  | NotABool(yctx) ->
-      [ NormalLine(Printf.sprintf "not a Boolean value %s" (show_yaml_context yctx)) ]
-
-  | NotAnArray(yctx) ->
-      [ NormalLine(Printf.sprintf "not an array %s" (show_yaml_context yctx)) ]
-
-  | NotAnObject(yctx) ->
-      [ NormalLine(Printf.sprintf "not an object %s" (show_yaml_context yctx)) ]
-
-  | BreaksVersionRequirement(yctx, requirement) ->
-      [ NormalLine(Printf.sprintf "breaks the requrement '%s' %s" (SemanticVersion.requirement_to_string requirement)(show_yaml_context yctx)) ]
-
-  | NotASemanticVersion(yctx, s) ->
-      [ NormalLine(Printf.sprintf "not a semantic version: '%s' %s" s (show_yaml_context yctx)) ]
-
-  | NotAVersionRequirement(yctx, s) ->
-      [ NormalLine(Printf.sprintf "not a version requirement: '%s' %s" s (show_yaml_context yctx)) ]
-
-  | InvalidPackageName(yctx, s) ->
-      [ NormalLine(Printf.sprintf "not a package name: '%s' %s" s (show_yaml_context yctx)) ]
-
-  | DuplicateRegistryHashValue{ context = yctx; registry_hash_value } ->
-      [ NormalLine(Printf.sprintf "More than one definition for registry hash value '%s' %s" registry_hash_value (show_yaml_context yctx)) ]
-
-  | CannotBeUsedAsAName(yctx, s) ->
-      [ NormalLine(Printf.sprintf "'%s' cannot be used as a name %s" s (show_yaml_context yctx)) ]
-
-  | UnsupportedRegistryFormat(format) ->
-      [ NormalLine(Printf.sprintf "unsupported registry format '%s'" format) ]
-
-  | NotACommand{ context = yctx; prefix = _; string = s } ->
-      [ NormalLine(Printf.sprintf "not a command: '%s' %s" s (show_yaml_context yctx)) ]
-
-  | BranchNotFound{ context = yctx; expected_tags; got_tags } ->
-      [
-        NormalLine(Printf.sprintf "expected tags not found; should contain exactly one of:");
-        DisplayLine(expected_tags |> String.concat ", ");
-        NormalLine("but only contains:");
-        DisplayLine(got_tags |> String.concat ", ");
-        NormalLine(Printf.sprintf "%s" (show_yaml_context yctx));
-      ]
-
-  | MoreThanOneBranchFound{ context = yctx; expected_tags; got_tags } ->
-      [
-        NormalLine(Printf.sprintf "more than one expected tag found:");
-        DisplayLine(got_tags |> String.concat ", ");
-        NormalLine("should be exactly one of:");
-        DisplayLine(expected_tags |> String.concat ", ");
-        NormalLine(Printf.sprintf "%s" (show_yaml_context yctx));
-      ]
-
-
-
-let report_config_error = function
-  | CannotDetermineStoreRoot{ envvar } ->
-      report_error [
-        NormalLine("cannot determine where the store root is;");
-        NormalLine(Printf.sprintf "set environment variable '%s'." envvar);
-      ]
-
-  | PackageDirectoryNotFound(candidate_paths) ->
-      let lines =
-        candidate_paths |> List.map (fun path ->
-          DisplayLine(Printf.sprintf "- %s" path)
-        )
-      in
-      report_error
-        (NormalLine("cannot find package directory. candidates:") :: lines)
-
-  | PackageConfigNotFound(abspath_package_config) ->
-      report_error [
-        NormalLine("cannot find a package config:");
-        DisplayLine(get_abs_path_string abspath_package_config);
-      ]
-
-  | PackageConfigError(abspath, e) ->
-      report_error (List.concat [
-        [ NormalLine(Printf.sprintf "in %s: package config error;" (get_abs_path_string abspath)) ];
-        make_yaml_error_lines e;
-      ])
-
-  | NotAPackageButADocument(abspath_package_config) ->
-      report_error [
-        NormalLine(Printf.sprintf "in %s:" (get_abs_path_string abspath_package_config));
-        NormalLine("this file is expected to be a config for a package,");
-        NormalLine("but is for a document.");
-      ]
-
-  | LockConfigNotFound(abspath) ->
-      report_error [
-        NormalLine("cannot find a lock config at:");
-        DisplayLine(get_abs_path_string abspath);
-      ]
-
-  | LockConfigError(abspath, e) ->
-      report_error (List.concat [
-        [ NormalLine(Printf.sprintf "in %s: lock config error;" (get_abs_path_string abspath)) ];
-        make_yaml_error_lines e;
-      ])
-
-  | RegistryConfigNotFound(abspath_registry_config) ->
-      report_error [
-        NormalLine("cannot find a registry config:");
-        DisplayLine(get_abs_path_string abspath_registry_config);
-      ]
-
-  | RegistryConfigError(abspath, e) ->
-      report_error (List.concat [
-        [ NormalLine(Printf.sprintf "in %s: registry config error;" (get_abs_path_string abspath)) ];
-        make_yaml_error_lines e;
-      ])
-
-  | ReleaseConfigNotFound(abspath_release_config) ->
-      report_error [
-        NormalLine("cannot find a release config:");
-        DisplayLine(get_abs_path_string abspath_release_config);
-      ]
-
-  | ReleaseConfigError(abspath, e) ->
-      report_error (List.concat [
-        [ NormalLine(Printf.sprintf "in %s: release config error;" (get_abs_path_string abspath)) ];
-        make_yaml_error_lines e;
-      ])
-
-  | StoreRootConfigNotFound(abspath) ->
-      report_error [
-        NormalLine("cannot find a store root config at:");
-        DisplayLine(get_abs_path_string abspath);
-      ]
-
-  | StoreRootConfigError(abspath, e) ->
-      report_error (List.concat [
-        [ NormalLine(Printf.sprintf "in %s: store root config error;" (get_abs_path_string abspath)) ];
-        make_yaml_error_lines e;
-      ])
-
-  | LockNameConflict(lock_name) ->
-      report_error [
-        NormalLine(Printf.sprintf "lock name conflict: '%s'" lock_name);
-      ]
-
-  | LockedPackageNotFound(libpath, candidates) ->
-      let lines =
-        candidates |> List.map (fun abspath ->
-          DisplayLine(Printf.sprintf "- %s" (get_abs_path_string abspath))
-        )
-      in
-      report_error
-        (NormalLine(Printf.sprintf "package '%s' not found. candidates:" (get_lib_path_string libpath)) :: lines)
-
-  | DependencyOnUnknownLock{ depending; depended } ->
-      report_error [
-        NormalLine(Printf.sprintf "unknown depended lock '%s' of '%s'." depended depending);
-      ]
-
-  | CannotFindLibraryFile(libpath, candidate_paths) ->
-      let lines =
-        candidate_paths |> List.map (fun abspath ->
-          DisplayLine(Printf.sprintf "- %s" (get_abs_path_string abspath))
-        )
-      in
-      report_error
-        (NormalLine(Printf.sprintf "cannot find '%s'. candidates:" (get_lib_path_string libpath)) :: lines)
-
-  | CannotSolvePackageConstraints ->
-      report_error [
-        NormalLine("cannot solve package constraints.");
-      ]
-
-  | FailedToFetchTarball{ lock_name; exit_status; command } ->
-      report_error [
-        NormalLine(Printf.sprintf "failed to fetch '%s' (exit status: %d). command:" lock_name exit_status);
-        DisplayLine(command);
-      ]
-
-  | FailedToExtractTarball{ lock_name; exit_status; command } ->
-      report_error [
-        NormalLine(Printf.sprintf "failed to extract the tarball of '%s' (exit status: %d). command:" lock_name exit_status);
-        DisplayLine(command);
-      ]
-
-  | FailedToFetchExternalZip{ url; exit_status; command } ->
-      report_error [
-        NormalLine(Printf.sprintf "failed to fetch file from '%s' (exit status: %d). command:" url exit_status);
-        DisplayLine(command);
-      ]
-
-  | ExternalZipChecksumMismatch{ url; path; expected; got } ->
-      report_error [
-        NormalLine("checksum mismatch of an external zip file.");
-        DisplayLine(Printf.sprintf "- fetched from: '%s'" url);
-        DisplayLine(Printf.sprintf "- path: '%s'" (get_abs_path_string path));
-        DisplayLine(Printf.sprintf "- expected: '%s'" expected);
-        DisplayLine(Printf.sprintf "- got: '%s'" got);
-      ]
-
-  | TarGzipChecksumMismatch{ lock_name; url; path; expected; got } ->
-      report_error [
-        NormalLine("checksum mismatch of a tarball.");
-        DisplayLine(Printf.sprintf "- lock name: '%s'" lock_name);
-        DisplayLine(Printf.sprintf "- fetched from: '%s'" url);
-        DisplayLine(Printf.sprintf "- path: '%s'" (get_abs_path_string path));
-        DisplayLine(Printf.sprintf "- expected: '%s'" expected);
-        DisplayLine(Printf.sprintf "- got: '%s'" got);
-      ]
-
-  | FailedToExtractExternalZip{ exit_status; command } ->
-      report_error [
-        NormalLine(Printf.sprintf "failed to extract a zip file (exit status: %d). command:" exit_status);
-        DisplayLine(command);
-      ]
-
-  | FailedToCopyFile{ exit_status; command } ->
-      report_error [
-        NormalLine(Printf.sprintf "failed to copy a file (exit status: %d). command:" exit_status);
-        DisplayLine(command);
-      ]
-
-  | PackageRegistryFetcherError(e) ->
-      begin
-        match e with
-        | FailedToFetchGitRegistry{ exit_status; command } ->
-            report_error [
-              NormalLine(Printf.sprintf "failed to fetch registry (exit status: %d). command:" exit_status);
-              DisplayLine(command);
-            ]
-
-        | FailedToUpdateGitRegistry{ exit_status; command } ->
-            report_error [
-              NormalLine(Printf.sprintf "failed to update registry (exit status: %d). command:" exit_status);
-              DisplayLine(command);
-            ]
-      end
-
-  | CanonicalRegistryUrlError(e) ->
-      begin
-        match e with
-        | ContainsQueryParameter{ url } ->
-            report_error [
-              NormalLine("registry URLs must not contain query parameters:");
-              DisplayLine(url);
-            ]
-
-        | NoUriScheme{ url } ->
-            report_error [
-              NormalLine("the registry URL does not contain a scheme:");
-              DisplayLine(url);
-            ]
-
-        | UnexpectedUrlScheme{ url; scheme } ->
-            report_error [
-              NormalLine(Printf.sprintf "unexpected scheme '%s' in a registry URL:" scheme);
-              DisplayLine(url);
-            ]
-      end
-
-  | CannotWriteEnvelopeConfig{ message; path } ->
-      report_error [
-        NormalLine(Printf.sprintf "cannot write an envelope config to '%s' (message: '%s')" (get_abs_path_string path) message);
-      ]
-
-  | CannotWriteLockConfig{ message; path } ->
-      report_error [
-        NormalLine(Printf.sprintf "cannot write a lock config to '%s' (message: '%s')" (get_abs_path_string path) message);
-      ]
-
-  | CannotWriteDepsConfig{ message; path } ->
-      report_error [
-        NormalLine(Printf.sprintf "cannot write a deps config to '%s' (message: '%s')" (get_abs_path_string path) message);
-      ]
-
-  | CannotWriteStoreRootConfig{ message; path } ->
-      report_error [
-        NormalLine(Printf.sprintf "cannot write a store root config to '%s' (message: '%s')" (get_abs_path_string path) message);
-      ]
-
-  | MultiplePackageDefinition{ package_name } ->
-      report_error [
-        NormalLine(Printf.sprintf "More than one definition for package '%s'." package_name)
-      ]
-
-  | DuplicateRegistryLocalName{ registry_local_name } ->
-      report_error [
-        NormalLine(Printf.sprintf "more than one definition for registry local name '%s'" registry_local_name)
-      ]
-
-  | UndefinedRegistryLocalName{ registry_local_name } ->
-      report_error [
-        NormalLine(Printf.sprintf "undefined registry local name '%s'" registry_local_name)
-      ]
-
-  | CannotTestDocument ->
-      report_error [
-        NormalLine("cannot run tests for documents (at least so far)");
-      ]
-
-  | FileAlreadyExists{ path } ->
-      report_error [
-        NormalLine(Printf.sprintf "file already exists: '%s'" (get_abs_path_string path));
-      ]
-
-  | InvalidExtensionForDocument{ path; extension } ->
-      report_error [
-        NormalLine(Printf.sprintf "invalid extension '%s' for a document: '%s'" extension (get_abs_path_string path));
-      ]
-
-  | FailedToWriteFile{ path; message } ->
-      report_error [
-        NormalLine(Printf.sprintf "failed to write file '%s':" (get_abs_path_string path));
-        DisplayLine(message);
-      ]
-
-  | NotALibraryLocalFixed{ dir = absdir_package } ->
-      report_error [
-        NormalLine(Printf.sprintf "the following local package is not a library:");
-        DisplayLine(get_abs_path_string absdir_package);
-      ]
-
-  | LocalFixedDoesNotSupportLanguageVersion{ dir = absdir_package; language_version; language_requirement } ->
-      let s_version = SemanticVersion.to_string language_version in
-      let s_req = SemanticVersion.requirement_to_string language_requirement in
-      report_error [
-        NormalLine(Printf.sprintf "the local package");
-        DisplayLine(get_abs_path_string absdir_package);
-        NormalLine(Printf.sprintf "requires the language version to be %s," s_req);
-        NormalLine(Printf.sprintf "but we are using %s." s_version);
-      ]
-
-  | PackageNameMismatchOfRelease{ path; from_filename; from_content } ->
-      report_error [
-        NormalLine(Printf.sprintf "the release config");
-        DisplayLine(get_abs_path_string path);
-        NormalLine("is inconsistent as package name;");
-        NormalLine(Printf.sprintf "its filename says the package name is '%s'," from_filename);
-        NormalLine(Printf.sprintf "but the content says '%s'." from_content);
-      ]
-
-  | PackageVersionMismatchOfRelease{ path; from_filename; from_content } ->
-      let s_version1 = SemanticVersion.to_string from_filename in
-      let s_version2 = SemanticVersion.to_string from_content in
-      report_error [
-        NormalLine(Printf.sprintf "the release config");
-        DisplayLine(get_abs_path_string path);
-        NormalLine("is inconsistent as package version;");
-        NormalLine(Printf.sprintf "its filename says the package version is '%s'," s_version1);
-        NormalLine(Printf.sprintf "but the content says '%s'." s_version2);
-      ]
-
-  | CannotReadDirectory{ path; message } ->
-      report_error [
-        NormalLine(Printf.sprintf "cannot read directory '%s':" (get_abs_path_string path));
-        DisplayLine(message);
-      ]
-
-
 type solve_input =
   | PackageSolveInput of {
       root     : abs_path; (* The absolute path of a directory used as the package root *)
@@ -746,7 +348,7 @@ let init_document ~(fpath_in : string) =
   in
   match res with
   | Ok(())   -> ()
-  | Error(e) -> report_config_error e; exit 1
+  | Error(e) -> ErrorReporting.report_config_error e; exit 1
 
 
 let init_library ~(fpath_in : string) =
@@ -775,7 +377,7 @@ let init_library ~(fpath_in : string) =
   in
   match res with
   | Ok(())   -> ()
-  | Error(e) -> report_config_error e; exit 1
+  | Error(e) -> ErrorReporting.report_config_error e; exit 1
 
 
 let make_solve_input ~(dir_current : string) ~(fpath_in : string) : solve_input =
@@ -1009,7 +611,7 @@ let solve ~(fpath_in : string) =
   in
   match res with
   | Ok(())   -> ()
-  | Error(e) -> report_config_error e; exit 1
+  | Error(e) -> ErrorReporting.report_config_error e; exit 1
 
 
 let update ~(fpath_in : string) =
@@ -1074,7 +676,7 @@ let update ~(fpath_in : string) =
   in
   match res with
   | Ok(())   -> ()
-  | Error(e) -> report_config_error e; exit 1
+  | Error(e) -> ErrorReporting.report_config_error e; exit 1
 
 
 type build_input =
@@ -1300,7 +902,7 @@ let build
   in
   match res with
   | Ok(exit_status) -> exit exit_status
-  | Error(e)        -> report_config_error e; exit 1
+  | Error(e)        -> ErrorReporting.report_config_error e; exit 1
 
 
 type test_input =
@@ -1383,7 +985,7 @@ let test
   in
   match res with
   | Ok(exit_status) -> exit exit_status
-  | Error(e)        -> report_config_error e; exit 1
+  | Error(e)        -> ErrorReporting.report_config_error e; exit 1
 
 
 let continue_if_ok res f =
@@ -1490,4 +1092,4 @@ let cache_list () =
   in
   match res with
   | Ok(())   -> ()
-  | Error(e) -> report_config_error e; exit 1
+  | Error(e) -> ErrorReporting.report_config_error e; exit 1

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -163,132 +163,6 @@ type package_init_input =
     }
 
 
-let initial_document_contents = Core.String.lstrip {string|
-use package open StdJaReport
-
-document (|
-  title = {The Title of Your Document},
-  author = {Your Name},
-|) '<
-  +chapter{First Chapter}<
-    +p{
-      Hello, world!
-    }
-  >
->
-|string}
-
-
-let initial_markdown_contents = Core.String.lstrip {string|
-<!-- MDJa -->
-<!-- (|
-  title = {The Title of Your Document},
-  author = {Your Name},
-|) -->
-# First Section
-
-Hello, world!
-|string}
-
-
-let initial_document_package_config_contents = Core.String.lstrip (Printf.sprintf {string|
-saphe: "^%s"
-satysfi: "^0.1.0-alpha.1"
-authors:
-  - "Your Name"
-registries:
-  - name: "default"
-    git:
-      url: "https://github.com/SATySFi/default-registry"
-      branch: "temp-dev-saphe"
-contents:
-  document: {}
-dependencies:
-  - used_as: "StdJaReport"
-    registered:
-      registry: "default"
-      name: "std-ja-report"
-      requirement: "^0.0.1"
-|string} (SemanticVersion.to_string Constant.current_ecosystem_version))
-
-
-let initial_markdown_package_config_contents = Core.String.lstrip (Printf.sprintf {string|
-saphe: "^%s"
-satysfi: "^0.1.0-alpha.1"
-authors:
-  - "Your Name"
-registries:
-  - name: "default"
-    git:
-      url: "https://github.com/SATySFi/default-registry"
-      branch: "temp-dev-saphe"
-contents:
-  document: {}
-dependencies:
-  - used_as: "MDJa"
-    registered:
-      registry: "default"
-      name: "md-ja"
-      requirement: "^0.0.1"
-|string} (SemanticVersion.to_string Constant.current_ecosystem_version))
-
-
-let initial_library_package_config_contents = Core.String.lstrip (Printf.sprintf {string|
-saphe: "^%s"
-satysfi: "^0.1.0-alpha.1"
-name: "your-library"
-authors:
-  - "Your Name"
-registries:
-  - name: "default"
-    git:
-      url: "https://github.com/SATySFi/default-registry"
-      branch: "temp-dev-saphe"
-contents:
-  library:
-    main_module: "Calc"
-    source_directories:
-    - "./src"
-    test_directories:
-    - "./test"
-dependencies:
-  - used_as: "Stdlib"
-    registered:
-      registry: "default"
-      name: "stdlib"
-      requirement: "^0.0.1"
-test_dependencies:
-  - used_as: "Testing"
-    registered:
-      registry: "default"
-      name: "testing"
-      requirement: "^0.0.1"
-|string} (SemanticVersion.to_string Constant.current_ecosystem_version))
-
-
-let initial_library_source_contents = Core.String.lstrip {string|
-module Calc :> sig
-  val succ : int -> int
-end = struct
-  val succ n = n + 1
-end
-|string}
-
-
-let initial_library_test_contents = Core.String.lstrip {string|
-use package open Testing
-use Calc
-
-module CalcTest = struct
-
-  #[test]
-  val succ-test () =
-    assert-equal Equality.int 43 (Calc.succ 42)
-
-end
-|string}
-
-
 let write_package_config (abspath_package_config : abs_path) ~(data : string) =
   let open ResultMonad in
   let* () =
@@ -333,14 +207,14 @@ let init_document ~(fpath_in : string) =
     match Filename.extension (get_abs_path_string abspath_doc) with
     | ".saty" ->
         ShellCommand.mkdir_p absdir;
-        let* () = write_package_config abspath_package_config ~data:initial_document_package_config_contents in
-        let* () = write_initial_file abspath_doc ~data:initial_document_contents in
+        let* () = write_package_config abspath_package_config ~data:InitData.document_package_config_contents in
+        let* () = write_initial_file abspath_doc ~data:InitData.document_contents in
         return ()
 
     | ".md" ->
         ShellCommand.mkdir_p absdir;
-        let* () = write_package_config abspath_package_config ~data:initial_markdown_package_config_contents in
-        let* () = write_initial_file abspath_doc ~data:initial_markdown_contents in
+        let* () = write_package_config abspath_package_config ~data:InitData.markdown_package_config_contents in
+        let* () = write_initial_file abspath_doc ~data:InitData.markdown_contents in
         return ()
 
     | extension ->
@@ -369,9 +243,9 @@ let init_library ~(fpath_in : string) =
     ShellCommand.mkdir_p absdir_package;
     ShellCommand.mkdir_p (append_to_abs_directory absdir_package "src");
     ShellCommand.mkdir_p (append_to_abs_directory absdir_package "test");
-    let* () = write_package_config abspath_package_config ~data:initial_library_package_config_contents in
-    let* () = write_initial_file abspath_source ~data:initial_library_source_contents in
-    let* () = write_initial_file abspath_test ~data:initial_library_test_contents in
+    let* () = write_package_config abspath_package_config ~data:InitData.library_package_config_contents in
+    let* () = write_initial_file abspath_source ~data:InitData.library_source_contents in
+    let* () = write_initial_file abspath_test ~data:InitData.library_test_contents in
 
     return ()
   in

--- a/src-saphe/storeRootConfig.ml
+++ b/src-saphe/storeRootConfig.ml
@@ -33,7 +33,7 @@ let registry_remote_encoder = function
 
 let registry_spec_decoder : (registry_hash_value * registry_remote) ConfigDecoder.t =
   let open ConfigDecoder in
-  get "hash_value" string >>= fun registry_hash_value ->
+  get "hash_value" registry_hash_value_decoder >>= fun registry_hash_value ->
   registry_remote_decoder >>= fun registry_remote ->
   succeed (registry_hash_value, registry_remote)
 


### PR DESCRIPTION
- Separate `errorReporting.ml` and `initData.ml` from `sapheMain.ml`
- Validate registry hash values when reading lock configs or store root configs