### PR TITLE
Add `--verbose` and `--quiet`

### DIFF
--- a/bin-saphe/dune
+++ b/bin-saphe/dune
@@ -2,5 +2,5 @@
  (name saphe)
  (public_name saphe)
  (package saphe)
- (libraries sapheMain cmdliner)
+ (libraries sapheMain satysfi-common cmdliner)
  (preprocess no_preprocessing))

--- a/bin-saphe/saphe.ml
+++ b/bin-saphe/saphe.ml
@@ -26,7 +26,7 @@ let build
   page_number_limit
   max_repeats
   show_full_path
-  verbose
+  verbosity
   debug_show_bbox
   debug_show_space
   debug_show_block_bbox
@@ -42,7 +42,7 @@ let build
     ~page_number_limit
     ~max_repeats
     ~show_full_path
-    ~verbose
+    ~verbosity
     ~debug_show_bbox
     ~debug_show_space
     ~debug_show_block_bbox
@@ -56,13 +56,13 @@ let test
   fpath_in
   text_mode_formats_str_opt
   show_full_path
-  verbose
+  verbosity
 =
   SapheMain.test
     ~fpath_in
     ~text_mode_formats_str_opt
     ~show_full_path
-    ~verbose
+    ~verbosity
 
 
 let arg_in : string Cmdliner.Term.t =
@@ -110,10 +110,11 @@ let flag_full_path =
     ~doc:"Displays paths in full-path style"
 
 
-let flag_verbose =
-  make_boolean_flag_spec
-    ~flags:[ "verbose" ]
-    ~doc:"Verbosity of logs"
+let flag_verbosity : Verbosity.t Cmdliner.Term.t =
+  let open Cmdliner in
+  let verbose = (Verbosity.Verbose, Arg.info [ "verbose" ] ~doc:"Make logs verbose") in
+  let quiet = (Verbosity.Quiet, Arg.info [ "quiet" ] ~doc:"Disable logs other than errors and warnings") in
+  Arg.(value (vflag Verbosity.Normal [ verbose; quiet ]))
 
 
 let flag_debug_show_bbox =
@@ -200,7 +201,7 @@ let command_build : unit Cmdliner.Cmd.t =
       $ flag_page_number_limit
       $ flag_max_repeats
       $ flag_full_path
-      $ flag_verbose
+      $ flag_verbosity
       $ flag_debug_show_bbox
       $ flag_debug_show_space
       $ flag_debug_show_block_bbox
@@ -218,7 +219,7 @@ let command_test : unit Cmdliner.Cmd.t =
       $ arg_in
       $ flag_text_mode
       $ flag_full_path
-      $ flag_verbose
+      $ flag_verbosity
     )
 
 

--- a/bin-saphe/saphe.ml
+++ b/bin-saphe/saphe.ml
@@ -15,8 +15,15 @@ let update fpath_in =
   SapheMain.update ~fpath_in
 
 
-let solve fpath_in =
-  SapheMain.solve ~fpath_in
+let solve
+  fpath_in
+  show_full_path
+  verbosity
+=
+  SapheMain.solve
+    ~fpath_in
+    ~show_full_path
+    ~verbosity
 
 
 let build
@@ -188,7 +195,11 @@ let command_update : unit Cmdliner.Cmd.t =
 let command_solve : unit Cmdliner.Cmd.t =
   let open Cmdliner in
   Cmd.v (Cmd.info "solve")
-    Term.(const solve $ arg_in)
+    Term.(const solve
+      $ arg_in
+      $ flag_full_path
+      $ flag_verbosity
+    )
 
 
 let command_build : unit Cmdliner.Cmd.t =

--- a/bin-saphe/saphe.ml
+++ b/bin-saphe/saphe.ml
@@ -1,4 +1,7 @@
 
+open LoggingUtil
+
+
 let init_document fpath_in =
   SapheMain.init_document ~fpath_in
 
@@ -117,11 +120,11 @@ let flag_full_path =
     ~doc:"Displays paths in full-path style"
 
 
-let flag_verbosity : Verbosity.t Cmdliner.Term.t =
+let flag_verbosity : verbosity Cmdliner.Term.t =
   let open Cmdliner in
-  let verbose = (Verbosity.Verbose, Arg.info [ "verbose" ] ~doc:"Make logs verbose") in
-  let quiet = (Verbosity.Quiet, Arg.info [ "quiet" ] ~doc:"Disable logs other than errors and warnings") in
-  Arg.(value (vflag Verbosity.Normal [ verbose; quiet ]))
+  let verbose = (Verbose, Arg.info [ "verbose" ] ~doc:"Make logs verbose") in
+  let quiet = (Quiet, Arg.info [ "quiet" ] ~doc:"Disable logs other than errors and warnings") in
+  Arg.(value (vflag NormalVerbosity [ verbose; quiet ]))
 
 
 let flag_debug_show_bbox =

--- a/bin-saphe/saphe.ml
+++ b/bin-saphe/saphe.ml
@@ -2,20 +2,46 @@
 open LoggingUtil
 
 
-let init_document fpath_in =
-  SapheMain.init_document ~fpath_in
+let init_document
+  fpath_in
+  show_full_path
+  verbosity
+=
+  SapheMain.init_document
+    ~fpath_in
+    ~show_full_path
+    ~verbosity
 
 
-let init_library fpath_in =
-  SapheMain.init_library ~fpath_in
+let init_library
+  fpath_in
+  show_full_path
+  verbosity
+=
+  SapheMain.init_library
+    ~fpath_in
+    ~show_full_path
+    ~verbosity
 
 
-let cache_list () =
-  SapheMain.cache_list ()
+let cache_list
+  show_full_path
+  verbosity
+=
+  SapheMain.cache_list
+    ~show_full_path
+    ~verbosity
 
 
-let update fpath_in =
-  SapheMain.update ~fpath_in
+let update
+  fpath_in
+  show_full_path
+  verbosity
+=
+  SapheMain.update
+    ~fpath_in
+    ~show_full_path
+    ~verbosity
 
 
 let solve
@@ -172,13 +198,21 @@ let flag_bytecomp =
 let command_init_document : unit Cmdliner.Cmd.t =
   let open Cmdliner in
   Cmd.v (Cmd.info "document")
-    Term.(const init_document $ arg_in_to_create)
+    Term.(const init_document
+      $ arg_in_to_create
+      $ flag_full_path
+      $ flag_verbosity
+    )
 
 
 let command_init_library : unit Cmdliner.Cmd.t =
   let open Cmdliner in
   Cmd.v (Cmd.info "library")
-    Term.(const init_library $ arg_in_to_create)
+    Term.(const init_library
+      $ arg_in_to_create
+      $ flag_full_path
+      $ flag_verbosity
+    )
 
 
 let command_init : unit Cmdliner.Cmd.t =
@@ -192,7 +226,11 @@ let command_init : unit Cmdliner.Cmd.t =
 let command_update : unit Cmdliner.Cmd.t =
   let open Cmdliner in
   Cmd.v (Cmd.info "update")
-    Term.(const update $ arg_in)
+    Term.(const update
+      $ arg_in
+      $ flag_full_path
+      $ flag_verbosity
+    )
 
 
 let command_solve : unit Cmdliner.Cmd.t =
@@ -240,7 +278,10 @@ let command_test : unit Cmdliner.Cmd.t =
 let command_cache_list : unit Cmdliner.Cmd.t =
   let open Cmdliner in
   Cmd.v (Cmd.info "list")
-    Term.(const cache_list $ const ())
+    Term.(const cache_list
+      $ flag_full_path
+      $ flag_verbosity
+    )
 
 
 let command_cache : unit Cmdliner.Cmd.t =

--- a/bin-saphe/saphe.ml
+++ b/bin-saphe/saphe.ml
@@ -24,6 +24,9 @@ let build
   fpath_out_opt
   text_mode_formats_str_opt
   page_number_limit
+  max_repeats
+  show_full_path
+  verbose
   debug_show_bbox
   debug_show_space
   debug_show_block_bbox
@@ -37,6 +40,9 @@ let build
     ~fpath_out_opt
     ~text_mode_formats_str_opt
     ~page_number_limit
+    ~max_repeats
+    ~show_full_path
+    ~verbose
     ~debug_show_bbox
     ~debug_show_space
     ~debug_show_block_bbox
@@ -49,10 +55,14 @@ let build
 let test
   fpath_in
   text_mode_formats_str_opt
+  show_full_path
+  verbose
 =
   SapheMain.test
     ~fpath_in
     ~text_mode_formats_str_opt
+    ~show_full_path
+    ~verbose
 
 
 let arg_in : string Cmdliner.Term.t =
@@ -83,9 +93,27 @@ let flag_page_number_limit : int Cmdliner.Term.t =
   Arg.(value (opt int 10000 (info [ "page-number-limit" ] ~docv:"INT" ~doc)))
 
 
+let flag_max_repeats : int Cmdliner.Term.t =
+  let open Cmdliner in
+  let doc = "Set the maximum number of iterations (default: 4)" in
+  Arg.(value (opt int 4 (info [ "max-repeats" ] ~docv:"INT" ~doc)))
+
+
 let make_boolean_flag_spec ~(flags : string list) ~(doc : string) : bool Cmdliner.Term.t =
   let open Cmdliner in
   Arg.(value (flag (info flags ~doc)))
+
+
+let flag_full_path =
+  make_boolean_flag_spec
+    ~flags:[ "full-path" ]
+    ~doc:"Displays paths in full-path style"
+
+
+let flag_verbose =
+  make_boolean_flag_spec
+    ~flags:[ "verbose" ]
+    ~doc:"Verbosity of logs"
 
 
 let flag_debug_show_bbox =
@@ -170,6 +198,9 @@ let command_build : unit Cmdliner.Cmd.t =
       $ flag_output
       $ flag_text_mode
       $ flag_page_number_limit
+      $ flag_max_repeats
+      $ flag_full_path
+      $ flag_verbose
       $ flag_debug_show_bbox
       $ flag_debug_show_space
       $ flag_debug_show_block_bbox
@@ -186,6 +217,8 @@ let command_test : unit Cmdliner.Cmd.t =
     Term.(const test
       $ arg_in
       $ flag_text_mode
+      $ flag_full_path
+      $ flag_verbose
     )
 
 

--- a/bin/dune
+++ b/bin/dune
@@ -2,5 +2,5 @@
  (name satysfi)
  (public_name satysfi)
  (package satysfi)
- (libraries main cmdliner)
+ (libraries main satysfi-common cmdliner)
  (preprocess no_preprocessing))

--- a/bin/satysfi.ml
+++ b/bin/satysfi.ml
@@ -4,12 +4,14 @@ let build_package
   fpath_deps
   text_mode_formats_str_opt
   show_full_path
+  verbose
 =
   Main.build_package
     ~fpath_in
     ~fpath_deps
     ~text_mode_formats_str_opt
     ~show_full_path
+    ~verbose
 
 
 let build_document
@@ -21,6 +23,7 @@ let build_document
   page_number_limit
   max_repeats
   show_full_path
+  verbose
   debug_show_bbox
   debug_show_space
   debug_show_block_bbox
@@ -38,6 +41,7 @@ let build_document
     ~page_number_limit
     ~max_repeats
     ~show_full_path
+    ~verbose
     ~debug_show_bbox
     ~debug_show_space
     ~debug_show_block_bbox
@@ -52,12 +56,14 @@ let test_package
   fpath_deps
   text_mode_formats_str_opt
   show_full_path
+  verbose
 =
   Main.test_package
     ~fpath_in
     ~fpath_deps
     ~text_mode_formats_str_opt
     ~show_full_path
+    ~verbose
 
 
 let arg_in : string Cmdliner.Term.t =
@@ -110,6 +116,12 @@ let flag_full_path =
   make_boolean_flag_spec
     ~flags:[ "full-path" ]
     ~doc:"Displays paths in full-path style"
+
+
+let flag_verbose =
+  make_boolean_flag_spec
+    ~flags:[ "verbose" ]
+    ~doc:"Verbosity of logs"
 
 
 let flag_debug_show_bbox =
@@ -166,6 +178,7 @@ let command_build_document =
       $ flag_page_number_limit
       $ flag_max_repeats
       $ flag_full_path
+      $ flag_verbose
       $ flag_debug_show_bbox
       $ flag_debug_show_space
       $ flag_debug_show_block_bbox
@@ -184,6 +197,7 @@ let command_build_package =
       $ flag_deps
       $ flag_text_mode
       $ flag_full_path
+      $ flag_verbose
     )
 
 
@@ -203,6 +217,7 @@ let command_test_package =
       $ flag_deps
       $ flag_text_mode
       $ flag_full_path
+      $ flag_verbose
     )
 
 

--- a/bin/satysfi.ml
+++ b/bin/satysfi.ml
@@ -4,14 +4,14 @@ let build_package
   fpath_deps
   text_mode_formats_str_opt
   show_full_path
-  verbose
+  verbosity
 =
   Main.build_package
     ~fpath_in
     ~fpath_deps
     ~text_mode_formats_str_opt
     ~show_full_path
-    ~verbose
+    ~verbosity
 
 
 let build_document
@@ -23,7 +23,7 @@ let build_document
   page_number_limit
   max_repeats
   show_full_path
-  verbose
+  verbosity
   debug_show_bbox
   debug_show_space
   debug_show_block_bbox
@@ -41,7 +41,7 @@ let build_document
     ~page_number_limit
     ~max_repeats
     ~show_full_path
-    ~verbose
+    ~verbosity
     ~debug_show_bbox
     ~debug_show_space
     ~debug_show_block_bbox
@@ -56,14 +56,14 @@ let test_package
   fpath_deps
   text_mode_formats_str_opt
   show_full_path
-  verbose
+  verbosity
 =
   Main.test_package
     ~fpath_in
     ~fpath_deps
     ~text_mode_formats_str_opt
     ~show_full_path
-    ~verbose
+    ~verbosity
 
 
 let arg_in : string Cmdliner.Term.t =
@@ -118,10 +118,11 @@ let flag_full_path =
     ~doc:"Displays paths in full-path style"
 
 
-let flag_verbose =
-  make_boolean_flag_spec
-    ~flags:[ "verbose" ]
-    ~doc:"Verbosity of logs"
+let flag_verbosity =
+  let open Cmdliner in
+  let verbose = (Verbosity.Verbose, Arg.info [ "verbose" ] ~doc:"Make logs verbose") in
+  let quiet = (Verbosity.Quiet, Arg.info [ "quiet" ] ~doc:"Disable logs other than errors and warnings") in
+  Arg.(value (vflag Verbosity.Normal [ verbose; quiet ]))
 
 
 let flag_debug_show_bbox =
@@ -178,7 +179,7 @@ let command_build_document =
       $ flag_page_number_limit
       $ flag_max_repeats
       $ flag_full_path
-      $ flag_verbose
+      $ flag_verbosity
       $ flag_debug_show_bbox
       $ flag_debug_show_space
       $ flag_debug_show_block_bbox
@@ -197,7 +198,7 @@ let command_build_package =
       $ flag_deps
       $ flag_text_mode
       $ flag_full_path
-      $ flag_verbose
+      $ flag_verbosity
     )
 
 
@@ -217,7 +218,7 @@ let command_test_package =
       $ flag_deps
       $ flag_text_mode
       $ flag_full_path
-      $ flag_verbose
+      $ flag_verbosity
     )
 
 

--- a/bin/satysfi.ml
+++ b/bin/satysfi.ml
@@ -1,4 +1,7 @@
 
+open LoggingUtil
+
+
 let build_package
   fpath_in
   fpath_deps
@@ -120,9 +123,9 @@ let flag_full_path =
 
 let flag_verbosity =
   let open Cmdliner in
-  let verbose = (Verbosity.Verbose, Arg.info [ "verbose" ] ~doc:"Make logs verbose") in
-  let quiet = (Verbosity.Quiet, Arg.info [ "quiet" ] ~doc:"Disable logs other than errors and warnings") in
-  Arg.(value (vflag Verbosity.Normal [ verbose; quiet ]))
+  let verbose = (Verbose, Arg.info [ "verbose" ] ~doc:"Make logs verbose") in
+  let quiet = (Quiet, Arg.info [ "quiet" ] ~doc:"Disable logs other than errors and warnings") in
+  Arg.(value (vflag NormalVerbosity [ verbose; quiet ]))
 
 
 let flag_debug_show_bbox =

--- a/src-common/commonUtil.ml
+++ b/src-common/commonUtil.ml
@@ -41,24 +41,3 @@ let parse_long_identifier (s : string) : (string list * string) option =
     return (modnms, varnm)
   else
     None
-
-
-type path_display_setting =
-  | FullPath
-  | RelativeToCwd of abs_path
-
-
-let display_path (setting : path_display_setting) (abspath : abs_path) =
-  match setting with
-  | FullPath                   -> AbsPath.to_string abspath
-  | RelativeToCwd(abspath_cwd) -> AbsPath.make_relative ~from:abspath_cwd abspath
-
-
-let is_verbose = function
-  | Verbosity.Verbose -> true
-  | _                 -> false
-
-
-let is_not_quiet = function
-  | Verbosity.Quiet -> false
-  | _               -> true

--- a/src-common/commonUtil.ml
+++ b/src-common/commonUtil.ml
@@ -1,7 +1,4 @@
 
-open MyUtil
-
-
 let is_middle_char (char : char) : bool =
   Char.equal char '-' || Core.Char.is_alpha char || Core.Char.is_digit char
 

--- a/src-common/commonUtil.ml
+++ b/src-common/commonUtil.ml
@@ -1,4 +1,7 @@
 
+open MyUtil
+
+
 let is_middle_char (char : char) : bool =
   Char.equal char '-' || Core.Char.is_alpha char || Core.Char.is_digit char
 
@@ -38,3 +41,24 @@ let parse_long_identifier (s : string) : (string list * string) option =
     return (modnms, varnm)
   else
     None
+
+
+type path_display_setting =
+  | FullPath
+  | RelativeToCwd of abs_path
+
+
+let display_path (setting : path_display_setting) (abspath : abs_path) =
+  match setting with
+  | FullPath                   -> AbsPath.to_string abspath
+  | RelativeToCwd(abspath_cwd) -> AbsPath.make_relative ~from:abspath_cwd abspath
+
+
+let is_verbose = function
+  | Verbosity.Verbose -> true
+  | _                 -> false
+
+
+let is_not_quiet = function
+  | Verbosity.Quiet -> false
+  | _               -> true

--- a/src-common/commonUtil.mli
+++ b/src-common/commonUtil.mli
@@ -1,4 +1,6 @@
 
+open MyUtil
+
 val is_uppercased_identifier : string -> bool
 
 val is_lowercased_identifier : string -> bool
@@ -6,3 +8,13 @@ val is_lowercased_identifier : string -> bool
 val parse_long_command : prefix:string -> string -> (string list * string) option
 
 val parse_long_identifier : string -> (string list * string) option
+
+type path_display_setting =
+  | FullPath
+  | RelativeToCwd of abs_path
+
+val display_path : path_display_setting -> abs_path -> string
+
+val is_verbose : Verbosity.t -> bool
+
+val is_not_quiet : Verbosity.t -> bool

--- a/src-common/commonUtil.mli
+++ b/src-common/commonUtil.mli
@@ -8,13 +8,3 @@ val is_lowercased_identifier : string -> bool
 val parse_long_command : prefix:string -> string -> (string list * string) option
 
 val parse_long_identifier : string -> (string list * string) option
-
-type path_display_setting =
-  | FullPath
-  | RelativeToCwd of abs_path
-
-val display_path : path_display_setting -> abs_path -> string
-
-val is_verbose : Verbosity.t -> bool
-
-val is_not_quiet : Verbosity.t -> bool

--- a/src-common/commonUtil.mli
+++ b/src-common/commonUtil.mli
@@ -1,6 +1,4 @@
 
-open MyUtil
-
 val is_uppercased_identifier : string -> bool
 
 val is_lowercased_identifier : string -> bool

--- a/src-common/loggingUtil.ml
+++ b/src-common/loggingUtil.ml
@@ -1,0 +1,35 @@
+
+open MyUtil
+
+
+type path_display_setting =
+  | FullPath
+  | RelativeToCwd of abs_path
+
+
+let display_path (setting : path_display_setting) (abspath : abs_path) =
+  match setting with
+  | FullPath                   -> AbsPath.to_string abspath
+  | RelativeToCwd(abspath_cwd) -> AbsPath.make_relative ~from:abspath_cwd abspath
+
+
+type verbosity =
+  | Verbose
+  | NormalVerbosity
+  | Quiet
+
+
+let is_verbose = function
+  | Verbose -> true
+  | _       -> false
+
+
+let is_not_quiet = function
+  | Quiet -> false
+  | _     -> true
+
+
+type logging_spec = {
+  path_display_setting : path_display_setting;
+  verbosity            : verbosity;
+}

--- a/src-common/loggingUtil.ml
+++ b/src-common/loggingUtil.ml
@@ -20,7 +20,7 @@ type logging_spec = {
 let show_path (spec : logging_spec) (abspath : abs_path) : string =
   match spec.path_display_setting with
   | FullPath                   -> AbsPath.to_string abspath
-  | RelativeToCwd(abspath_cwd) -> AbsPath.make_relative ~from:abspath_cwd abspath
+  | RelativeToCwd(abspath_cwd) -> AbsPath.to_relative_string_if_descendant ~from:abspath_cwd abspath
 
 
 let is_verbose (spec : logging_spec) =

--- a/src-common/loggingUtil.ml
+++ b/src-common/loggingUtil.ml
@@ -6,30 +6,30 @@ type path_display_setting =
   | FullPath
   | RelativeToCwd of abs_path
 
-
-let display_path (setting : path_display_setting) (abspath : abs_path) =
-  match setting with
-  | FullPath                   -> AbsPath.to_string abspath
-  | RelativeToCwd(abspath_cwd) -> AbsPath.make_relative ~from:abspath_cwd abspath
-
-
 type verbosity =
   | Verbose
   | NormalVerbosity
   | Quiet
 
-
-let is_verbose = function
-  | Verbose -> true
-  | _       -> false
-
-
-let is_not_quiet = function
-  | Quiet -> false
-  | _     -> true
-
-
 type logging_spec = {
   path_display_setting : path_display_setting;
   verbosity            : verbosity;
 }
+
+
+let show_path (spec : logging_spec) (abspath : abs_path) : string =
+  match spec.path_display_setting with
+  | FullPath                   -> AbsPath.to_string abspath
+  | RelativeToCwd(abspath_cwd) -> AbsPath.make_relative ~from:abspath_cwd abspath
+
+
+let is_verbose (spec : logging_spec) =
+  match spec.verbosity with
+  | Verbose -> true
+  | _       -> false
+
+
+let is_not_quiet (spec : logging_spec) =
+  match spec.verbosity with
+  | Quiet -> false
+  | _     -> true

--- a/src-common/loggingUtil.mli
+++ b/src-common/loggingUtil.mli
@@ -1,0 +1,22 @@
+
+open MyUtil
+
+type path_display_setting =
+  | FullPath
+  | RelativeToCwd of abs_path
+
+val display_path : path_display_setting -> abs_path -> string
+
+type verbosity =
+  | Verbose
+  | NormalVerbosity
+  | Quiet
+
+val is_verbose : verbosity -> bool
+
+val is_not_quiet : verbosity -> bool
+
+type logging_spec = {
+  path_display_setting : path_display_setting;
+  verbosity            : verbosity;
+}

--- a/src-common/loggingUtil.mli
+++ b/src-common/loggingUtil.mli
@@ -5,18 +5,18 @@ type path_display_setting =
   | FullPath
   | RelativeToCwd of abs_path
 
-val display_path : path_display_setting -> abs_path -> string
-
 type verbosity =
   | Verbose
   | NormalVerbosity
   | Quiet
 
-val is_verbose : verbosity -> bool
-
-val is_not_quiet : verbosity -> bool
-
 type logging_spec = {
   path_display_setting : path_display_setting;
   verbosity            : verbosity;
 }
+
+val show_path : logging_spec -> abs_path -> string
+
+val is_verbose : logging_spec -> bool
+
+val is_not_quiet : logging_spec -> bool

--- a/src-common/verbosity.ml
+++ b/src-common/verbosity.ml
@@ -1,5 +1,0 @@
-
-type t =
-  | Verbose
-  | Normal
-  | Quiet

--- a/src-common/verbosity.ml
+++ b/src-common/verbosity.ml
@@ -1,0 +1,5 @@
+
+type t =
+  | Verbose
+  | Normal
+  | Quiet

--- a/src-saphe/configUtil.ml
+++ b/src-saphe/configUtil.ml
@@ -170,10 +170,12 @@ let writable_name_decoder : string ConfigDecoder.t =
     failure (fun context -> CannotBeUsedAsAName{ context; got = s })
 
 
+(* TODO: make a type-level distinction between ordinary registry URLs and canonicalized ones *)
 let make_registry_hash_value (registry_remote : registry_remote) : (registry_hash_value, config_error) result =
   let open ResultMonad in
   match registry_remote with
   | GitRegistry{ url; branch } ->
+      (* TODO: perhaps the canonicalization performed here is unnecessary *)
       let* canonicalized_url =
         CanonicalRegistryUrl.make url
           |> Result.map_error (fun e -> CanonicalRegistryUrlError(e))
@@ -181,9 +183,6 @@ let make_registry_hash_value (registry_remote : registry_remote) : (registry_has
       let hash_value =
         Digest.to_hex (Digest.string (Printf.sprintf "git#%s#%s" canonicalized_url branch))
       in
-(*
-      Logging.report_canonicalized_url ~url ~canonicalized_url ~hash_value;
-*)
       return hash_value
 
 

--- a/src-saphe/lockConfig.ml
+++ b/src-saphe/lockConfig.ml
@@ -62,7 +62,7 @@ let lock_contents_encoder ~dir:(absdir_lock_config : abs_path) (contents : Lock.
   | Lock.LocalFixed{ absolute_path } ->
       [
         ("local", `O([
-          ("relative_path", `String(AbsPath.make_relative ~from:absdir_lock_config absolute_path));
+          ("relative_path", `String(AbsPath.to_relative_string ~from:absdir_lock_config absolute_path));
         ]));
       ]
 

--- a/src-saphe/lockFetcher.ml
+++ b/src-saphe/lockFetcher.ml
@@ -87,7 +87,7 @@ let fetch_registered_lock (logging_spec : logging_spec) ~(wget_command : string)
             Logging.lock_cache_exists logging_spec lock_tarball_name abspath_tarball;
             return ()
           end else begin
-            Logging.downloading_lock lock_tarball_name abspath_tarball;
+            Logging.downloading_lock logging_spec lock_tarball_name abspath_tarball;
             fetch_tarball ~wget_command ~lock_name:lock_tarball_name ~url ~output:abspath_tarball
           end
         in

--- a/src-saphe/lockFetcher.ml
+++ b/src-saphe/lockFetcher.ml
@@ -1,5 +1,6 @@
 
 open MyUtil
+open LoggingUtil
 open PackageSystemBase
 open ConfigError
 
@@ -49,7 +50,7 @@ let extract_external_zip ~(unzip_command : string) ~(zip : abs_path) ~(output_co
     err @@ FailedToExtractExternalZip{ exit_status; command }
 
 
-let fetch_registered_lock ~(wget_command : string) ~(tar_command : string) ~store_root:(absdir_store_root : abs_path) (reglock : RegisteredLock.t) (source : implementation_source) : unit ok =
+let fetch_registered_lock (logging_spec : logging_spec) ~(wget_command : string) ~(tar_command : string) ~store_root:(absdir_store_root : abs_path) (reglock : RegisteredLock.t) (source : implementation_source) : unit ok =
   let open ResultMonad in
   let RegisteredLock.{ registered_package_id; locked_version } = reglock in
   let RegisteredPackageId.{ registry_hash_value; package_name } = registered_package_id in
@@ -68,7 +69,7 @@ let fetch_registered_lock ~(wget_command : string) ~(tar_command : string) ~stor
   let abspath_config = Constant.library_package_config_path ~dir:absdir_lock in
   if AbsPathIo.file_exists abspath_config then begin
   (* If the lock has already been fetched: *)
-    Logging.lock_already_installed lock_tarball_name absdir_lock;
+    Logging.lock_already_installed logging_spec lock_tarball_name absdir_lock;
     return ()
   end else
     match source with
@@ -83,7 +84,7 @@ let fetch_registered_lock ~(wget_command : string) ~(tar_command : string) ~stor
         in
         let* () =
           if AbsPathIo.file_exists abspath_tarball then begin
-            Logging.lock_cache_exists lock_tarball_name abspath_tarball;
+            Logging.lock_cache_exists logging_spec lock_tarball_name abspath_tarball;
             return ()
           end else begin
             Logging.downloading_lock lock_tarball_name abspath_tarball;
@@ -238,13 +239,14 @@ let fetch_external_resources ~(wget_command : string) ~(unzip_command : string) 
   return ()
 
 
-let main ~(wget_command : string) ~(tar_command : string) ~(unzip_command : string) ~(store_root : abs_path) (impl_spec : implementation_spec) : unit ok =
+let main (logging_spec : logging_spec) ~(wget_command : string) ~(tar_command : string) ~(unzip_command : string) ~(store_root : abs_path) (impl_spec : implementation_spec) : unit ok =
   let open ResultMonad in
   let ImplSpec{ lock; source } = impl_spec in
   match lock with
   | Lock.Registered(reglock) ->
       let* () =
         fetch_registered_lock
+          logging_spec
           ~wget_command
           ~tar_command
           ~store_root

--- a/src-saphe/lockFetcher.mli
+++ b/src-saphe/lockFetcher.mli
@@ -1,9 +1,11 @@
 
 open MyUtil
+open LoggingUtil
 open PackageSystemBase
 open ConfigError
 
 val main :
+  logging_spec ->
   wget_command:string ->
   tar_command:string ->
   unzip_command:string ->

--- a/src-saphe/logging.ml
+++ b/src-saphe/logging.ml
@@ -71,30 +71,38 @@ let end_deps_config_output (spec : logging_spec) (abspath_deps_config : abs_path
   end
 
 
-let lock_already_installed (lock_name : lock_name) (absdir : abs_path) =
-  Printf.printf "  '%s': already installed at '%s'\n"
-    lock_name
-    (AbsPath.to_string absdir)
+let lock_already_installed (spec : logging_spec) (lock_name : lock_name) (absdir : abs_path) =
+  if is_not_quiet spec then begin
+    Printf.printf "  '%s': already installed at '%s'\n"
+      lock_name
+      (AbsPath.to_string absdir)
+  end
 
 
-let lock_cache_exists (lock_name : lock_name) (abspath_tarball : abs_path) =
-  Printf.printf "  cache for '%s' exists at '%s'\n"
-    lock_name
-    (AbsPath.to_string abspath_tarball)
+let lock_cache_exists (spec : logging_spec) (lock_name : lock_name) (abspath_tarball : abs_path) =
+  if is_not_quiet spec then begin
+    Printf.printf "  cache for '%s' exists at '%s'\n"
+      lock_name
+      (AbsPath.to_string abspath_tarball)
+  end
 
 
-let store_root_config_updated ~(created : bool) (abspath_store_root_config : abs_path) =
-  let verb = if created then "created" else "updated" in
-  Printf.printf "  %s the store root config '%s'\n"
-    verb
-    (AbsPath.to_string abspath_store_root_config)
+let store_root_config_updated (spec : logging_spec) ~(created : bool) (abspath_store_root_config : abs_path) =
+  if is_not_quiet spec then begin
+    let verb = if created then "created" else "updated" in
+    Printf.printf "  %s the store root config '%s'\n"
+      verb
+      (AbsPath.to_string abspath_store_root_config)
+  end
 
 
-let package_registry_updated ~(created : bool) (absdir_registry_repo : abs_path) =
-  let verb = if created then "fetched" else "updated" in
-  Printf.printf "  %s the package registry '%s'\n"
-    verb
-    (AbsPath.to_string absdir_registry_repo)
+let package_registry_updated (spec : logging_spec) ~(created : bool) (absdir_registry_repo : abs_path) =
+  if is_not_quiet spec then begin
+    let verb = if created then "fetched" else "updated" in
+    Printf.printf "  %s the package registry '%s'\n"
+      verb
+      (AbsPath.to_string absdir_registry_repo)
+  end
 
 
 let initialize_file (spec : logging_spec) (abspath_doc : abs_path) =

--- a/src-saphe/logging.ml
+++ b/src-saphe/logging.ml
@@ -72,10 +72,13 @@ let end_deps_config_output (spec : logging_spec) (abspath_deps_config : abs_path
 
 
 let lock_already_installed (spec : logging_spec) (lock_name : lock_name) (absdir : abs_path) =
-  if is_not_quiet spec then begin
+  if is_verbose spec then begin
     Printf.printf "  '%s': already installed at '%s'\n"
       lock_name
       (AbsPath.to_string absdir)
+  end else if is_not_quiet spec then begin
+    Printf.printf "  '%s': already installed\n"
+      lock_name
   end
 
 
@@ -88,13 +91,15 @@ let lock_cache_exists (spec : logging_spec) (lock_name : lock_name) (abspath_tar
 
 
 let store_root_config_updated (spec : logging_spec) ~(created : bool) (abspath_store_root_config : abs_path) =
-  if is_not_quiet spec then begin
-    let verb = if created then "created" else "updated" in
+  let verb = if created then "created" else "updated" in
+  if is_verbose spec then begin
     Printf.printf "  %s the store root config '%s'\n"
       verb
       (AbsPath.to_string abspath_store_root_config)
+  end else if is_not_quiet spec then begin
+    Printf.printf "  %s the store root config\n"
+      verb
   end
-
 
 let package_registry_updated (spec : logging_spec) ~(created : bool) (absdir_registry_repo : abs_path) =
   if is_not_quiet spec then begin
@@ -113,11 +118,7 @@ let initialize_package_config (spec : logging_spec) (abspath_package_config : ab
   Printf.printf "  created a package config '%s'\n" (show_path spec abspath_package_config)
 
 
-let downloading_lock (lock_name : lock_name) (absdir : abs_path) =
-  Printf.printf "  downloading '%s' to '%s'...\n" lock_name (AbsPath.to_string absdir)
-
-
-let report_canonicalized_url ~(url : string) ~(canonicalized_url : string) ~(hash_value : registry_hash_value) =
-  Printf.printf "  registry URL: '%s'\n" url;
-  Printf.printf "    canonicalized: '%s'\n" canonicalized_url;
-  Printf.printf "    hash value: '%s'\n" hash_value
+let downloading_lock (spec : logging_spec) (lock_name : lock_name) (absdir : abs_path) =
+  if is_not_quiet spec then begin
+    Printf.printf "  downloading '%s' to '%s'...\n" lock_name (AbsPath.to_string absdir)
+  end

--- a/src-saphe/logging.ml
+++ b/src-saphe/logging.ml
@@ -4,64 +4,68 @@ open LoggingUtil
 open PackageSystemBase
 
 
-let show_path (spec : logging_spec) =
-  display_path spec.path_display_setting
-
-
 let show_package_dependency_before_solving (spec : logging_spec) (dependencies_with_flags : (dependency_flag * package_dependency) list) =
-  Printf.printf "  package dependencies to solve:\n";
-  dependencies_with_flags |> List.iter (fun (flag, dep) ->
-    let PackageDependency{ used_as; spec = dep_spec } = dep in
-    match dep_spec with
-    | RegisteredDependency{ registered_package_id; version_requirement; _ } ->
-        let RegisteredPackageId.{ package_name; _ } = registered_package_id in
-        let s_restr = SemanticVersion.requirement_to_string version_requirement in
-        let s_test_only =
-          match flag with
-          | SourceDependency   -> ""
-          | TestOnlyDependency -> ", test_only"
-        in
-        Printf.printf "  - %s (%s%s) used as %s\n"
-          package_name
-          s_restr
-          s_test_only
-          used_as
+  if is_not_quiet spec then begin
+    Printf.printf "  package dependencies to solve:\n";
+    dependencies_with_flags |> List.iter (fun (flag, dep) ->
+      let PackageDependency{ used_as; spec = dep_spec } = dep in
+      match dep_spec with
+      | RegisteredDependency{ registered_package_id; version_requirement; _ } ->
+          let RegisteredPackageId.{ package_name; _ } = registered_package_id in
+          let s_restr = SemanticVersion.requirement_to_string version_requirement in
+          let s_test_only =
+            match flag with
+            | SourceDependency   -> ""
+            | TestOnlyDependency -> ", test_only"
+          in
+          Printf.printf "  - %s (%s%s) used as %s\n"
+            package_name
+            s_restr
+            s_test_only
+            used_as
 
-    | LocalFixedDependency{ absolute_path } ->
-        Printf.printf "  - '%s' used as %s\n"
-          (show_path spec absolute_path)
-          used_as
-  )
+      | LocalFixedDependency{ absolute_path } ->
+          Printf.printf "  - '%s' used as %s\n"
+            (show_path spec absolute_path)
+            used_as
+    )
+  end
 
 
 let show_package_dependency_solutions (spec : logging_spec) (solutions : package_solution list) =
-  Printf.printf "  package dependency solutions:\n";
-  solutions |> List.iter (fun solution ->
-    match solution.lock with
-    | Lock.Registered(RegisteredLock.{ registered_package_id; locked_version; _ }) ->
-        let RegisteredPackageId.{ package_name; _ } = registered_package_id in
-        Printf.printf "  - %s %s\n"
-          package_name
-          (SemanticVersion.to_string locked_version)
+  if is_not_quiet spec then begin
+    Printf.printf "  package dependency solutions:\n";
+    solutions |> List.iter (fun solution ->
+      match solution.lock with
+      | Lock.Registered(RegisteredLock.{ registered_package_id; locked_version; _ }) ->
+          let RegisteredPackageId.{ package_name; _ } = registered_package_id in
+          Printf.printf "  - %s %s\n"
+            package_name
+            (SemanticVersion.to_string locked_version)
 
-    | Lock.LocalFixed{ absolute_path } ->
-        Printf.printf "  - %s\n"
-          (show_path spec absolute_path)
-  )
+      | Lock.LocalFixed{ absolute_path } ->
+          Printf.printf "  - %s\n"
+            (show_path spec absolute_path)
+    )
+  end
 
 
 let end_lock_config_output (spec : logging_spec) (abspath_lock_config : abs_path) =
-  Printf.printf "  lock config written on '%s'.\n"
-    (show_path spec abspath_lock_config)
+  if is_not_quiet spec then begin
+    Printf.printf "  lock config written on '%s'.\n"
+      (show_path spec abspath_lock_config)
+  end
 
 
 let end_envelope_config_output (spec : logging_spec) (abspath_envelope_config : abs_path) =
-  Printf.printf "  envelope config written on '%s'.\n"
-    (show_path spec abspath_envelope_config)
+  if is_not_quiet spec then begin
+    Printf.printf "  envelope config written on '%s'.\n"
+      (show_path spec abspath_envelope_config)
+  end
 
 
 let end_deps_config_output (spec : logging_spec) (abspath_deps_config : abs_path) =
-  if is_verbose spec.verbosity then begin
+  if is_verbose spec then begin
     Printf.printf "  deps config written on '%s'.\n"
       (show_path spec abspath_deps_config)
   end

--- a/src-saphe/logging.ml
+++ b/src-saphe/logging.ml
@@ -1,24 +1,18 @@
 
 open MyUtil
-open CommonUtil
+open LoggingUtil
 open PackageSystemBase
 
 
-type config = {
-  path_display_setting : path_display_setting;
-  verbosity            : Verbosity.t;
-}
+let show_path (spec : logging_spec) =
+  display_path spec.path_display_setting
 
 
-let show_path (config : config) =
-  display_path config.path_display_setting
-
-
-let show_package_dependency_before_solving (config : config) (dependencies_with_flags : (dependency_flag * package_dependency) list) =
+let show_package_dependency_before_solving (spec : logging_spec) (dependencies_with_flags : (dependency_flag * package_dependency) list) =
   Printf.printf "  package dependencies to solve:\n";
   dependencies_with_flags |> List.iter (fun (flag, dep) ->
-    let PackageDependency{ used_as; spec } = dep in
-    match spec with
+    let PackageDependency{ used_as; spec = dep_spec } = dep in
+    match dep_spec with
     | RegisteredDependency{ registered_package_id; version_requirement; _ } ->
         let RegisteredPackageId.{ package_name; _ } = registered_package_id in
         let s_restr = SemanticVersion.requirement_to_string version_requirement in
@@ -35,12 +29,12 @@ let show_package_dependency_before_solving (config : config) (dependencies_with_
 
     | LocalFixedDependency{ absolute_path } ->
         Printf.printf "  - '%s' used as %s\n"
-          (show_path config absolute_path)
+          (show_path spec absolute_path)
           used_as
   )
 
 
-let show_package_dependency_solutions (config : config) (solutions : package_solution list) =
+let show_package_dependency_solutions (spec : logging_spec) (solutions : package_solution list) =
   Printf.printf "  package dependency solutions:\n";
   solutions |> List.iter (fun solution ->
     match solution.lock with
@@ -52,24 +46,24 @@ let show_package_dependency_solutions (config : config) (solutions : package_sol
 
     | Lock.LocalFixed{ absolute_path } ->
         Printf.printf "  - %s\n"
-          (show_path config absolute_path)
+          (show_path spec absolute_path)
   )
 
 
-let end_lock_config_output (config : config) (abspath_lock_config : abs_path) =
+let end_lock_config_output (spec : logging_spec) (abspath_lock_config : abs_path) =
   Printf.printf "  lock config written on '%s'.\n"
-    (show_path config abspath_lock_config)
+    (show_path spec abspath_lock_config)
 
 
-let end_envelope_config_output (config : config) (abspath_envelope_config : abs_path) =
+let end_envelope_config_output (spec : logging_spec) (abspath_envelope_config : abs_path) =
   Printf.printf "  envelope config written on '%s'.\n"
-    (show_path config abspath_envelope_config)
+    (show_path spec abspath_envelope_config)
 
 
-let end_deps_config_output (config : config) (abspath_deps_config : abs_path) =
-  if is_verbose config.verbosity then begin
+let end_deps_config_output (spec : logging_spec) (abspath_deps_config : abs_path) =
+  if is_verbose spec.verbosity then begin
     Printf.printf "  deps config written on '%s'.\n"
-      (show_path config abspath_deps_config)
+      (show_path spec abspath_deps_config)
   end
 
 
@@ -99,12 +93,12 @@ let package_registry_updated ~(created : bool) (absdir_registry_repo : abs_path)
     (AbsPath.to_string absdir_registry_repo)
 
 
-let initialize_file (config : config) (abspath_doc : abs_path) =
-  Printf.printf "  created '%s'\n" (show_path config abspath_doc)
+let initialize_file (spec : logging_spec) (abspath_doc : abs_path) =
+  Printf.printf "  created '%s'\n" (show_path spec abspath_doc)
 
 
-let initialize_package_config (config : config) (abspath_package_config : abs_path) =
-  Printf.printf "  created a package config '%s'\n" (show_path config abspath_package_config)
+let initialize_package_config (spec : logging_spec) (abspath_package_config : abs_path) =
+  Printf.printf "  created a package config '%s'\n" (show_path spec abspath_package_config)
 
 
 let downloading_lock (lock_name : lock_name) (absdir : abs_path) =

--- a/src-saphe/logging.mli
+++ b/src-saphe/logging.mli
@@ -13,13 +13,13 @@ val end_envelope_config_output : logging_spec -> abs_path -> unit
 
 val end_deps_config_output : logging_spec -> abs_path -> unit
 
-val lock_already_installed : lock_name -> abs_path -> unit
+val lock_already_installed : logging_spec -> lock_name -> abs_path -> unit
 
-val lock_cache_exists : lock_name -> abs_path -> unit
+val lock_cache_exists : logging_spec -> lock_name -> abs_path -> unit
 
-val store_root_config_updated : created:bool -> abs_path -> unit
+val store_root_config_updated : logging_spec -> created:bool -> abs_path -> unit
 
-val package_registry_updated : created:bool -> abs_path -> unit
+val package_registry_updated : logging_spec -> created:bool -> abs_path -> unit
 
 val initialize_file : logging_spec -> abs_path -> unit
 

--- a/src-saphe/logging.mli
+++ b/src-saphe/logging.mli
@@ -1,16 +1,22 @@
 
 open MyUtil
+open CommonUtil
 open PackageSystemBase
 
-val show_package_dependency_before_solving : (dependency_flag * package_dependency) list -> unit
+type config = {
+  path_display_setting : path_display_setting;
+  verbosity            : Verbosity.t;
+}
 
-val show_package_dependency_solutions : package_solution list -> unit
+val show_package_dependency_before_solving : config -> (dependency_flag * package_dependency) list -> unit
 
-val end_lock_config_output : abs_path -> unit
+val show_package_dependency_solutions : config -> package_solution list -> unit
 
-val end_envelope_config_output : abs_path -> unit
+val end_lock_config_output : config -> abs_path -> unit
 
-val end_deps_config_output : abs_path -> unit
+val end_envelope_config_output : config -> abs_path -> unit
+
+val end_deps_config_output : config -> abs_path -> unit
 
 val lock_already_installed : lock_name -> abs_path -> unit
 
@@ -20,9 +26,9 @@ val store_root_config_updated : created:bool -> abs_path -> unit
 
 val package_registry_updated : created:bool -> abs_path -> unit
 
-val initialize_file : abs_path -> unit
+val initialize_file : config -> abs_path -> unit
 
-val initialize_package_config : abs_path -> unit
+val initialize_package_config : config -> abs_path -> unit
 
 val downloading_lock : lock_name -> abs_path -> unit
 

--- a/src-saphe/logging.mli
+++ b/src-saphe/logging.mli
@@ -25,6 +25,4 @@ val initialize_file : logging_spec -> abs_path -> unit
 
 val initialize_package_config : logging_spec -> abs_path -> unit
 
-val downloading_lock : lock_name -> abs_path -> unit
-
-val report_canonicalized_url : url:string -> canonicalized_url:string -> hash_value:registry_hash_value -> unit
+val downloading_lock : logging_spec -> lock_name -> abs_path -> unit

--- a/src-saphe/logging.mli
+++ b/src-saphe/logging.mli
@@ -1,22 +1,17 @@
 
 open MyUtil
-open CommonUtil
+open LoggingUtil
 open PackageSystemBase
 
-type config = {
-  path_display_setting : path_display_setting;
-  verbosity            : Verbosity.t;
-}
+val show_package_dependency_before_solving : logging_spec -> (dependency_flag * package_dependency) list -> unit
 
-val show_package_dependency_before_solving : config -> (dependency_flag * package_dependency) list -> unit
+val show_package_dependency_solutions : logging_spec -> package_solution list -> unit
 
-val show_package_dependency_solutions : config -> package_solution list -> unit
+val end_lock_config_output : logging_spec -> abs_path -> unit
 
-val end_lock_config_output : config -> abs_path -> unit
+val end_envelope_config_output : logging_spec -> abs_path -> unit
 
-val end_envelope_config_output : config -> abs_path -> unit
-
-val end_deps_config_output : config -> abs_path -> unit
+val end_deps_config_output : logging_spec -> abs_path -> unit
 
 val lock_already_installed : lock_name -> abs_path -> unit
 
@@ -26,9 +21,9 @@ val store_root_config_updated : created:bool -> abs_path -> unit
 
 val package_registry_updated : created:bool -> abs_path -> unit
 
-val initialize_file : config -> abs_path -> unit
+val initialize_file : logging_spec -> abs_path -> unit
 
-val initialize_package_config : config -> abs_path -> unit
+val initialize_package_config : logging_spec -> abs_path -> unit
 
 val downloading_lock : lock_name -> abs_path -> unit
 

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -526,19 +526,19 @@ let update
     (* Constructs the input: *)
     let solve_input = make_solve_input ~current_dir:absdir_current ~fpath_in in
 
+    (* Loads the package config: *)
     let* registry_remotes =
       match solve_input with
       | PackageSolveInput{ root = absdir_package; _ } ->
-          (* Loads the package config: *)
           let abspath_package_config = Constant.library_package_config_path ~dir:absdir_package in
           let* PackageConfig.{ registry_remotes; _ } = PackageConfig.load abspath_package_config in
           return registry_remotes
 
-    | DocumentSolveInput{ config = abspath_package_config; _ } ->
-        (* Loads the package config: *)
-        let* PackageConfig.{ registry_remotes; _ } = PackageConfig.load abspath_package_config in
-        return registry_remotes
+      | DocumentSolveInput{ config = abspath_package_config; _ } ->
+          let* PackageConfig.{ registry_remotes; _ } = PackageConfig.load abspath_package_config in
+          return registry_remotes
     in
+
     (* Arranges the store root config: *)
     let* absdir_store_root = get_store_root () in
     let abspath_store_root_config = Constant.store_root_config_path ~store_root:absdir_store_root in

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -632,7 +632,7 @@ let build
       let abspath_in = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_in in
       if AbsPathIo.is_directory abspath_in then
         let options =
-          SatysfiCommand.{
+          SatysfiCommand.PackageBuildOption{
             show_full_path;
             verbosity;
           }
@@ -649,7 +649,7 @@ let build
         }
       else
         let options =
-          SatysfiCommand.{
+          SatysfiCommand.DocumentBuildOption{
             show_full_path;
             verbosity;
             page_number_limit;
@@ -721,11 +721,11 @@ let build
 
         (* Builds the package by invoking `satysfi`: *)
         let SatysfiCommand.{ exit_status; command = _ } =
-          SatysfiCommand.(build_package
+          SatysfiCommand.build_package
             ~envelope:abspath_envelope_config
             ~deps:abspath_deps_config
             ~mode:text_mode_formats_str_opt
-            ~options)
+            ~options
         in
         return exit_status
 
@@ -770,13 +770,13 @@ let build
 
         (* Builds the document by invoking `satysfi`: *)
         let SatysfiCommand.{ exit_status; command = _ } =
-          SatysfiCommand.(build_document
+          SatysfiCommand.build_document
             ~doc:abspath_doc
             ~out:abspath_out
             ~dump:abspath_dump
             ~deps:abspath_deps_config
             ~mode:text_mode_formats_str_opt
-            ~options)
+            ~options
         in
         return exit_status
   in
@@ -809,7 +809,7 @@ let test
       let abspath_in = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_in in
       if AbsPathIo.is_directory abspath_in then
         let options =
-          SatysfiCommand.{
+          SatysfiCommand.PackageBuildOption{
             show_full_path;
             verbosity;
           }
@@ -866,11 +866,11 @@ let test
 
         (* Builds the package by invoking `satysfi`: *)
         let SatysfiCommand.{ exit_status; command = _ } =
-          SatysfiCommand.(test_package
+          SatysfiCommand.test_package
             ~envelope:abspath_envelope_config
             ~deps:abspath_deps_config
             ~mode:text_mode_formats_str_opt
-            ~options)
+            ~options
         in
         return exit_status
 

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -614,7 +614,7 @@ let build
     ~(page_number_limit : int)
     ~(max_repeats : int)
     ~(show_full_path : bool)
-    ~(verbose : bool)
+    ~(verbosity : Verbosity.t)
     ~(debug_show_bbox : bool)
     ~(debug_show_space : bool)
     ~(debug_show_block_bbox : bool)
@@ -634,7 +634,7 @@ let build
         let options =
           SatysfiCommand.{
             show_full_path;
-            verbose;
+            verbosity;
           }
         in
         let abspath_package_config = Constant.library_package_config_path ~dir:abspath_in in
@@ -651,7 +651,7 @@ let build
         let options =
           SatysfiCommand.{
             show_full_path;
-            verbose;
+            verbosity;
             page_number_limit;
             debug_show_bbox;
             debug_show_space;
@@ -799,7 +799,7 @@ let test
     ~(fpath_in : string)
     ~(text_mode_formats_str_opt : string option)
     ~(show_full_path : bool)
-    ~(verbose : bool)
+    ~(verbosity : Verbosity.t)
 =
   let res =
     let open ResultMonad in
@@ -811,7 +811,7 @@ let test
         let options =
           SatysfiCommand.{
             show_full_path;
-            verbose;
+            verbosity;
           }
         in
         let abspath_package_config = Constant.library_package_config_path ~dir:abspath_in in

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -63,7 +63,7 @@ let make_lock_name ~seen_from:(absdir_seen_from : abs_path) (lock : Lock.t) : lo
 
   | Lock.LocalFixed{ absolute_path } ->
       Printf.sprintf "local.%s"
-        (AbsPath.make_relative ~from:absdir_seen_from absolute_path)
+        (AbsPath.to_relative_string ~from:absdir_seen_from absolute_path)
 
 
 let make_lock_dependency ~(seen_from : abs_path) (dep : locked_dependency) : LockConfig.lock_dependency =

--- a/src-saphe/sapheMain.ml
+++ b/src-saphe/sapheMain.ml
@@ -548,15 +548,15 @@ let update
 
     PackageRegistryArranger.main
       ~err:(fun e -> CanonicalRegistryUrlError(e))
-      (fun () registry_remote ->
-        let* registry_hash_value = ConfigUtil.make_registry_hash_value registry_remote in
+      (fun () canonical_registry_remote ->
+        let* registry_hash_value = ConfigUtil.make_registry_hash_value canonical_registry_remote in
 
         (* Manupulates the store root config: *)
         let* () =
           update_store_root_config_if_needed
             store_root_config.StoreRootConfig.registries
             registry_hash_value
-            registry_remote
+            canonical_registry_remote
             abspath_store_root_config
         in
 
@@ -566,7 +566,7 @@ let update
         in
         let git_command = "git" in (* TODO: make this changeable *)
         let* created =
-          PackageRegistryFetcher.main ~do_update:true ~git_command absdir_registry_repo registry_remote
+          PackageRegistryFetcher.main ~do_update:true ~git_command absdir_registry_repo canonical_registry_remote
             |> Result.map_error (fun e -> PackageRegistryFetcherError(e))
         in
         Logging.package_registry_updated logging_spec ~created absdir_registry_repo;

--- a/src-saphe/sapheMain.mli
+++ b/src-saphe/sapheMain.mli
@@ -14,6 +14,9 @@ val build :
   fpath_out_opt:(string option) ->
   text_mode_formats_str_opt:(string option) ->
   page_number_limit:int ->
+  max_repeats:int ->
+  show_full_path:bool ->
+  verbose:bool ->
   debug_show_bbox:bool ->
   debug_show_space:bool ->
   debug_show_block_bbox:bool ->
@@ -26,6 +29,8 @@ val build :
 val test :
   fpath_in:string ->
   text_mode_formats_str_opt:(string option) ->
+  show_full_path:bool ->
+  verbose:bool ->
   unit
 
 val cache_list : unit -> unit

--- a/src-saphe/sapheMain.mli
+++ b/src-saphe/sapheMain.mli
@@ -3,9 +3,17 @@ open LoggingUtil
 
 val version : string
 
-val init_document : fpath_in:string -> unit
+val init_document :
+  fpath_in:string ->
+  show_full_path:bool ->
+  verbosity:verbosity ->
+  unit
 
-val init_library : fpath_in:string -> unit
+val init_library :
+  fpath_in:string ->
+  show_full_path:bool ->
+  verbosity:verbosity ->
+  unit
 
 val solve :
   fpath_in:string ->
@@ -13,7 +21,11 @@ val solve :
   verbosity:verbosity ->
   unit
 
-val update : fpath_in:string -> unit
+val update :
+  fpath_in:string ->
+  show_full_path:bool ->
+  verbosity:verbosity ->
+  unit
 
 val build :
   fpath_in:string ->
@@ -39,4 +51,7 @@ val test :
   verbosity:verbosity ->
   unit
 
-val cache_list : unit -> unit
+val cache_list :
+  show_full_path:bool ->
+  verbosity:verbosity ->
+  unit

--- a/src-saphe/sapheMain.mli
+++ b/src-saphe/sapheMain.mli
@@ -5,7 +5,11 @@ val init_document : fpath_in:string -> unit
 
 val init_library : fpath_in:string -> unit
 
-val solve : fpath_in:string -> unit
+val solve :
+  fpath_in:string ->
+  show_full_path:bool ->
+  verbosity:Verbosity.t ->
+  unit
 
 val update : fpath_in:string -> unit
 

--- a/src-saphe/sapheMain.mli
+++ b/src-saphe/sapheMain.mli
@@ -16,7 +16,7 @@ val build :
   page_number_limit:int ->
   max_repeats:int ->
   show_full_path:bool ->
-  verbose:bool ->
+  verbosity:Verbosity.t ->
   debug_show_bbox:bool ->
   debug_show_space:bool ->
   debug_show_block_bbox:bool ->
@@ -30,7 +30,7 @@ val test :
   fpath_in:string ->
   text_mode_formats_str_opt:(string option) ->
   show_full_path:bool ->
-  verbose:bool ->
+  verbosity:Verbosity.t ->
   unit
 
 val cache_list : unit -> unit

--- a/src-saphe/sapheMain.mli
+++ b/src-saphe/sapheMain.mli
@@ -1,4 +1,6 @@
 
+open LoggingUtil
+
 val version : string
 
 val init_document : fpath_in:string -> unit
@@ -8,7 +10,7 @@ val init_library : fpath_in:string -> unit
 val solve :
   fpath_in:string ->
   show_full_path:bool ->
-  verbosity:Verbosity.t ->
+  verbosity:verbosity ->
   unit
 
 val update : fpath_in:string -> unit
@@ -20,7 +22,7 @@ val build :
   page_number_limit:int ->
   max_repeats:int ->
   show_full_path:bool ->
-  verbosity:Verbosity.t ->
+  verbosity:verbosity ->
   debug_show_bbox:bool ->
   debug_show_space:bool ->
   debug_show_block_bbox:bool ->
@@ -34,7 +36,7 @@ val test :
   fpath_in:string ->
   text_mode_formats_str_opt:(string option) ->
   show_full_path:bool ->
-  verbosity:Verbosity.t ->
+  verbosity:verbosity ->
   unit
 
 val cache_list : unit -> unit

--- a/src-saphe/satysfiCommand.ml
+++ b/src-saphe/satysfiCommand.ml
@@ -30,13 +30,13 @@ let make_verbosity_args (verbosity : Verbosity.t) =
   | Verbosity.Quiet   -> [ "--quiet" ]
 
 
-type package_build_option = {
+type package_build_option = PackageBuildOption of {
   show_full_path         : bool;
   verbosity              : Verbosity.t;
 }
 
 
-let make_package_build_option_args (options : package_build_option) =
+let make_package_build_option_args (PackageBuildOption(options) : package_build_option) =
   List.concat [
     if options.show_full_path then [ "--full-path" ] else [];
     make_verbosity_args options.verbosity;
@@ -64,7 +64,7 @@ let build_package
   { exit_status; command }
 
 
-type document_build_option = {
+type document_build_option = DocumentBuildOption of {
   show_full_path         : bool;
   verbosity              : Verbosity.t;
   page_number_limit      : int;
@@ -78,7 +78,7 @@ type document_build_option = {
 }
 
 
-let make_document_build_option_args (options : document_build_option) =
+let make_document_build_option_args (DocumentBuildOption(options) : document_build_option) =
   let flag b s = if b then [ s ] else [] in
   List.concat [
     flag options.show_full_path         "--full-path";

--- a/src-saphe/satysfiCommand.ml
+++ b/src-saphe/satysfiCommand.ml
@@ -1,5 +1,6 @@
 
 open MyUtil
+open LoggingUtil
 
 
 type run_result = {
@@ -23,16 +24,16 @@ let make_mode_args (text_mode_formats_str_opt : string option) =
   | Some(text_mode_formats_str) -> [ "--text-mode"; text_mode_formats_str ]
 
 
-let make_verbosity_args (verbosity : Verbosity.t) =
+let make_verbosity_args (verbosity : verbosity) =
   match verbosity with
-  | Verbosity.Verbose -> [ "--verbose" ]
-  | Verbosity.Normal  -> []
-  | Verbosity.Quiet   -> [ "--quiet" ]
+  | Verbose         -> [ "--verbose" ]
+  | NormalVerbosity -> []
+  | Quiet           -> [ "--quiet" ]
 
 
 type package_build_option = PackageBuildOption of {
-  show_full_path         : bool;
-  verbosity              : Verbosity.t;
+  show_full_path : bool;
+  verbosity      : verbosity;
 }
 
 
@@ -66,7 +67,7 @@ let build_package
 
 type document_build_option = DocumentBuildOption of {
   show_full_path         : bool;
-  verbosity              : Verbosity.t;
+  verbosity              : verbosity;
   page_number_limit      : int;
   debug_show_bbox        : bool;
   debug_show_space       : bool;

--- a/src-saphe/satysfiCommand.ml
+++ b/src-saphe/satysfiCommand.ml
@@ -19,24 +19,27 @@ let escape_command_line (args : string list) : string =
 
 let make_mode_args (text_mode_formats_str_opt : string option) =
   match text_mode_formats_str_opt with
-  | None ->
-      []
+  | None                        -> []
+  | Some(text_mode_formats_str) -> [ "--text-mode"; text_mode_formats_str ]
 
-  | Some(text_mode_formats_str) ->
-      [ "--text-mode"; text_mode_formats_str ]
+
+let make_verbosity_args (verbosity : Verbosity.t) =
+  match verbosity with
+  | Verbosity.Verbose -> [ "--verbose" ]
+  | Verbosity.Normal  -> []
+  | Verbosity.Quiet   -> [ "--quiet" ]
 
 
 type package_build_option = {
   show_full_path         : bool;
-  verbose                : bool;
+  verbosity              : Verbosity.t;
 }
 
 
 let make_package_build_option_args (options : package_build_option) =
-  let flag b s = if b then [ s ] else [] in
   List.concat [
-    flag options.show_full_path "--full-path";
-    flag options.verbose        "--verbose";
+    if options.show_full_path then [ "--full-path" ] else [];
+    make_verbosity_args options.verbosity;
   ]
 
 
@@ -63,7 +66,7 @@ let build_package
 
 type document_build_option = {
   show_full_path         : bool;
-  verbose                : bool;
+  verbosity              : Verbosity.t;
   page_number_limit      : int;
   debug_show_bbox        : bool;
   debug_show_space       : bool;
@@ -79,7 +82,7 @@ let make_document_build_option_args (options : document_build_option) =
   let flag b s = if b then [ s ] else [] in
   List.concat [
     flag options.show_full_path         "--full-path";
-    flag options.verbose                "--verbose";
+    make_verbosity_args options.verbosity;
     flag options.debug_show_bbox        "--debug-show-bbox";
     flag options.debug_show_space       "--debug-show-space";
     flag options.debug_show_block_bbox  "--debug-show-block-bbox";

--- a/src-util/absPath.mli
+++ b/src-util/absPath.mli
@@ -2,17 +2,19 @@
 type t
 [@@deriving show]
 
+val compare : t -> t -> int
+
 val of_string : string -> t option
 
 val of_string_exn : string -> t
 
 val to_string : t -> string
 
+val to_relative_string : from:t -> t -> string
+
+val to_relative_string_if_descendant : from:t -> t -> string
+
 val to_components : t -> string list
-
-val compare : t -> t -> int
-
-val make_relative : from:t -> t -> string
 
 val make_absolute_if_relative : origin:t -> string -> t
 

--- a/src/backend/buildDocument.ml
+++ b/src/backend/buildDocument.ml
@@ -78,10 +78,10 @@ let transform_text =
   EvalUtil.get_string
 
 
-let output_pdf (abspath_out : abs_path) (pdfret : HandlePdf.t) : (unit, config_error) result =
+let output_pdf (display_config : Logging.config) (abspath_out : abs_path) (pdfret : HandlePdf.t) : (unit, config_error) result =
   let open ResultMonad in
   try
-    HandlePdf.write_to_file abspath_out pdfret;
+    HandlePdf.write_to_file display_config abspath_out pdfret;
     return ()
   with
   | _ -> err @@ CannotOutputResult{ path = abspath_out; message = "HandlePdf.write_to_file failed" }
@@ -149,7 +149,17 @@ let build_document ~(max_repeats : int) (transform : syntactic_value -> 'a) (res
 let main (output_mode : output_mode) (pdf_config : HandlePdf.config) ~(page_number_limit : int) ~(max_repeats : int) (display_config : Logging.config) =
   match output_mode with
   | PdfMode ->
-      build_document ~max_repeats (transform_pdf display_config pdf_config ~page_number_limit) reset_pdf output_pdf display_config
+      build_document
+        ~max_repeats
+        (transform_pdf display_config pdf_config ~page_number_limit)
+        reset_pdf
+        (output_pdf display_config)
+        display_config
 
   | TextMode(_) ->
-      build_document ~max_repeats transform_text Fun.id output_text display_config
+      build_document
+        ~max_repeats
+        transform_text
+        Fun.id
+        output_text
+        display_config

--- a/src/backend/buildDocument.mli
+++ b/src/backend/buildDocument.mli
@@ -1,6 +1,7 @@
 
-open ConfigError
 open MyUtil
+open LoggingUtil
+open ConfigError
 open Types
 
 
@@ -9,7 +10,7 @@ val main :
   HandlePdf.config ->
   page_number_limit:int ->
   max_repeats:int ->
-  Logging.config ->
+  logging_spec ->
   is_bytecomp_mode:bool ->
   environment ->
   abstract_tree ->

--- a/src/backend/handlePdf.ml
+++ b/src/backend/handlePdf.ml
@@ -503,8 +503,8 @@ let create_empty_pdf () : t =
   PDF(pdf, Alist.empty)
 
 
-let write_to_file (abspath : abs_path) ((PDF(pdf, pageacc)) : t) : unit =
-  Logging.begin_to_embed_fonts ();
+let write_to_file (display_config : Logging.config) (abspath : abs_path) ((PDF(pdf, pageacc)) : t) : unit =
+  Logging.begin_to_embed_fonts display_config;
   let pdfdict_font = FontInfo.get_font_dictionary pdf in
   let pdfarr_procset =
     Pdf.Array(List.map (fun s -> Pdf.Name(s))
@@ -518,7 +518,7 @@ let write_to_file (abspath : abs_path) ((PDF(pdf, pageacc)) : t) : unit =
       ("/ProcSet", pdfarr_procset);
     ])
   in
-  Logging.begin_to_write_page ();
+  Logging.begin_to_write_page display_config;
   let pagelst =
     pageacc |> Alist.to_list |> List.map (fun page ->
       { page with Pdfpage.resources = Pdf.Indirect(ir_resources); }

--- a/src/backend/handlePdf.ml
+++ b/src/backend/handlePdf.ml
@@ -1,5 +1,6 @@
 
 open MyUtil
+open LoggingUtil
 open LengthInterface
 open GraphicBase
 open HorzBox
@@ -503,8 +504,8 @@ let create_empty_pdf () : t =
   PDF(pdf, Alist.empty)
 
 
-let write_to_file (display_config : Logging.config) (abspath : abs_path) ((PDF(pdf, pageacc)) : t) : unit =
-  Logging.begin_to_embed_fonts display_config;
+let write_to_file (logging_spec : logging_spec) (abspath : abs_path) ((PDF(pdf, pageacc)) : t) : unit =
+  Logging.begin_to_embed_fonts logging_spec;
   let pdfdict_font = FontInfo.get_font_dictionary pdf in
   let pdfarr_procset =
     Pdf.Array(List.map (fun s -> Pdf.Name(s))
@@ -518,7 +519,7 @@ let write_to_file (display_config : Logging.config) (abspath : abs_path) ((PDF(p
       ("/ProcSet", pdfarr_procset);
     ])
   in
-  Logging.begin_to_write_page display_config;
+  Logging.begin_to_write_page logging_spec;
   let pagelst =
     pageacc |> Alist.to_list |> List.map (fun page ->
       { page with Pdfpage.resources = Pdf.Indirect(ir_resources); }

--- a/src/backend/handlePdf.mli
+++ b/src/backend/handlePdf.mli
@@ -1,5 +1,6 @@
 
 open MyUtil
+open LoggingUtil
 open LengthInterface
 open HorzBox
 
@@ -19,7 +20,7 @@ type page
 
 val write_page : config -> page -> page_parts_scheme_func -> t -> t
 
-val write_to_file : Logging.config -> abs_path -> t -> unit
+val write_to_file : logging_spec -> abs_path -> t -> unit
 
 val make_empty_page : paper_size:(length * length) -> page_break_info -> page_content_scheme -> page
 

--- a/src/backend/handlePdf.mli
+++ b/src/backend/handlePdf.mli
@@ -19,7 +19,7 @@ type page
 
 val write_page : config -> page -> page_parts_scheme_func -> t -> t
 
-val write_to_file : abs_path -> t -> unit
+val write_to_file : Logging.config -> abs_path -> t -> unit
 
 val make_empty_page : paper_size:(length * length) -> page_break_info -> page_content_scheme -> page
 

--- a/src/frontend/closedEnvelopeDependencyResolver.ml
+++ b/src/frontend/closedEnvelopeDependencyResolver.ml
@@ -1,8 +1,9 @@
 
 open MyUtil
-open Types
+open LoggingUtil
 open EnvelopeSystemBase
 open ConfigError
+open Types
 
 
 type 'a ok = ('a, config_error) result
@@ -18,7 +19,7 @@ type envelope_info = {
 }
 
 
-let main (display_config : Logging.config) ~(use_test_only_envelope : bool) ~(extensions : string list) (deps_config : DepsConfig.t) : ((envelope_name * (EnvelopeConfig.t * untyped_envelope)) list) ok =
+let main (logging_spec : logging_spec) ~(use_test_only_envelope : bool) ~(extensions : string list) (deps_config : DepsConfig.t) : ((envelope_name * (EnvelopeConfig.t * untyped_envelope)) list) ok =
   let open ResultMonad in
 
   let { envelopes; _ } = deps_config in
@@ -40,7 +41,7 @@ let main (display_config : Logging.config) ~(use_test_only_envelope : bool) ~(ex
       else
         let* envelope_with_config =
           EnvelopeReader.main
-            display_config
+            logging_spec
             ~use_test_files:false (* Does not use tests of depended packages. *)
             ~extensions
             ~envelope_config:abspath_envelope_config

--- a/src/frontend/envelopeChecker.ml
+++ b/src/frontend/envelopeChecker.ml
@@ -110,7 +110,7 @@ let typecheck_library_file (display_config : Logging.config) (config : typecheck
     Logging.begin_to_typecheck_file display_config abspath_in;
     let* absmodsig_opt = utsig_opt |> optionM (ModuleTypechecker.typecheck_signature config tyenv_for_sig) in
     let* ret = ModuleTypechecker.main config tyenv_for_struct absmodsig_opt rng_struct utbinds in
-    Logging.pass_type_check None;
+    Logging.pass_type_check display_config None;
     return ret
   in
   res |> Result.map_error (fun tyerr -> TypeError(tyerr))
@@ -120,7 +120,7 @@ let typecheck_document_file (display_config : Logging.config) (config : typechec
   let open ResultMonad in
   Logging.begin_to_typecheck_file display_config abspath_in;
   let* (ty, ast) = Typechecker.main config Stage1 tyenv utast |> Result.map_error (fun tyerr -> TypeError(tyerr)) in
-  Logging.pass_type_check (Some(Display.show_mono_type ty));
+  Logging.pass_type_check display_config (Some(Display.show_mono_type ty));
   if config.is_text_mode then
     if Typechecker.are_unifiable ty (Range.dummy "text-mode", BaseType(StringType)) then
       return ast

--- a/src/frontend/envelopeChecker.mli
+++ b/src/frontend/envelopeChecker.mli
@@ -1,5 +1,6 @@
 
 open MyUtil
+open LoggingUtil
 open EnvelopeSystemBase
 open Types
 open StaticEnv
@@ -7,7 +8,7 @@ open ConfigError
 
 val main :
   testing:bool ->
-  Logging.config ->
+  logging_spec ->
   typecheck_config ->
   type_environment ->
   global_type_environment ->
@@ -17,7 +18,7 @@ val main :
 
 val main_document :
   testing:bool ->
-  Logging.config ->
+  logging_spec ->
   typecheck_config ->
   type_environment ->
   global_type_environment ->

--- a/src/frontend/envelopeReader.ml
+++ b/src/frontend/envelopeReader.ml
@@ -1,8 +1,9 @@
 
 open MyUtil
+open LoggingUtil
 open EnvelopeSystemBase
-open Types
 open ConfigError
+open Types
 
 
 type 'a ok = ('a, config_error) result
@@ -25,7 +26,7 @@ let listup_sources_in_directory (extensions : string list) (absdir_src : abs_pat
   return abspaths
 
 
-let main (display_config : Logging.config) ~(use_test_files : bool) ~(extensions : string list) ~envelope_config:(abspath_envelope_config : abs_path) : (EnvelopeConfig.t * untyped_envelope) ok =
+let main (logging_spec : logging_spec) ~(use_test_files : bool) ~(extensions : string list) ~envelope_config:(abspath_envelope_config : abs_path) : (EnvelopeConfig.t * untyped_envelope) ok =
   let open ResultMonad in
   let* config = EnvelopeConfig.load abspath_envelope_config in
   let absdir_envelope = AbsPath.dirname abspath_envelope_config in
@@ -49,7 +50,7 @@ let main (display_config : Logging.config) ~(use_test_files : bool) ~(extensions
         let* acc =
           abspaths |> foldM (fun acc abspath_src ->
             let* utsrc =
-              Logging.begin_to_parse_file display_config abspath_src;
+              Logging.begin_to_parse_file logging_spec abspath_src;
               ParserInterface.process_file abspath_src |> Result.map_error (fun e -> FailedToParse(e))
             in
             match utsrc with

--- a/src/frontend/envelopeReader.mli
+++ b/src/frontend/envelopeReader.mli
@@ -1,10 +1,11 @@
 
 open MyUtil
-open Types
+open LoggingUtil
 open ConfigError
+open Types
 
 val main :
-  Logging.config ->
+  logging_spec ->
   use_test_files:bool ->
   extensions:(string list) ->
   envelope_config:abs_path ->

--- a/src/frontend/errorReporting.ml
+++ b/src/frontend/errorReporting.ml
@@ -3,6 +3,7 @@ open ConfigError
 open FontError
 open Format
 open MyUtil
+open LoggingUtil
 open StaticEnv
 open Types
 open TypeError
@@ -664,7 +665,7 @@ let make_yaml_error_message : yaml_error -> line list = function
       [ NormalLine(Printf.sprintf "not a relative path: '%s' %s" s (show_yaml_context yctx)) ]
 
 
-let make_config_error_message (display_config : Logging.config) : config_error -> string = function
+let make_config_error_message (logging_spec : logging_spec) : config_error -> string = function
   | UnexpectedExtension(ext) ->
       make_error_message Interface [
         NormalLine(Printf.sprintf "unexpected file extension '%s'." ext);
@@ -673,18 +674,18 @@ let make_config_error_message (display_config : Logging.config) : config_error -
   | NotALibraryFile(abspath) ->
       make_error_message Typechecker [
         NormalLine("the following file is expected to be a library file, but is not:");
-        DisplayLine(Logging.show_path display_config abspath);
+        DisplayLine(Logging.show_path logging_spec abspath);
       ]
 
   | NotADocumentFile(abspath_in, ty) ->
-      let fname = Logging.show_path display_config abspath_in in
+      let fname = Logging.show_path logging_spec abspath_in in
       make_error_message Typechecker [
         NormalLine(Printf.sprintf "file '%s' is not a document file; it is of type" fname);
         DisplayLine(Display.show_mono_type ty);
       ]
 
   | NotAStringFile(abspath_in, ty) ->
-      let fname = Logging.show_path display_config abspath_in in
+      let fname = Logging.show_path logging_spec abspath_in in
       make_error_message Typechecker [
         NormalLine(Printf.sprintf "file '%s' is not a file for generating text; it is of type" fname);
         DisplayLine(Display.show_mono_type ty);
@@ -699,8 +700,8 @@ let make_config_error_message (display_config : Logging.config) : config_error -
   | FileModuleNameConflict(modnm, abspath1, abspath2) ->
       make_error_message Interface [
         NormalLine(Printf.sprintf "more than one file defines module '%s':" modnm);
-        DisplayLine(Printf.sprintf "- %s" (Logging.show_path display_config abspath1));
-        DisplayLine(Printf.sprintf "- %s" (Logging.show_path display_config abspath2));
+        DisplayLine(Printf.sprintf "- %s" (Logging.show_path logging_spec abspath1));
+        DisplayLine(Printf.sprintf "- %s" (Logging.show_path logging_spec abspath2));
       ]
 
   | NoMainModule(modnm) ->
@@ -725,7 +726,7 @@ let make_config_error_message (display_config : Logging.config) : config_error -
       in
       make_error_message Interface (
         (NormalLine("cyclic dependency detected:")) ::
-          (pairs |> List.map (fun (abspath, _) -> DisplayLine(Logging.show_path display_config abspath)))
+          (pairs |> List.map (fun (abspath, _) -> DisplayLine(Logging.show_path logging_spec abspath)))
       )
 
   | CannotReadFileOwingToSystem(msg) ->
@@ -735,13 +736,13 @@ let make_config_error_message (display_config : Logging.config) : config_error -
       ]
 
   | LibraryContainsWholeReturnValue(abspath) ->
-      let fname = Logging.show_path display_config abspath in
+      let fname = Logging.show_path logging_spec abspath in
       make_error_message Interface [
         NormalLine(Printf.sprintf "file '%s' is not a library; it has a return value." fname);
       ]
 
   | DocumentLacksWholeReturnValue(abspath) ->
-      let fname = Logging.show_path display_config abspath in
+      let fname = Logging.show_path logging_spec abspath in
       make_error_message Interface [
         NormalLine(Printf.sprintf "file '%s' is not a document; it lacks a return value." fname);
       ]
@@ -795,7 +796,7 @@ let make_config_error_message (display_config : Logging.config) : config_error -
   | LocalFileNotFound{ relative; candidates } ->
       let lines =
         candidates |> List.map (fun abspath ->
-          DisplayLine(Printf.sprintf "- %s" (Logging.show_path display_config abspath))
+          DisplayLine(Printf.sprintf "- %s" (Logging.show_path logging_spec abspath))
         )
       in
       make_error_message Interface
@@ -804,37 +805,37 @@ let make_config_error_message (display_config : Logging.config) : config_error -
   | DepsConfigNotFound(abspath_deps_config) ->
       make_error_message Interface [
         NormalLine("cannot find a deps config at:");
-        DisplayLine(Logging.show_path display_config abspath_deps_config);
+        DisplayLine(Logging.show_path logging_spec abspath_deps_config);
       ]
 
   | DepsConfigError(abspath_deps_config, e) ->
       make_error_message Interface (List.append [
         NormalLine("failed to load a deps config:");
-        DisplayLine(Logging.show_path display_config abspath_deps_config);
+        DisplayLine(Logging.show_path logging_spec abspath_deps_config);
       ] (make_yaml_error_message e))
 
   | EnvelopeConfigNotFound(abspath_envelope_config) ->
       make_error_message Interface [
         NormalLine("cannot find an envelope config at:");
-        DisplayLine(Logging.show_path display_config abspath_envelope_config);
+        DisplayLine(Logging.show_path logging_spec abspath_envelope_config);
       ]
 
   | EnvelopeConfigError(abspath_envelope_config, e) ->
       make_error_message Interface (List.append [
         NormalLine("failed to load an envelope config:");
-        DisplayLine(Logging.show_path display_config abspath_envelope_config);
+        DisplayLine(Logging.show_path logging_spec abspath_envelope_config);
       ] (make_yaml_error_message e))
 
   | DumpFileError(abspath_dump, e) ->
       make_error_message Interface (List.append [
         NormalLine("failed to load a dump file (just removing it will remedy this):");
-        DisplayLine(Logging.show_path display_config abspath_dump);
+        DisplayLine(Logging.show_path logging_spec abspath_dump);
       ] (make_yaml_error_message e))
 
   | CannotWriteDumpFile(abspath_dump) ->
       make_error_message Interface [
         NormalLine("cannot write a dump file:");
-        DisplayLine(Logging.show_path display_config abspath_dump);
+        DisplayLine(Logging.show_path logging_spec abspath_dump);
       ]
 
   | DependedEnvelopeNotFound(envelope_name) ->
@@ -868,71 +869,71 @@ let make_config_error_message (display_config : Logging.config) : config_error -
 
   | CannotReadDirectory{ path; message } ->
       make_error_message Interface [
-        NormalLine(Printf.sprintf "cannot read directory '%s':" (Logging.show_path display_config path));
+        NormalLine(Printf.sprintf "cannot read directory '%s':" (Logging.show_path logging_spec path));
         DisplayLine(message);
       ]
 
   | CannotOutputResult{ path; message } ->
       make_error_message Interface [
-        NormalLine(Printf.sprintf "cannot output the final result '%s':" (Logging.show_path display_config path));
+        NormalLine(Printf.sprintf "cannot output the final result '%s':" (Logging.show_path logging_spec path));
         DisplayLine(message);
       ]
 
 
-let make_font_error_message (display_config : Logging.config) = function
+let make_font_error_message (logging_spec : logging_spec) = function
   | FailedToReadFont(abspath, msg) ->
-      let fname = Logging.show_path display_config abspath in
+      let fname = Logging.show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "cannot load font file '%s';" fname);
         DisplayLine(msg);
       ]
 
   | FailedToDecodeFont(abspath, e) ->
-      let fname = Logging.show_path display_config abspath in
+      let fname = Logging.show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "cannot decode font file '%s';" fname);
         NormalLine(Format.asprintf "%a" Otfed.Decode.Error.pp e);
       ]
 
   | FailedToMakeSubset(abspath, e) ->
-      let fname = Logging.show_path display_config abspath in
+      let fname = Logging.show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "cannot make a subset of font file '%s';" fname);
         NormalLine(Format.asprintf "%a" Otfed.Subset.Error.pp e);
       ]
 
   | NotASingleFont(abspath) ->
-      let fname = Logging.show_path display_config abspath in
+      let fname = Logging.show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "the font file '%s' is not a single font file." fname);
       ]
 
   | NotAFontCollectionElement(abspath, index) ->
-      let fname = Logging.show_path display_config abspath in
+      let fname = Logging.show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "the font file '%s' (used with index %d) is not a collection." fname index);
       ]
 
   | NoMathTable(abspath) ->
-      let fname = Logging.show_path display_config abspath in
+      let fname = Logging.show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "font file '%s' does not have a 'MATH' table." fname);
       ]
 
   | PostscriptNameNotFound(abspath) ->
-      let fname = Logging.show_path display_config abspath in
+      let fname = Logging.show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "font file '%s' does not have a PostScript name." fname);
       ]
 
   | CannotFindUnicodeCmap(abspath) ->
-      let fname = Logging.show_path display_config abspath in
+      let fname = Logging.show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "font file '%s' does not have a 'cmap' subtable for Unicode code points." fname);
       ]
 
   | CollectionIndexOutOfBounds{ path; index; num_elements } ->
-      let fname = Logging.show_path display_config path in
+      let fname = Logging.show_path logging_spec path in
       [
         NormalLine(Printf.sprintf "%d: index out of bounds;" index);
         NormalLine(Printf.sprintf "font file '%s' has %d elements." fname num_elements);
@@ -945,7 +946,7 @@ let make_font_error_message (display_config : Logging.config) = function
       [ NormalLine("unsupported: /CIDToGIDMap other than /Identity") ]
 
 
-let error_log_environment (display_config : Logging.config) (suspended : unit -> ('a, config_error) result) : ('a, config_error) result =
+let error_log_environment (logging_spec : logging_spec) (suspended : unit -> ('a, config_error) result) : ('a, config_error) result =
   let report_error kind lines =
     report_and_exit (make_error_message kind lines)
   in
@@ -971,31 +972,31 @@ let error_log_environment (display_config : Logging.config) (suspended : unit ->
       ]
 
   | FontInfo.FontInfoError(e) ->
-      report_error Interface (make_font_error_message display_config e)
+      report_error Interface (make_font_error_message logging_spec e)
 
   | ImageHashTable.CannotLoadPdf(msg, abspath, pageno) ->
-      let fname = Logging.show_path display_config abspath in
+      let fname = Logging.show_path logging_spec abspath in
       report_error Interface [
         NormalLine(Printf.sprintf "cannot load PDF file '%s' page #%d;" fname pageno);
         DisplayLine(msg);
       ]
 
   | ImageHashTable.CannotLoadImage(msg, abspath) ->
-      let fname = Logging.show_path display_config abspath in
+      let fname = Logging.show_path logging_spec abspath in
       report_error Interface [
         NormalLine(Printf.sprintf "cannot load image file '%s';" fname);
         DisplayLine(msg);
       ]
 
   | ImageHashTable.ImageOfWrongFileType(abspath) ->
-      let fname = Logging.show_path display_config abspath in
+      let fname = Logging.show_path logging_spec abspath in
       report_error Interface [
         NormalLine(Printf.sprintf "cannot load image file '%s';" fname);
         DisplayLine("This file format is not supported.");
       ]
 
   | ImageHashTable.UnsupportedColorModel(_, abspath) ->
-      let fname = Logging.show_path display_config abspath in
+      let fname = Logging.show_path logging_spec abspath in
       report_error Interface [
         NormalLine(Printf.sprintf "cannot load image file '%s';" fname);
         DisplayLine("This color model is not supported.");

--- a/src/frontend/errorReporting.ml
+++ b/src/frontend/errorReporting.ml
@@ -674,18 +674,18 @@ let make_config_error_message (logging_spec : logging_spec) : config_error -> st
   | NotALibraryFile(abspath) ->
       make_error_message Typechecker [
         NormalLine("the following file is expected to be a library file, but is not:");
-        DisplayLine(Logging.show_path logging_spec abspath);
+        DisplayLine(show_path logging_spec abspath);
       ]
 
   | NotADocumentFile(abspath_in, ty) ->
-      let fname = Logging.show_path logging_spec abspath_in in
+      let fname = show_path logging_spec abspath_in in
       make_error_message Typechecker [
         NormalLine(Printf.sprintf "file '%s' is not a document file; it is of type" fname);
         DisplayLine(Display.show_mono_type ty);
       ]
 
   | NotAStringFile(abspath_in, ty) ->
-      let fname = Logging.show_path logging_spec abspath_in in
+      let fname = show_path logging_spec abspath_in in
       make_error_message Typechecker [
         NormalLine(Printf.sprintf "file '%s' is not a file for generating text; it is of type" fname);
         DisplayLine(Display.show_mono_type ty);
@@ -700,8 +700,8 @@ let make_config_error_message (logging_spec : logging_spec) : config_error -> st
   | FileModuleNameConflict(modnm, abspath1, abspath2) ->
       make_error_message Interface [
         NormalLine(Printf.sprintf "more than one file defines module '%s':" modnm);
-        DisplayLine(Printf.sprintf "- %s" (Logging.show_path logging_spec abspath1));
-        DisplayLine(Printf.sprintf "- %s" (Logging.show_path logging_spec abspath2));
+        DisplayLine(Printf.sprintf "- %s" (show_path logging_spec abspath1));
+        DisplayLine(Printf.sprintf "- %s" (show_path logging_spec abspath2));
       ]
 
   | NoMainModule(modnm) ->
@@ -726,7 +726,7 @@ let make_config_error_message (logging_spec : logging_spec) : config_error -> st
       in
       make_error_message Interface (
         (NormalLine("cyclic dependency detected:")) ::
-          (pairs |> List.map (fun (abspath, _) -> DisplayLine(Logging.show_path logging_spec abspath)))
+          (pairs |> List.map (fun (abspath, _) -> DisplayLine(show_path logging_spec abspath)))
       )
 
   | CannotReadFileOwingToSystem(msg) ->
@@ -736,13 +736,13 @@ let make_config_error_message (logging_spec : logging_spec) : config_error -> st
       ]
 
   | LibraryContainsWholeReturnValue(abspath) ->
-      let fname = Logging.show_path logging_spec abspath in
+      let fname = show_path logging_spec abspath in
       make_error_message Interface [
         NormalLine(Printf.sprintf "file '%s' is not a library; it has a return value." fname);
       ]
 
   | DocumentLacksWholeReturnValue(abspath) ->
-      let fname = Logging.show_path logging_spec abspath in
+      let fname = show_path logging_spec abspath in
       make_error_message Interface [
         NormalLine(Printf.sprintf "file '%s' is not a document; it lacks a return value." fname);
       ]
@@ -796,7 +796,7 @@ let make_config_error_message (logging_spec : logging_spec) : config_error -> st
   | LocalFileNotFound{ relative; candidates } ->
       let lines =
         candidates |> List.map (fun abspath ->
-          DisplayLine(Printf.sprintf "- %s" (Logging.show_path logging_spec abspath))
+          DisplayLine(Printf.sprintf "- %s" (show_path logging_spec abspath))
         )
       in
       make_error_message Interface
@@ -805,37 +805,37 @@ let make_config_error_message (logging_spec : logging_spec) : config_error -> st
   | DepsConfigNotFound(abspath_deps_config) ->
       make_error_message Interface [
         NormalLine("cannot find a deps config at:");
-        DisplayLine(Logging.show_path logging_spec abspath_deps_config);
+        DisplayLine(show_path logging_spec abspath_deps_config);
       ]
 
   | DepsConfigError(abspath_deps_config, e) ->
       make_error_message Interface (List.append [
         NormalLine("failed to load a deps config:");
-        DisplayLine(Logging.show_path logging_spec abspath_deps_config);
+        DisplayLine(show_path logging_spec abspath_deps_config);
       ] (make_yaml_error_message e))
 
   | EnvelopeConfigNotFound(abspath_envelope_config) ->
       make_error_message Interface [
         NormalLine("cannot find an envelope config at:");
-        DisplayLine(Logging.show_path logging_spec abspath_envelope_config);
+        DisplayLine(show_path logging_spec abspath_envelope_config);
       ]
 
   | EnvelopeConfigError(abspath_envelope_config, e) ->
       make_error_message Interface (List.append [
         NormalLine("failed to load an envelope config:");
-        DisplayLine(Logging.show_path logging_spec abspath_envelope_config);
+        DisplayLine(show_path logging_spec abspath_envelope_config);
       ] (make_yaml_error_message e))
 
   | DumpFileError(abspath_dump, e) ->
       make_error_message Interface (List.append [
         NormalLine("failed to load a dump file (just removing it will remedy this):");
-        DisplayLine(Logging.show_path logging_spec abspath_dump);
+        DisplayLine(show_path logging_spec abspath_dump);
       ] (make_yaml_error_message e))
 
   | CannotWriteDumpFile(abspath_dump) ->
       make_error_message Interface [
         NormalLine("cannot write a dump file:");
-        DisplayLine(Logging.show_path logging_spec abspath_dump);
+        DisplayLine(show_path logging_spec abspath_dump);
       ]
 
   | DependedEnvelopeNotFound(envelope_name) ->
@@ -869,71 +869,71 @@ let make_config_error_message (logging_spec : logging_spec) : config_error -> st
 
   | CannotReadDirectory{ path; message } ->
       make_error_message Interface [
-        NormalLine(Printf.sprintf "cannot read directory '%s':" (Logging.show_path logging_spec path));
+        NormalLine(Printf.sprintf "cannot read directory '%s':" (show_path logging_spec path));
         DisplayLine(message);
       ]
 
   | CannotOutputResult{ path; message } ->
       make_error_message Interface [
-        NormalLine(Printf.sprintf "cannot output the final result '%s':" (Logging.show_path logging_spec path));
+        NormalLine(Printf.sprintf "cannot output the final result '%s':" (show_path logging_spec path));
         DisplayLine(message);
       ]
 
 
 let make_font_error_message (logging_spec : logging_spec) = function
   | FailedToReadFont(abspath, msg) ->
-      let fname = Logging.show_path logging_spec abspath in
+      let fname = show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "cannot load font file '%s';" fname);
         DisplayLine(msg);
       ]
 
   | FailedToDecodeFont(abspath, e) ->
-      let fname = Logging.show_path logging_spec abspath in
+      let fname = show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "cannot decode font file '%s';" fname);
         NormalLine(Format.asprintf "%a" Otfed.Decode.Error.pp e);
       ]
 
   | FailedToMakeSubset(abspath, e) ->
-      let fname = Logging.show_path logging_spec abspath in
+      let fname = show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "cannot make a subset of font file '%s';" fname);
         NormalLine(Format.asprintf "%a" Otfed.Subset.Error.pp e);
       ]
 
   | NotASingleFont(abspath) ->
-      let fname = Logging.show_path logging_spec abspath in
+      let fname = show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "the font file '%s' is not a single font file." fname);
       ]
 
   | NotAFontCollectionElement(abspath, index) ->
-      let fname = Logging.show_path logging_spec abspath in
+      let fname = show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "the font file '%s' (used with index %d) is not a collection." fname index);
       ]
 
   | NoMathTable(abspath) ->
-      let fname = Logging.show_path logging_spec abspath in
+      let fname = show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "font file '%s' does not have a 'MATH' table." fname);
       ]
 
   | PostscriptNameNotFound(abspath) ->
-      let fname = Logging.show_path logging_spec abspath in
+      let fname = show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "font file '%s' does not have a PostScript name." fname);
       ]
 
   | CannotFindUnicodeCmap(abspath) ->
-      let fname = Logging.show_path logging_spec abspath in
+      let fname = show_path logging_spec abspath in
       [
         NormalLine(Printf.sprintf "font file '%s' does not have a 'cmap' subtable for Unicode code points." fname);
       ]
 
   | CollectionIndexOutOfBounds{ path; index; num_elements } ->
-      let fname = Logging.show_path logging_spec path in
+      let fname = show_path logging_spec path in
       [
         NormalLine(Printf.sprintf "%d: index out of bounds;" index);
         NormalLine(Printf.sprintf "font file '%s' has %d elements." fname num_elements);
@@ -975,28 +975,28 @@ let error_log_environment (logging_spec : logging_spec) (suspended : unit -> ('a
       report_error Interface (make_font_error_message logging_spec e)
 
   | ImageHashTable.CannotLoadPdf(msg, abspath, pageno) ->
-      let fname = Logging.show_path logging_spec abspath in
+      let fname = show_path logging_spec abspath in
       report_error Interface [
         NormalLine(Printf.sprintf "cannot load PDF file '%s' page #%d;" fname pageno);
         DisplayLine(msg);
       ]
 
   | ImageHashTable.CannotLoadImage(msg, abspath) ->
-      let fname = Logging.show_path logging_spec abspath in
+      let fname = show_path logging_spec abspath in
       report_error Interface [
         NormalLine(Printf.sprintf "cannot load image file '%s';" fname);
         DisplayLine(msg);
       ]
 
   | ImageHashTable.ImageOfWrongFileType(abspath) ->
-      let fname = Logging.show_path logging_spec abspath in
+      let fname = show_path logging_spec abspath in
       report_error Interface [
         NormalLine(Printf.sprintf "cannot load image file '%s';" fname);
         DisplayLine("This file format is not supported.");
       ]
 
   | ImageHashTable.UnsupportedColorModel(_, abspath) ->
-      let fname = Logging.show_path logging_spec abspath in
+      let fname = show_path logging_spec abspath in
       report_error Interface [
         NormalLine(Printf.sprintf "cannot load image file '%s';" fname);
         DisplayLine("This color model is not supported.");

--- a/src/frontend/errorReporting.mli
+++ b/src/frontend/errorReporting.mli
@@ -1,11 +1,9 @@
 
+open LoggingUtil
 open ConfigError
 
+val make_config_error_message : logging_spec -> config_error -> string
 
-val make_config_error_message : Logging.config -> config_error -> string
-
-
-val error_log_environment : Logging.config -> (unit -> ('a, config_error) result) -> ('a, config_error) result
-
+val error_log_environment : logging_spec -> (unit -> ('a, config_error) result) -> ('a, config_error) result
 
 val report_and_exit : string -> unit

--- a/src/frontend/logging.ml
+++ b/src/frontend/logging.ml
@@ -1,49 +1,43 @@
 
 open MyUtil
-open CommonUtil
+open LoggingUtil
 
 
-type config = {
-  path_display_setting : path_display_setting;
-  verbosity            : Verbosity.t;
-}
+let show_path (spec : logging_spec) =
+  display_path spec.path_display_setting
 
 
-let show_path (config : config) =
-  display_path config.path_display_setting
-
-
-let begin_to_typecheck_file (config : config) (abspath_in : abs_path) =
-  if is_verbose config.verbosity then begin
+let begin_to_typecheck_file (spec : logging_spec) (abspath_in : abs_path) =
+  if is_verbose spec.verbosity then begin
     print_endline " ---- ---- ---- ----";
     Printf.printf "  type checking '%s' ...\n"
-      (show_path config abspath_in)
+      (show_path spec abspath_in)
   end
 
 
-let begin_to_preprocess_file (config : config) (abspath_in : abs_path) =
-  if is_verbose config.verbosity then begin
+let begin_to_preprocess_file (spec : logging_spec) (abspath_in : abs_path) =
+  if is_verbose spec.verbosity then begin
     Printf.printf "  preprocessing '%s' ...\n"
-      (show_path config abspath_in)
+      (show_path spec abspath_in)
   end
 
 
-let begin_to_eval_file (config : config) (abspath_in : abs_path) =
-  if is_verbose config.verbosity then begin
+let begin_to_eval_file (spec : logging_spec) (abspath_in : abs_path) =
+  if is_verbose spec.verbosity then begin
     Printf.printf "  evaluating '%s' ...\n"
-      (show_path config abspath_in)
+      (show_path spec abspath_in)
   end
 
 
-let begin_to_parse_file (config : config) (abspath_in : abs_path) =
-  if is_verbose config.verbosity then begin
+let begin_to_parse_file (spec : logging_spec) (abspath_in : abs_path) =
+  if is_verbose spec.verbosity then begin
     Printf.printf "  parsing '%s' ...\n"
-      (show_path config abspath_in)
+      (show_path spec abspath_in)
   end
 
 
-let pass_type_check (config : config) (opt : string option) =
-  if is_verbose config.verbosity then
+let pass_type_check (spec : logging_spec) (opt : string option) =
+  if is_verbose spec.verbosity then
     match opt with
     | None      -> print_endline "  type check passed."
     | Some(str) -> Printf.printf "  type check passed. (%s)\n" str
@@ -60,8 +54,8 @@ let ordinal i =
   Printf.sprintf "%d%s" i suffix
 
 
-let start_evaluation (config : config) (i : int) =
-  if is_not_quiet config.verbosity then begin
+let start_evaluation (spec : logging_spec) (i : int) =
+  if is_not_quiet spec.verbosity then begin
     print_endline " ---- ---- ---- ----";
     if i <= 1 then
       print_endline "  evaluating texts ..."
@@ -71,35 +65,35 @@ let start_evaluation (config : config) (i : int) =
   end
 
 
-let end_evaluation (config : config) =
-  if is_not_quiet config.verbosity then begin
+let end_evaluation (spec : logging_spec) =
+  if is_not_quiet spec.verbosity then begin
     print_endline "  evaluation done."
   end
 
 
-let start_page_break (config : config) =
-  if is_not_quiet config.verbosity then begin
+let start_page_break (spec : logging_spec) =
+  if is_not_quiet spec.verbosity then begin
     print_endline " ---- ---- ---- ----";
     print_endline "  breaking contents into pages ..."
   end
 
 
-let needs_another_trial (config : config) =
-  if is_not_quiet config.verbosity then begin
+let needs_another_trial (spec : logging_spec) =
+  if is_not_quiet spec.verbosity then begin
     print_endline "  needs another trial for solving cross references..."
   end
 
 
-let achieve_count_max (config : config) =
-  if is_not_quiet config.verbosity then begin
+let achieve_count_max (spec : logging_spec) =
+  if is_not_quiet spec.verbosity then begin
     print_endline "  could not reach a fixpoint when resolving cross references."
   end
 
 
-let achieve_fixpoint (config : config) (unresolved_crossrefs : string list) =
+let achieve_fixpoint (spec : logging_spec) (unresolved_crossrefs : string list) =
   match unresolved_crossrefs with
   | [] ->
-      if is_not_quiet config.verbosity then begin
+      if is_not_quiet spec.verbosity then begin
         print_endline "  all cross references were solved."
       end
 
@@ -110,58 +104,58 @@ let achieve_fixpoint (config : config) (unresolved_crossrefs : string list) =
       )
 
 
-let end_output (config : config) (file_name_out : abs_path) =
-  if is_not_quiet config.verbosity then begin
+let end_output (spec : logging_spec) (file_name_out : abs_path) =
+  if is_not_quiet spec.verbosity then begin
     print_endline " ---- ---- ---- ----";
     Printf.printf "  output written on '%s'.\n"
-      (show_path config file_name_out)
+      (show_path spec file_name_out)
   end
 
 
-let target_file (config : config) (file_name_out : abs_path) =
-  if is_not_quiet config.verbosity then begin
+let target_file (spec : logging_spec) (file_name_out : abs_path) =
+  if is_not_quiet spec.verbosity then begin
     print_endline " ---- ---- ---- ----";
     Printf.printf "  target file: '%s'\n"
-      (show_path config file_name_out)
+      (show_path spec file_name_out)
   end
 
 
-let dump_file (config : config) ~(already_exists : bool) (dump_file : abs_path) =
-  if is_not_quiet config.verbosity then begin
+let dump_file (spec : logging_spec) ~(already_exists : bool) (dump_file : abs_path) =
+  if is_not_quiet spec.verbosity then begin
     if already_exists then
       Printf.printf "  dump file: '%s' (already exists)\n"
-        (show_path config dump_file)
+        (show_path spec dump_file)
     else
       Printf.printf "  dump file: '%s' (will be created)\n"
-        (show_path config dump_file)
+        (show_path spec dump_file)
   end
 
 
-let deps_config_file (config : config) (abspath_deps_config : abs_path) =
-  if is_not_quiet config.verbosity then begin
+let deps_config_file (spec : logging_spec) (abspath_deps_config : abs_path) =
+  if is_not_quiet spec.verbosity then begin
     Printf.printf "  deps file: '%s'\n"
-      (show_path config abspath_deps_config)
+      (show_path spec abspath_deps_config)
   end
 
 
-let begin_to_embed_fonts (config : config) =
-  if is_not_quiet config.verbosity then begin
+let begin_to_embed_fonts (spec : logging_spec) =
+  if is_not_quiet spec.verbosity then begin
     print_endline " ---- ---- ---- ----";
     print_endline "  embedding fonts ..."
   end
 
 
-let begin_to_write_page (config : config) =
-  if is_not_quiet config.verbosity then begin
+let begin_to_write_page (spec : logging_spec) =
+  if is_not_quiet spec.verbosity then begin
     print_endline " ---- ---- ---- ----";
     print_endline "  writing pages ..."
   end
 
 
 let warn_cmyk_image (file_name : abs_path) =
-  let config = { path_display_setting = FullPath; verbosity = Verbosity.Normal } in (* TODO: make this changeable *)
+  let spec = { path_display_setting = FullPath; verbosity = NormalVerbosity } in (* TODO: make this changeable *)
   Printf.printf "  [Warning] Jpeg images with CMYK color mode are not fully supported: '%s'\n"
-    (show_path config file_name);
+    (show_path spec file_name);
   print_endline "  Please convert the image to a jpeg image with YCbCr (RGB) color model."
 
 

--- a/src/frontend/logging.ml
+++ b/src/frontend/logging.ml
@@ -19,29 +19,39 @@ let show_path (config : config) (abspath : abs_path) =
 
 
 let begin_to_typecheck_file (config : config) (abspath_in : abs_path) =
-  print_endline " ---- ---- ---- ----";
-  Printf.printf "  type checking '%s' ...\n"
-    (show_path config abspath_in)
+  if config.verbose then begin
+    print_endline " ---- ---- ---- ----";
+    Printf.printf "  type checking '%s' ...\n"
+      (show_path config abspath_in)
+  end
 
 
 let begin_to_preprocess_file (config : config) (abspath_in : abs_path) =
-  Printf.printf "  preprocessing '%s' ...\n"
-    (show_path config abspath_in)
+  if config.verbose then begin
+    Printf.printf "  preprocessing '%s' ...\n"
+      (show_path config abspath_in)
+  end
 
 
 let begin_to_eval_file (config : config) (abspath_in : abs_path) =
-  Printf.printf "  evaluating '%s' ...\n"
-    (show_path config abspath_in)
+  if config.verbose then begin
+    Printf.printf "  evaluating '%s' ...\n"
+      (show_path config abspath_in)
+  end
 
 
 let begin_to_parse_file (config : config) (abspath_in : abs_path) =
-  Printf.printf "  parsing '%s' ...\n"
-    (show_path config abspath_in)
+  if config.verbose then begin
+    Printf.printf "  parsing '%s' ...\n"
+      (show_path config abspath_in)
+  end
 
 
-let pass_type_check = function
-  | None      -> print_endline "  type check passed."
-  | Some(str) -> Printf.printf "  type check passed. (%s)\n" str
+let pass_type_check (config : config) (opt : string option) =
+  if config.verbose then
+    match opt with
+    | None      -> print_endline "  type check passed."
+    | Some(str) -> Printf.printf "  type check passed. (%s)\n" str
 
 
 let ordinal i =
@@ -55,7 +65,7 @@ let ordinal i =
   Printf.sprintf "%d%s" i suffix
 
 
-let start_evaluation i =
+let start_evaluation (_config : config) (i : int) =
   print_endline " ---- ---- ---- ----";
   if i <= 1 then
     print_endline "  evaluating texts ..."
@@ -64,24 +74,24 @@ let start_evaluation i =
       (ordinal i)
 
 
-let end_evaluation () =
+let end_evaluation (_config : config) =
   print_endline "  evaluation done."
 
 
-let start_page_break () =
+let start_page_break (_config : config) =
   print_endline " ---- ---- ---- ----";
   print_endline "  breaking contents into pages ..."
 
 
-let needs_another_trial () =
+let needs_another_trial (_config : config) =
   print_endline "  needs another trial for solving cross references..."
 
 
-let achieve_count_max () =
-  print_endline "  could not reach to fixpoint when resolving cross references."
+let achieve_count_max (_config : config) =
+  print_endline "  could not reach a fixpoint when resolving cross references."
 
 
-let achieve_fixpoint unresolved_crossrefs =
+let achieve_fixpoint (_config : config) (unresolved_crossrefs : string list) =
   match unresolved_crossrefs with
   | [] ->
       print_endline "  all cross references were solved."

--- a/src/frontend/logging.ml
+++ b/src/frontend/logging.ml
@@ -3,12 +3,8 @@ open MyUtil
 open LoggingUtil
 
 
-let show_path (spec : logging_spec) =
-  display_path spec.path_display_setting
-
-
 let begin_to_typecheck_file (spec : logging_spec) (abspath_in : abs_path) =
-  if is_verbose spec.verbosity then begin
+  if is_verbose spec then begin
     print_endline " ---- ---- ---- ----";
     Printf.printf "  type checking '%s' ...\n"
       (show_path spec abspath_in)
@@ -16,28 +12,28 @@ let begin_to_typecheck_file (spec : logging_spec) (abspath_in : abs_path) =
 
 
 let begin_to_preprocess_file (spec : logging_spec) (abspath_in : abs_path) =
-  if is_verbose spec.verbosity then begin
+  if is_verbose spec then begin
     Printf.printf "  preprocessing '%s' ...\n"
       (show_path spec abspath_in)
   end
 
 
 let begin_to_eval_file (spec : logging_spec) (abspath_in : abs_path) =
-  if is_verbose spec.verbosity then begin
+  if is_verbose spec then begin
     Printf.printf "  evaluating '%s' ...\n"
       (show_path spec abspath_in)
   end
 
 
 let begin_to_parse_file (spec : logging_spec) (abspath_in : abs_path) =
-  if is_verbose spec.verbosity then begin
+  if is_verbose spec then begin
     Printf.printf "  parsing '%s' ...\n"
       (show_path spec abspath_in)
   end
 
 
 let pass_type_check (spec : logging_spec) (opt : string option) =
-  if is_verbose spec.verbosity then
+  if is_verbose spec then
     match opt with
     | None      -> print_endline "  type check passed."
     | Some(str) -> Printf.printf "  type check passed. (%s)\n" str
@@ -55,7 +51,7 @@ let ordinal i =
 
 
 let start_evaluation (spec : logging_spec) (i : int) =
-  if is_not_quiet spec.verbosity then begin
+  if is_not_quiet spec then begin
     print_endline " ---- ---- ---- ----";
     if i <= 1 then
       print_endline "  evaluating texts ..."
@@ -66,26 +62,26 @@ let start_evaluation (spec : logging_spec) (i : int) =
 
 
 let end_evaluation (spec : logging_spec) =
-  if is_not_quiet spec.verbosity then begin
+  if is_not_quiet spec then begin
     print_endline "  evaluation done."
   end
 
 
 let start_page_break (spec : logging_spec) =
-  if is_not_quiet spec.verbosity then begin
+  if is_not_quiet spec then begin
     print_endline " ---- ---- ---- ----";
     print_endline "  breaking contents into pages ..."
   end
 
 
 let needs_another_trial (spec : logging_spec) =
-  if is_not_quiet spec.verbosity then begin
+  if is_not_quiet spec then begin
     print_endline "  needs another trial for solving cross references..."
   end
 
 
 let achieve_count_max (spec : logging_spec) =
-  if is_not_quiet spec.verbosity then begin
+  if is_not_quiet spec then begin
     print_endline "  could not reach a fixpoint when resolving cross references."
   end
 
@@ -93,7 +89,7 @@ let achieve_count_max (spec : logging_spec) =
 let achieve_fixpoint (spec : logging_spec) (unresolved_crossrefs : string list) =
   match unresolved_crossrefs with
   | [] ->
-      if is_not_quiet spec.verbosity then begin
+      if is_not_quiet spec then begin
         print_endline "  all cross references were solved."
       end
 
@@ -105,7 +101,7 @@ let achieve_fixpoint (spec : logging_spec) (unresolved_crossrefs : string list) 
 
 
 let end_output (spec : logging_spec) (file_name_out : abs_path) =
-  if is_not_quiet spec.verbosity then begin
+  if is_not_quiet spec then begin
     print_endline " ---- ---- ---- ----";
     Printf.printf "  output written on '%s'.\n"
       (show_path spec file_name_out)
@@ -113,7 +109,7 @@ let end_output (spec : logging_spec) (file_name_out : abs_path) =
 
 
 let target_file (spec : logging_spec) (file_name_out : abs_path) =
-  if is_not_quiet spec.verbosity then begin
+  if is_not_quiet spec then begin
     print_endline " ---- ---- ---- ----";
     Printf.printf "  target file: '%s'\n"
       (show_path spec file_name_out)
@@ -121,7 +117,7 @@ let target_file (spec : logging_spec) (file_name_out : abs_path) =
 
 
 let dump_file (spec : logging_spec) ~(already_exists : bool) (dump_file : abs_path) =
-  if is_not_quiet spec.verbosity then begin
+  if is_not_quiet spec then begin
     if already_exists then
       Printf.printf "  dump file: '%s' (already exists)\n"
         (show_path spec dump_file)
@@ -132,21 +128,21 @@ let dump_file (spec : logging_spec) ~(already_exists : bool) (dump_file : abs_pa
 
 
 let deps_config_file (spec : logging_spec) (abspath_deps_config : abs_path) =
-  if is_not_quiet spec.verbosity then begin
+  if is_not_quiet spec then begin
     Printf.printf "  deps file: '%s'\n"
       (show_path spec abspath_deps_config)
   end
 
 
 let begin_to_embed_fonts (spec : logging_spec) =
-  if is_not_quiet spec.verbosity then begin
+  if is_not_quiet spec then begin
     print_endline " ---- ---- ---- ----";
     print_endline "  embedding fonts ..."
   end
 
 
 let begin_to_write_page (spec : logging_spec) =
-  if is_not_quiet spec.verbosity then begin
+  if is_not_quiet spec then begin
     print_endline " ---- ---- ---- ----";
     print_endline "  writing pages ..."
   end

--- a/src/frontend/logging.ml
+++ b/src/frontend/logging.ml
@@ -8,7 +8,7 @@ type path_display_setting =
 
 type config = {
   path_display_setting : path_display_setting;
-  verbose              : bool;
+  verbosity            : Verbosity.t;
 }
 
 
@@ -18,8 +18,18 @@ let show_path (config : config) (abspath : abs_path) =
   | RelativeToCwd(abspath_cwd) -> AbsPath.make_relative ~from:abspath_cwd abspath
 
 
+let is_verbose = function
+  | Verbosity.Verbose -> true
+  | _                 -> false
+
+
+let is_not_quiet = function
+  | Verbosity.Quiet -> false
+  | _               -> true
+
+
 let begin_to_typecheck_file (config : config) (abspath_in : abs_path) =
-  if config.verbose then begin
+  if is_verbose config.verbosity then begin
     print_endline " ---- ---- ---- ----";
     Printf.printf "  type checking '%s' ...\n"
       (show_path config abspath_in)
@@ -27,28 +37,28 @@ let begin_to_typecheck_file (config : config) (abspath_in : abs_path) =
 
 
 let begin_to_preprocess_file (config : config) (abspath_in : abs_path) =
-  if config.verbose then begin
+  if is_verbose config.verbosity then begin
     Printf.printf "  preprocessing '%s' ...\n"
       (show_path config abspath_in)
   end
 
 
 let begin_to_eval_file (config : config) (abspath_in : abs_path) =
-  if config.verbose then begin
+  if is_verbose config.verbosity then begin
     Printf.printf "  evaluating '%s' ...\n"
       (show_path config abspath_in)
   end
 
 
 let begin_to_parse_file (config : config) (abspath_in : abs_path) =
-  if config.verbose then begin
+  if is_verbose config.verbosity then begin
     Printf.printf "  parsing '%s' ...\n"
       (show_path config abspath_in)
   end
 
 
 let pass_type_check (config : config) (opt : string option) =
-  if config.verbose then
+  if is_verbose config.verbosity then
     match opt with
     | None      -> print_endline "  type check passed."
     | Some(str) -> Printf.printf "  type check passed. (%s)\n" str
@@ -65,68 +75,88 @@ let ordinal i =
   Printf.sprintf "%d%s" i suffix
 
 
-let start_evaluation (_config : config) (i : int) =
-  print_endline " ---- ---- ---- ----";
-  if i <= 1 then
-    print_endline "  evaluating texts ..."
-  else
-    Printf.printf "  evaluating texts (%s trial) ...\n"
-      (ordinal i)
+let start_evaluation (config : config) (i : int) =
+  if is_not_quiet config.verbosity then begin
+    print_endline " ---- ---- ---- ----";
+    if i <= 1 then
+      print_endline "  evaluating texts ..."
+    else
+      Printf.printf "  evaluating texts (%s trial) ...\n"
+        (ordinal i)
+  end
 
 
-let end_evaluation (_config : config) =
-  print_endline "  evaluation done."
+let end_evaluation (config : config) =
+  if is_not_quiet config.verbosity then begin
+    print_endline "  evaluation done."
+  end
 
 
-let start_page_break (_config : config) =
-  print_endline " ---- ---- ---- ----";
-  print_endline "  breaking contents into pages ..."
+let start_page_break (config : config) =
+  if is_not_quiet config.verbosity then begin
+    print_endline " ---- ---- ---- ----";
+    print_endline "  breaking contents into pages ..."
+  end
 
 
-let needs_another_trial (_config : config) =
-  print_endline "  needs another trial for solving cross references..."
+let needs_another_trial (config : config) =
+  if is_not_quiet config.verbosity then begin
+    print_endline "  needs another trial for solving cross references..."
+  end
 
 
-let achieve_count_max (_config : config) =
-  print_endline "  could not reach a fixpoint when resolving cross references."
+let achieve_count_max (config : config) =
+  if is_not_quiet config.verbosity then begin
+    print_endline "  could not reach a fixpoint when resolving cross references."
+  end
 
 
-let achieve_fixpoint (_config : config) (unresolved_crossrefs : string list) =
+let achieve_fixpoint (config : config) (unresolved_crossrefs : string list) =
   match unresolved_crossrefs with
   | [] ->
-      print_endline "  all cross references were solved."
+      if is_not_quiet config.verbosity then begin
+        print_endline "  all cross references were solved."
+      end
 
   | _ :: _ ->
-      print_endline "  some cross references were not solved:";
+      print_endline "  [Warning] some cross references were not solved:";
       unresolved_crossrefs |> List.iter (fun crossref ->
         Printf.printf "  - %s\n" crossref
       )
 
 
 let end_output (config : config) (file_name_out : abs_path) =
-  print_endline " ---- ---- ---- ----";
-  Printf.printf "  output written on '%s'.\n"
-    (show_path config file_name_out)
+  if is_not_quiet config.verbosity then begin
+    print_endline " ---- ---- ---- ----";
+    Printf.printf "  output written on '%s'.\n"
+      (show_path config file_name_out)
+  end
 
 
 let target_file (config : config) (file_name_out : abs_path) =
-  print_endline " ---- ---- ---- ----";
-  Printf.printf "  target file: '%s'\n"
-    (show_path config file_name_out)
+  if is_not_quiet config.verbosity then begin
+    print_endline " ---- ---- ---- ----";
+    Printf.printf "  target file: '%s'\n"
+      (show_path config file_name_out)
+  end
 
 
 let dump_file (config : config) ~(already_exists : bool) (dump_file : abs_path) =
-  if already_exists then
-    Printf.printf "  dump file: '%s' (already exists)\n"
-      (show_path config dump_file)
-  else
-    Printf.printf "  dump file: '%s' (will be created)\n"
-      (show_path config dump_file)
+  if is_not_quiet config.verbosity then begin
+    if already_exists then
+      Printf.printf "  dump file: '%s' (already exists)\n"
+        (show_path config dump_file)
+    else
+      Printf.printf "  dump file: '%s' (will be created)\n"
+        (show_path config dump_file)
+  end
 
 
 let deps_config_file (config : config) (abspath_deps_config : abs_path) =
-  Printf.printf "  deps file: '%s'\n"
-    (show_path config abspath_deps_config)
+  if is_not_quiet config.verbosity then begin
+    Printf.printf "  deps file: '%s'\n"
+      (show_path config abspath_deps_config)
+  end
 
 
 let begin_to_embed_fonts () =
@@ -140,7 +170,7 @@ let begin_to_write_page () =
 
 
 let warn_cmyk_image (file_name : abs_path) =
-  let config = { path_display_setting = FullPath; verbose = false } in (* TODO: make this changeable *)
+  let config = { path_display_setting = FullPath; verbosity = Verbosity.Normal } in (* TODO: make this changeable *)
   Printf.printf "  [Warning] Jpeg images with CMYK color mode are not fully supported: '%s'\n"
     (show_path config file_name);
   print_endline "  Please convert the image to a jpeg image with YCbCr (RGB) color model."

--- a/src/frontend/logging.ml
+++ b/src/frontend/logging.ml
@@ -8,6 +8,7 @@ type path_display_setting =
 
 type config = {
   path_display_setting : path_display_setting;
+  verbose              : bool;
 }
 
 
@@ -129,7 +130,7 @@ let begin_to_write_page () =
 
 
 let warn_cmyk_image (file_name : abs_path) =
-  let config = { path_display_setting = FullPath } in (* TODO: make this changeable *)
+  let config = { path_display_setting = FullPath; verbose = false } in (* TODO: make this changeable *)
   Printf.printf "  [Warning] Jpeg images with CMYK color mode are not fully supported: '%s'\n"
     (show_path config file_name);
   print_endline "  Please convert the image to a jpeg image with YCbCr (RGB) color model."

--- a/src/frontend/logging.ml
+++ b/src/frontend/logging.ml
@@ -159,14 +159,18 @@ let deps_config_file (config : config) (abspath_deps_config : abs_path) =
   end
 
 
-let begin_to_embed_fonts () =
-  print_endline " ---- ---- ---- ----";
-  print_endline "  embedding fonts ..."
+let begin_to_embed_fonts (config : config) =
+  if is_not_quiet config.verbosity then begin
+    print_endline " ---- ---- ---- ----";
+    print_endline "  embedding fonts ..."
+  end
 
 
-let begin_to_write_page () =
-  print_endline " ---- ---- ---- ----";
-  print_endline "  writing pages ..."
+let begin_to_write_page (config : config) =
+  if is_not_quiet config.verbosity then begin
+    print_endline " ---- ---- ---- ----";
+    print_endline "  writing pages ..."
+  end
 
 
 let warn_cmyk_image (file_name : abs_path) =

--- a/src/frontend/logging.ml
+++ b/src/frontend/logging.ml
@@ -1,10 +1,7 @@
 
 open MyUtil
+open CommonUtil
 
-
-type path_display_setting =
-  | FullPath
-  | RelativeToCwd of abs_path
 
 type config = {
   path_display_setting : path_display_setting;
@@ -12,20 +9,8 @@ type config = {
 }
 
 
-let show_path (config : config) (abspath : abs_path) =
-  match config.path_display_setting with
-  | FullPath                   -> AbsPath.to_string abspath
-  | RelativeToCwd(abspath_cwd) -> AbsPath.make_relative ~from:abspath_cwd abspath
-
-
-let is_verbose = function
-  | Verbosity.Verbose -> true
-  | _                 -> false
-
-
-let is_not_quiet = function
-  | Verbosity.Quiet -> false
-  | _               -> true
+let show_path (config : config) =
+  display_path config.path_display_setting
 
 
 let begin_to_typecheck_file (config : config) (abspath_in : abs_path) =

--- a/src/frontend/logging.mli
+++ b/src/frontend/logging.mli
@@ -1,47 +1,42 @@
 
 open MyUtil
-open CommonUtil
+open LoggingUtil
 
-type config = {
-  path_display_setting : path_display_setting;
-  verbosity            : Verbosity.t;
-}
+val show_path : logging_spec -> abs_path -> string
 
-val show_path : config -> abs_path -> string
+val begin_to_typecheck_file : logging_spec -> abs_path -> unit
 
-val begin_to_typecheck_file : config -> abs_path -> unit
+val begin_to_preprocess_file : logging_spec -> abs_path -> unit
 
-val begin_to_preprocess_file : config -> abs_path -> unit
+val begin_to_eval_file : logging_spec -> abs_path -> unit
 
-val begin_to_eval_file : config -> abs_path -> unit
+val begin_to_parse_file : logging_spec -> abs_path -> unit
 
-val begin_to_parse_file : config -> abs_path -> unit
+val pass_type_check : logging_spec -> string option -> unit
 
-val pass_type_check : config -> string option -> unit
+val start_evaluation : logging_spec -> int -> unit
 
-val start_evaluation : config -> int -> unit
+val end_evaluation : logging_spec -> unit
 
-val end_evaluation : config -> unit
+val start_page_break : logging_spec -> unit
 
-val start_page_break : config -> unit
+val needs_another_trial : logging_spec -> unit
 
-val needs_another_trial : config -> unit
+val achieve_count_max : logging_spec -> unit
 
-val achieve_count_max : config -> unit
+val achieve_fixpoint : logging_spec -> string list -> unit
 
-val achieve_fixpoint : config -> string list -> unit
+val end_output : logging_spec -> abs_path -> unit
 
-val end_output : config -> abs_path -> unit
+val target_file : logging_spec -> abs_path -> unit
 
-val target_file : config -> abs_path -> unit
+val dump_file : logging_spec -> already_exists:bool -> abs_path -> unit
 
-val dump_file : config -> already_exists:bool -> abs_path -> unit
+val deps_config_file : logging_spec -> abs_path -> unit
 
-val deps_config_file : config -> abs_path -> unit
+val begin_to_embed_fonts : logging_spec -> unit
 
-val begin_to_embed_fonts : config -> unit
-
-val begin_to_write_page : config -> unit
+val begin_to_write_page : logging_spec -> unit
 
 val warn_noninjective_cmap : Uchar.t -> Uchar.t -> Otfed.Value.glyph_id -> unit
 

--- a/src/frontend/logging.mli
+++ b/src/frontend/logging.mli
@@ -42,9 +42,9 @@ val dump_file : config -> already_exists:bool -> abs_path -> unit
 
 val deps_config_file : config -> abs_path -> unit
 
-val begin_to_embed_fonts : unit -> unit
+val begin_to_embed_fonts : config -> unit
 
-val begin_to_write_page : unit -> unit
+val begin_to_write_page : config -> unit
 
 val warn_noninjective_cmap : Uchar.t -> Uchar.t -> Otfed.Value.glyph_id -> unit
 

--- a/src/frontend/logging.mli
+++ b/src/frontend/logging.mli
@@ -2,8 +2,6 @@
 open MyUtil
 open LoggingUtil
 
-val show_path : logging_spec -> abs_path -> string
-
 val begin_to_typecheck_file : logging_spec -> abs_path -> unit
 
 val begin_to_preprocess_file : logging_spec -> abs_path -> unit

--- a/src/frontend/logging.mli
+++ b/src/frontend/logging.mli
@@ -7,6 +7,7 @@ type path_display_setting =
 
 type config = {
   path_display_setting : path_display_setting;
+  verbose              : bool;
 }
 
 val show_path : config -> abs_path -> string

--- a/src/frontend/logging.mli
+++ b/src/frontend/logging.mli
@@ -1,9 +1,6 @@
 
 open MyUtil
-
-type path_display_setting =
-  | FullPath
-  | RelativeToCwd of abs_path
+open CommonUtil
 
 type config = {
   path_display_setting : path_display_setting;

--- a/src/frontend/logging.mli
+++ b/src/frontend/logging.mli
@@ -20,17 +20,19 @@ val begin_to_eval_file : config -> abs_path -> unit
 
 val begin_to_parse_file : config -> abs_path -> unit
 
-val pass_type_check : string option -> unit
+val pass_type_check : config -> string option -> unit
 
-val start_evaluation : int -> unit
+val start_evaluation : config -> int -> unit
 
-val end_evaluation : unit -> unit
+val end_evaluation : config -> unit
 
-val start_page_break : unit -> unit
+val start_page_break : config -> unit
 
-val achieve_count_max : unit -> unit
+val needs_another_trial : config -> unit
 
-val achieve_fixpoint : string list -> unit
+val achieve_count_max : config -> unit
+
+val achieve_fixpoint : config -> string list -> unit
 
 val end_output : config -> abs_path -> unit
 
@@ -43,8 +45,6 @@ val deps_config_file : config -> abs_path -> unit
 val begin_to_embed_fonts : unit -> unit
 
 val begin_to_write_page : unit -> unit
-
-val needs_another_trial : unit -> unit
 
 val warn_noninjective_cmap : Uchar.t -> Uchar.t -> Otfed.Value.glyph_id -> unit
 

--- a/src/frontend/logging.mli
+++ b/src/frontend/logging.mli
@@ -7,7 +7,7 @@ type path_display_setting =
 
 type config = {
   path_display_setting : path_display_setting;
-  verbose              : bool;
+  verbosity            : Verbosity.t;
 }
 
 val show_path : config -> abs_path -> string

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -151,14 +151,14 @@ let make_output_mode text_mode_formats_str_opt =
   | Some(s) -> TextMode(String.split_on_char ',' s)
 
 
-let make_display_config ~(show_full_path : bool) ~(verbose : bool) ~current_dir:(absdir_current : abs_path) =
+let make_display_config ~(show_full_path : bool) ~(verbosity : Verbosity.t) ~current_dir:(absdir_current : abs_path) =
   let path_display_setting =
     if show_full_path then
       Logging.FullPath
     else
       Logging.RelativeToCwd(absdir_current)
   in
-  Logging.{ path_display_setting; verbose }
+  Logging.{ path_display_setting; verbosity }
 
 
 (* TODO: discard `job_directory` *)
@@ -171,11 +171,11 @@ let build_package
     ~(fpath_deps : string)
     ~(text_mode_formats_str_opt : string option)
     ~(show_full_path : bool)
-    ~(verbose : bool)
+    ~(verbosity : Verbosity.t)
 =
   let open ResultMonad in
   let absdir_current = AbsPathIo.getcwd () in
-  let display_config = make_display_config ~show_full_path ~verbose ~current_dir:absdir_current in
+  let display_config = make_display_config ~show_full_path ~verbosity ~current_dir:absdir_current in
   error_log_environment display_config (fun () ->
     let abspath_envelope_config = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_in in
     let abspath_deps_config = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_deps in
@@ -237,7 +237,7 @@ let build_document
     ~(page_number_limit : int)
     ~(max_repeats : int)
     ~(show_full_path : bool)
-    ~(verbose : bool)
+    ~(verbosity : Verbosity.t)
     ~(debug_show_bbox : bool)
     ~(debug_show_space : bool)
     ~(debug_show_block_bbox : bool)
@@ -248,7 +248,7 @@ let build_document
 =
 let open ResultMonad in
   let absdir_current = AbsPathIo.getcwd () in
-  let display_config = make_display_config ~show_full_path ~verbose ~current_dir:absdir_current in
+  let display_config = make_display_config ~show_full_path ~verbosity ~current_dir:absdir_current in
   error_log_environment display_config (fun () ->
     let abspath_in = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_in in
     let abspath_out = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_out in
@@ -340,11 +340,11 @@ let test_package
     ~(fpath_deps : string)
     ~(text_mode_formats_str_opt : string option)
     ~(show_full_path : bool)
-    ~(verbose : bool)
+    ~(verbosity : Verbosity.t)
 =
   let open ResultMonad in
   let absdir_current = AbsPathIo.getcwd () in
-  let display_config = make_display_config ~show_full_path ~verbose ~current_dir:absdir_current in
+  let display_config = make_display_config ~show_full_path ~verbosity ~current_dir:absdir_current in
   error_log_environment display_config (fun () ->
     let abspath_in = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_in in
     let abspath_deps_config = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_deps in

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -151,14 +151,14 @@ let make_output_mode text_mode_formats_str_opt =
   | Some(s) -> TextMode(String.split_on_char ',' s)
 
 
-let make_display_config ~(show_full_path : bool) ~current_dir:(absdir_current : abs_path) =
+let make_display_config ~(show_full_path : bool) ~(verbose : bool) ~current_dir:(absdir_current : abs_path) =
   let path_display_setting =
     if show_full_path then
       Logging.FullPath
     else
       Logging.RelativeToCwd(absdir_current)
   in
-  Logging.{ path_display_setting }
+  Logging.{ path_display_setting; verbose }
 
 
 (* TODO: discard `job_directory` *)
@@ -171,10 +171,11 @@ let build_package
     ~(fpath_deps : string)
     ~(text_mode_formats_str_opt : string option)
     ~(show_full_path : bool)
+    ~(verbose : bool)
 =
   let open ResultMonad in
   let absdir_current = AbsPathIo.getcwd () in
-  let display_config = make_display_config ~show_full_path ~current_dir:absdir_current in
+  let display_config = make_display_config ~show_full_path ~verbose ~current_dir:absdir_current in
   error_log_environment display_config (fun () ->
     let abspath_envelope_config = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_in in
     let abspath_deps_config = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_deps in
@@ -236,6 +237,7 @@ let build_document
     ~(page_number_limit : int)
     ~(max_repeats : int)
     ~(show_full_path : bool)
+    ~(verbose : bool)
     ~(debug_show_bbox : bool)
     ~(debug_show_space : bool)
     ~(debug_show_block_bbox : bool)
@@ -246,7 +248,7 @@ let build_document
 =
 let open ResultMonad in
   let absdir_current = AbsPathIo.getcwd () in
-  let display_config = make_display_config ~show_full_path ~current_dir:absdir_current in
+  let display_config = make_display_config ~show_full_path ~verbose ~current_dir:absdir_current in
   error_log_environment display_config (fun () ->
     let abspath_in = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_in in
     let abspath_out = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_out in
@@ -338,10 +340,11 @@ let test_package
     ~(fpath_deps : string)
     ~(text_mode_formats_str_opt : string option)
     ~(show_full_path : bool)
+    ~(verbose : bool)
 =
   let open ResultMonad in
   let absdir_current = AbsPathIo.getcwd () in
-  let display_config = make_display_config ~show_full_path ~current_dir:absdir_current in
+  let display_config = make_display_config ~show_full_path ~verbose ~current_dir:absdir_current in
   error_log_environment display_config (fun () ->
     let abspath_in = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_in in
     let abspath_deps_config = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_deps in

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -1,5 +1,6 @@
 
 open MyUtil
+open CommonUtil
 open EnvelopeSystemBase
 open ErrorReporting
 open Types
@@ -154,9 +155,9 @@ let make_output_mode text_mode_formats_str_opt =
 let make_display_config ~(show_full_path : bool) ~(verbosity : Verbosity.t) ~current_dir:(absdir_current : abs_path) =
   let path_display_setting =
     if show_full_path then
-      Logging.FullPath
+      FullPath
     else
-      Logging.RelativeToCwd(absdir_current)
+      RelativeToCwd(absdir_current)
   in
   Logging.{ path_display_setting; verbosity }
 

--- a/src/frontend/main.ml
+++ b/src/frontend/main.ml
@@ -1,6 +1,6 @@
 
 open MyUtil
-open CommonUtil
+open LoggingUtil
 open EnvelopeSystemBase
 open ErrorReporting
 open Types
@@ -37,8 +37,8 @@ let initialize ~(is_bytecomp_mode : bool) (output_mode : output_mode) (runtime_c
   (tyenv, env)
 
 
-let eval_library_file (display_config : Logging.config) ~(is_bytecomp_mode : bool) ~(run_tests : bool) (env : environment) (abspath : abs_path) (binds : binding list) : environment =
-  Logging.begin_to_eval_file display_config abspath;
+let eval_library_file (logging_spec : logging_spec) ~(is_bytecomp_mode : bool) ~(run_tests : bool) (env : environment) (abspath : abs_path) (binds : binding list) : environment =
+  Logging.begin_to_eval_file logging_spec abspath;
   if is_bytecomp_mode then
     failwith "TODO: eval_libary_file, Bytecomp"
 (*
@@ -52,10 +52,10 @@ let eval_library_file (display_config : Logging.config) ~(is_bytecomp_mode : boo
 
 (* Performs preprecessing. the evaluation is run by the naive interpreter
    regardless of whether `--bytecomp` was specified. *)
-let preprocess_bindings (display_config : Logging.config) ~(run_tests : bool) (env : environment) (libs : (abs_path * binding list) list) : environment * (abs_path * code_rec_or_nonrec list) list =
+let preprocess_bindings (logging_spec : logging_spec) ~(run_tests : bool) (env : environment) (libs : (abs_path * binding list) list) : environment * (abs_path * code_rec_or_nonrec list) list =
   let (env, codebindacc) =
     libs |> List.fold_left (fun (env, codebindacc) (abspath, binds) ->
-      Logging.begin_to_preprocess_file display_config abspath;
+      Logging.begin_to_preprocess_file logging_spec abspath;
       let (env, cd_rec_or_nonrecs) = Evaluator.interpret_bindings_0 ~run_tests env binds in
       (env, Alist.extend codebindacc (abspath, cd_rec_or_nonrecs))
     ) (env, Alist.empty)
@@ -65,26 +65,26 @@ let preprocess_bindings (display_config : Logging.config) ~(run_tests : bool) (e
 
 
 (* Performs evaluation and returns the resulting environment. *)
-let evaluate_bindings (display_config : Logging.config) ~(is_bytecomp_mode : bool) ~(run_tests : bool) (env : environment) (codebinds : (abs_path * code_rec_or_nonrec list) list) : environment =
+let evaluate_bindings (logging_spec : logging_spec) ~(is_bytecomp_mode : bool) ~(run_tests : bool) (env : environment) (codebinds : (abs_path * code_rec_or_nonrec list) list) : environment =
   codebinds |> List.fold_left (fun env (abspath, cd_rec_or_nonrecs) ->
     let binds =
       cd_rec_or_nonrecs |> List.map (fun cd_rec_or_nonrec ->
         Bind(Stage0, unlift_rec_or_nonrec cd_rec_or_nonrec)
       )
     in
-    eval_library_file display_config ~is_bytecomp_mode ~run_tests env abspath binds
+    eval_library_file logging_spec ~is_bytecomp_mode ~run_tests env abspath binds
   ) env
 
 
-let preprocess_and_evaluate (display_config : Logging.config) (pdf_config : HandlePdf.config) ~(page_number_limit : int) ~(is_bytecomp_mode : bool) (output_mode : output_mode) ~(run_tests : bool) (env : environment) (libs : (abs_path * binding list) list) (ast_doc : abstract_tree) (_abspath_in : abs_path) (abspath_out : abs_path) (abspath_dump : abs_path) =
+let preprocess_and_evaluate (logging_spec : logging_spec) (pdf_config : HandlePdf.config) ~(page_number_limit : int) ~(is_bytecomp_mode : bool) (output_mode : output_mode) ~(run_tests : bool) (env : environment) (libs : (abs_path * binding list) list) (ast_doc : abstract_tree) (_abspath_in : abs_path) (abspath_out : abs_path) (abspath_dump : abs_path) =
   (* Performs preprocessing: *)
-  let (env, codebinds) = preprocess_bindings display_config ~run_tests env libs in
+  let (env, codebinds) = preprocess_bindings logging_spec ~run_tests env libs in
   let code_doc = Evaluator.interpret_1 env ast_doc in
 
   (* Performs evaluation: *)
-  let env = evaluate_bindings display_config ~is_bytecomp_mode ~run_tests env codebinds in
+  let env = evaluate_bindings logging_spec ~is_bytecomp_mode ~run_tests env codebinds in
   let ast_doc = unlift_code code_doc in
-  BuildDocument.main output_mode pdf_config ~page_number_limit display_config ~is_bytecomp_mode env ast_doc abspath_out abspath_dump
+  BuildDocument.main output_mode pdf_config ~page_number_limit logging_spec ~is_bytecomp_mode env ast_doc abspath_out abspath_dump
 
 
 let get_candidate_file_extensions (output_mode : output_mode) =
@@ -123,11 +123,11 @@ let make_used_as_map_for_checking_dependency (deps_config : DepsConfig.t) (envel
   | Some(used_as_map) -> return used_as_map
 
 
-let check_depended_envelopes (display_config : Logging.config) (typecheck_config : typecheck_config) ~(use_test_only_envelope : bool) ~(extensions : string list) (tyenv_prim : Typeenv.t) (deps_config : DepsConfig.t) =
+let check_depended_envelopes (logging_spec : logging_spec) (typecheck_config : typecheck_config) ~(use_test_only_envelope : bool) ~(extensions : string list) (tyenv_prim : Typeenv.t) (deps_config : DepsConfig.t) =
   let open ResultMonad in
   (* Resolves dependency among envelopes: *)
   let* sorted_envelopes =
-    ClosedEnvelopeDependencyResolver.main display_config ~use_test_only_envelope ~extensions deps_config
+    ClosedEnvelopeDependencyResolver.main logging_spec ~use_test_only_envelope ~extensions deps_config
   in
 
   (* Typechecks every depended envelope (Note: We must ignore `#[test-only]` in dependencies): *)
@@ -135,7 +135,7 @@ let check_depended_envelopes (display_config : Logging.config) (typecheck_config
     sorted_envelopes |> foldM (fun (genv, configenv, libacc) (envelope_name, (config, envelope)) ->
       let* used_as_map = make_used_as_map_for_checking_dependency deps_config envelope_name in
       let* (ssig, libs) =
-        EnvelopeChecker.main ~testing:false display_config typecheck_config tyenv_prim genv ~used_as_map envelope
+        EnvelopeChecker.main ~testing:false logging_spec typecheck_config tyenv_prim genv ~used_as_map envelope
       in
       let genv = genv |> GlobalTypeenv.add (EnvelopeName.EN(envelope_name)) ssig in
       let configenv = configenv |> GlobalTypeenv.add (EnvelopeName.EN(envelope_name)) config in
@@ -152,7 +152,7 @@ let make_output_mode text_mode_formats_str_opt =
   | Some(s) -> TextMode(String.split_on_char ',' s)
 
 
-let make_display_config ~(show_full_path : bool) ~(verbosity : Verbosity.t) ~current_dir:(absdir_current : abs_path) =
+let make_logging_spec ~(show_full_path : bool) ~(verbosity : verbosity) ~current_dir:(absdir_current : abs_path) =
   let path_display_setting =
     if show_full_path then
       FullPath
@@ -172,12 +172,12 @@ let build_package
     ~(fpath_deps : string)
     ~(text_mode_formats_str_opt : string option)
     ~(show_full_path : bool)
-    ~(verbosity : Verbosity.t)
+    ~(verbosity : verbosity)
 =
   let open ResultMonad in
   let absdir_current = AbsPathIo.getcwd () in
-  let display_config = make_display_config ~show_full_path ~verbosity ~current_dir:absdir_current in
-  error_log_environment display_config (fun () ->
+  let logging_spec = make_logging_spec ~show_full_path ~verbosity ~current_dir:absdir_current in
+  error_log_environment logging_spec (fun () ->
     let abspath_envelope_config = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_in in
     let abspath_deps_config = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_deps in
     let output_mode = make_output_mode text_mode_formats_str_opt in
@@ -198,20 +198,20 @@ let build_package
     in
 
     (* Loads the deps config: *)
-    Logging.deps_config_file display_config abspath_deps_config;
+    Logging.deps_config_file logging_spec abspath_deps_config;
     let* deps_config = DepsConfig.load abspath_deps_config in
     let used_as_map = make_used_as_map deps_config.explicit_dependencies in
 
     (* Parses the main envelope: *)
     let* (_config, envelope) =
-      EnvelopeReader.main display_config ~use_test_files:false ~extensions
+      EnvelopeReader.main logging_spec ~use_test_files:false ~extensions
         ~envelope_config:abspath_envelope_config
     in
 
     (* Typechecks each depended envelope in the topological order: *)
     let* (genv, _configenv, _libs_dep) =
       check_depended_envelopes
-        display_config typecheck_config
+        logging_spec typecheck_config
         ~use_test_only_envelope:false ~extensions
         tyenv_prim deps_config
     in
@@ -220,13 +220,13 @@ let build_package
     let* (_ssig, _libs_target) =
       EnvelopeChecker.main
         ~testing:false
-        display_config typecheck_config tyenv_prim genv ~used_as_map envelope
+        logging_spec typecheck_config tyenv_prim genv ~used_as_map envelope
     in
     return ()
 
   ) |> function
   | Ok(())   -> ()
-  | Error(e) -> report_and_exit (make_config_error_message display_config e)
+  | Error(e) -> report_and_exit (make_config_error_message logging_spec e)
 
 
 let build_document
@@ -238,7 +238,7 @@ let build_document
     ~(page_number_limit : int)
     ~(max_repeats : int)
     ~(show_full_path : bool)
-    ~(verbosity : Verbosity.t)
+    ~(verbosity : verbosity)
     ~(debug_show_bbox : bool)
     ~(debug_show_space : bool)
     ~(debug_show_block_bbox : bool)
@@ -249,8 +249,8 @@ let build_document
 =
 let open ResultMonad in
   let absdir_current = AbsPathIo.getcwd () in
-  let display_config = make_display_config ~show_full_path ~verbosity ~current_dir:absdir_current in
-  error_log_environment display_config (fun () ->
+  let logging_spec = make_logging_spec ~show_full_path ~verbosity ~current_dir:absdir_current in
+  error_log_environment logging_spec (fun () ->
     let abspath_in = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_in in
     let abspath_out = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_out in
     let abspath_dump = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_dump in
@@ -283,20 +283,20 @@ let open ResultMonad in
     in
 
     (* Loads the deps config: *)
-    Logging.deps_config_file display_config abspath_deps_config;
+    Logging.deps_config_file logging_spec abspath_deps_config;
     let* deps_config = DepsConfig.load abspath_deps_config in
     let used_as_map = make_used_as_map deps_config.explicit_dependencies in
 
-    Logging.target_file display_config abspath_out;
+    Logging.target_file logging_spec abspath_out;
 
     (* Initializes the dump file: *)
     let* dump_file_exists = CrossRef.initialize abspath_dump in
-    Logging.dump_file display_config ~already_exists:dump_file_exists abspath_dump;
+    Logging.dump_file logging_spec ~already_exists:dump_file_exists abspath_dump;
 
     (* Typechecks each depended envelope in the topological order: *)
     let* (genv, configenv, libs_dep) =
       check_depended_envelopes
-        display_config
+        logging_spec
         typecheck_config
         ~use_test_only_envelope:false
         ~extensions
@@ -306,14 +306,14 @@ let open ResultMonad in
 
     (* Resolve dependency of the document and the local source files: *)
     let* (sorted_locals, utdoc) =
-      OpenFileDependencyResolver.main display_config ~extensions input_kind configenv ~used_as_map abspath_in
+      OpenFileDependencyResolver.main logging_spec ~extensions input_kind configenv ~used_as_map abspath_in
     in
 
     (* Typechecking and elaboration: *)
     let* (libs_local, ast_doc) =
       EnvelopeChecker.main_document
         ~testing:false
-        display_config typecheck_config tyenv_prim genv ~used_as_map sorted_locals (abspath_in, utdoc)
+        logging_spec typecheck_config tyenv_prim genv ~used_as_map sorted_locals (abspath_in, utdoc)
     in
 
     (* Evaluation: *)
@@ -322,7 +322,7 @@ let open ResultMonad in
     else
       let libs = List.append libs_dep libs_local in
       preprocess_and_evaluate
-        display_config
+        logging_spec
         pdf_config
         ~page_number_limit
         ~max_repeats
@@ -333,7 +333,7 @@ let open ResultMonad in
 
   ) |> function
   | Ok(())   -> ()
-  | Error(e) -> report_and_exit (make_config_error_message display_config e)
+  | Error(e) -> report_and_exit (make_config_error_message logging_spec e)
 
 
 let test_package
@@ -341,12 +341,12 @@ let test_package
     ~(fpath_deps : string)
     ~(text_mode_formats_str_opt : string option)
     ~(show_full_path : bool)
-    ~(verbosity : Verbosity.t)
+    ~(verbosity : verbosity)
 =
   let open ResultMonad in
   let absdir_current = AbsPathIo.getcwd () in
-  let display_config = make_display_config ~show_full_path ~verbosity ~current_dir:absdir_current in
-  error_log_environment display_config (fun () ->
+  let logging_spec = make_logging_spec ~show_full_path ~verbosity ~current_dir:absdir_current in
+  error_log_environment logging_spec (fun () ->
     let abspath_in = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_in in
     let abspath_deps_config = AbsPath.make_absolute_if_relative ~origin:absdir_current fpath_deps in
     let output_mode = make_output_mode text_mode_formats_str_opt in
@@ -368,19 +368,19 @@ let test_package
     in
 
     (* Loads the deps config: *)
-    Logging.deps_config_file display_config abspath_deps_config;
+    Logging.deps_config_file logging_spec abspath_deps_config;
     let* deps_config = DepsConfig.load abspath_deps_config in
 
     (* Parses the main envelope: *)
     let* (_config, package) =
-      EnvelopeReader.main display_config ~use_test_files:true ~extensions
+      EnvelopeReader.main logging_spec ~use_test_files:true ~extensions
         ~envelope_config:abspath_in
     in
 
     (* Typechecks each depended envelope in the topological order: *)
     let* (genv, _configenv, libs_dep) =
       check_depended_envelopes
-        display_config
+        logging_spec
         typecheck_config_deps
         ~use_test_only_envelope:true
         ~extensions
@@ -397,14 +397,14 @@ let test_package
     let* (_ssig, libs_target) =
       EnvelopeChecker.main
         ~testing:true
-        display_config typecheck_config_main tyenv_prim genv ~used_as_map package
+        logging_spec typecheck_config_main tyenv_prim genv ~used_as_map package
     in
 
     (* Runs tests (Note: we do not run the tests in dependencies): *)
-    let (env, codebinds_dep) = preprocess_bindings display_config ~run_tests:false env libs_dep in
-    let (env, codebinds_target) = preprocess_bindings display_config ~run_tests:true env libs_target in
-    let env = evaluate_bindings display_config ~run_tests:false ~is_bytecomp_mode:false env codebinds_dep in
-    let _env = evaluate_bindings display_config ~run_tests:true ~is_bytecomp_mode:false env codebinds_target in
+    let (env, codebinds_dep) = preprocess_bindings logging_spec ~run_tests:false env libs_dep in
+    let (env, codebinds_target) = preprocess_bindings logging_spec ~run_tests:true env libs_target in
+    let env = evaluate_bindings logging_spec ~run_tests:false ~is_bytecomp_mode:false env codebinds_dep in
+    let _env = evaluate_bindings logging_spec ~run_tests:true ~is_bytecomp_mode:false env codebinds_target in
 
     let test_results = State.get_all_test_results () in
     let failure_found =
@@ -427,4 +427,4 @@ let test_package
       end
 
   | Error(e) ->
-      report_and_exit (make_config_error_message display_config e)
+      report_and_exit (make_config_error_message logging_spec e)

--- a/src/frontend/main.mli
+++ b/src/frontend/main.mli
@@ -6,7 +6,7 @@ val build_package :
   fpath_deps:string ->
   text_mode_formats_str_opt:(string option) ->
   show_full_path:bool ->
-  verbose:bool ->
+  verbosity:Verbosity.t ->
   unit
 
 val build_document :
@@ -18,7 +18,7 @@ val build_document :
   page_number_limit:int ->
   max_repeats:int ->
   show_full_path:bool ->
-  verbose:bool ->
+  verbosity:Verbosity.t ->
   debug_show_bbox:bool ->
   debug_show_space:bool ->
   debug_show_block_bbox:bool ->
@@ -33,5 +33,5 @@ val test_package :
   fpath_deps:string ->
   text_mode_formats_str_opt:(string option) ->
   show_full_path:bool ->
-  verbose:bool ->
+  verbosity:Verbosity.t ->
   unit

--- a/src/frontend/main.mli
+++ b/src/frontend/main.mli
@@ -6,6 +6,7 @@ val build_package :
   fpath_deps:string ->
   text_mode_formats_str_opt:(string option) ->
   show_full_path:bool ->
+  verbose:bool ->
   unit
 
 val build_document :
@@ -17,6 +18,7 @@ val build_document :
   page_number_limit:int ->
   max_repeats:int ->
   show_full_path:bool ->
+  verbose:bool ->
   debug_show_bbox:bool ->
   debug_show_space:bool ->
   debug_show_block_bbox:bool ->
@@ -31,4 +33,5 @@ val test_package :
   fpath_deps:string ->
   text_mode_formats_str_opt:(string option) ->
   show_full_path:bool ->
+  verbose:bool ->
   unit

--- a/src/frontend/main.mli
+++ b/src/frontend/main.mli
@@ -1,4 +1,6 @@
 
+open LoggingUtil
+
 val version : string
 
 val build_package :
@@ -6,7 +8,7 @@ val build_package :
   fpath_deps:string ->
   text_mode_formats_str_opt:(string option) ->
   show_full_path:bool ->
-  verbosity:Verbosity.t ->
+  verbosity:verbosity ->
   unit
 
 val build_document :
@@ -18,7 +20,7 @@ val build_document :
   page_number_limit:int ->
   max_repeats:int ->
   show_full_path:bool ->
-  verbosity:Verbosity.t ->
+  verbosity:verbosity ->
   debug_show_bbox:bool ->
   debug_show_space:bool ->
   debug_show_block_bbox:bool ->
@@ -33,5 +35,5 @@ val test_package :
   fpath_deps:string ->
   text_mode_formats_str_opt:(string option) ->
   show_full_path:bool ->
-  verbosity:Verbosity.t ->
+  verbosity:verbosity ->
   unit

--- a/src/frontend/openFileDependencyResolver.mli
+++ b/src/frontend/openFileDependencyResolver.mli
@@ -1,11 +1,12 @@
 
 open MyUtil
+open LoggingUtil
 open EnvelopeSystemBase
-open Types
 open ConfigError
+open Types
 
 val main :
-  Logging.config ->
+  logging_spec ->
   extensions:(string list) ->
   input_kind ->
   EnvelopeConfig.t GlobalTypeenv.t ->

--- a/test/common/absPathTest.ml
+++ b/test/common/absPathTest.ml
@@ -11,22 +11,39 @@ let of_string_exn_test () =
   ]
 
 
-let make_relative_test () =
+let to_relative_string_test () =
   List.iter (fun (s_from, s_target, expected) ->
     let from = AbsPath.of_string_exn s_from in
     let target = AbsPath.of_string_exn s_target in
-    let got = AbsPath.make_relative ~from target in
+    let got = AbsPath.to_relative_string ~from target in
     Alcotest.(check string) "make_relative" expected got
   ) [
-    ("/foo/bar", "/foo/bar/baz.txt", "baz.txt");
-    ("/foo/bar/qux", "/foo/bar/baz.txt", "../baz.txt");
+    ("/foo/bar",          "/foo/bar/baz.txt", "baz.txt");
+    ("/foo/bar/qux",      "/foo/bar/baz.txt", "../baz.txt");
     ("/foo/bar/qux/quux", "/foo/bar/baz.txt", "../../baz.txt");
-    ("/foo/bar", "/foo/bar", ".");
+    ("/foo/bar",          "/foo/bar",         ".");
+    ("/foo/bar",          "/foo/bar.txt",     "../bar.txt");
+  ]
+
+
+let to_relative_string_if_descendant_test () =
+  List.iter (fun (s_from, s_target, expected) ->
+    let from = AbsPath.of_string_exn s_from in
+    let target = AbsPath.of_string_exn s_target in
+    let got = AbsPath.to_relative_string ~from target in
+    Alcotest.(check string) "make_relative" expected got
+  ) [
+    ("/foo/bar",          "/foo/bar/baz.txt", "baz.txt");
+    ("/foo/bar/qux",      "/foo/bar/baz.txt", "/foo/bar/baz.txt");
+    ("/foo/bar/qux/quux", "/foo/bar/baz.txt", "/foo/bar/baz.txt");
+    ("/foo/bar",          "/foo/bar",         ".");
+    ("/foo/bar",          "/foo/bar.txt",     "/foo/bar.txt");
   ]
 
 
 let test_cases =
   Alcotest.[
     test_case "of_string_exn" `Quick of_string_exn_test;
-    test_case "make_relative" `Quick make_relative_test;
+    test_case "to_relative_string" `Quick to_relative_string_test;
+    test_case "to_relative_string_if_descendant" `Quick to_relative_string_if_descendant_test;
   ]

--- a/test/common/absPathTest.ml
+++ b/test/common/absPathTest.ml
@@ -1,8 +1,8 @@
 
 let of_string_exn_test () =
-  List.iter (fun (input, expected) ->
+  List.iteri (fun i (input, expected) ->
     let got = AbsPath.to_components (AbsPath.of_string_exn input) in
-    Alcotest.(check (list string)) "of_string_exn" expected got
+    Alcotest.(check (list string)) (Printf.sprintf "of_string_exn (%d)" i) expected got
   ) [
     ("/foo/bar/baz.txt", ["foo"; "bar"; "baz.txt"]);
     ("/foo//bar/baz.txt", ["foo"; "bar"; "baz.txt"]);
@@ -12,11 +12,11 @@ let of_string_exn_test () =
 
 
 let to_relative_string_test () =
-  List.iter (fun (s_from, s_target, expected) ->
+  List.iteri (fun i (s_from, s_target, expected) ->
     let from = AbsPath.of_string_exn s_from in
     let target = AbsPath.of_string_exn s_target in
     let got = AbsPath.to_relative_string ~from target in
-    Alcotest.(check string) "make_relative" expected got
+    Alcotest.(check string) (Printf.sprintf "to_relative_string (%d)" i) expected got
   ) [
     ("/foo/bar",          "/foo/bar/baz.txt", "baz.txt");
     ("/foo/bar/qux",      "/foo/bar/baz.txt", "../baz.txt");
@@ -27,11 +27,11 @@ let to_relative_string_test () =
 
 
 let to_relative_string_if_descendant_test () =
-  List.iter (fun (s_from, s_target, expected) ->
+  List.iteri (fun i (s_from, s_target, expected) ->
     let from = AbsPath.of_string_exn s_from in
     let target = AbsPath.of_string_exn s_target in
-    let got = AbsPath.to_relative_string ~from target in
-    Alcotest.(check string) "make_relative" expected got
+    let got = AbsPath.to_relative_string_if_descendant ~from target in
+    Alcotest.(check string) (Printf.sprintf "to_relative_string_if_descendant (%d)" i) expected got
   ) [
     ("/foo/bar",          "/foo/bar/baz.txt", "baz.txt");
     ("/foo/bar/qux",      "/foo/bar/baz.txt", "/foo/bar/baz.txt");


### PR DESCRIPTION
- `--verbose`: displays detailed logs
- `--quiet`: suppresses most of the logs except for errors and warnings
- Refine the non-`--full-path` style; descendant paths (relative to the current working directory) will be displayed in the relative form, and non-descendant ones will be in the absolute form