### PR TITLE
Add the syntax for quantifiers to value bindings

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,6 @@
 (lang dune 3.16)
 
-(using menhir 2.1)
+(using menhir 3.0)
 
 (formatting
  (enabled_for dune))

--- a/src/dune
+++ b/src/dune
@@ -57,8 +57,8 @@
 
 (menhir
  (modules parser dataParser)
- (flags
-  (--table --explain)))
+ (explain true)
+ (flags --table))
 
 (rule
  (targets types.ml)

--- a/src/frontend/bytecomp/compiler.ml
+++ b/src/frontend/bytecomp/compiler.ml
@@ -138,7 +138,7 @@ and compile_code_pattern_branch (irpatbr : ir_pattern_branch) : (instruction lis
       IRPatternBranchWhen(irpat, compiled, compiled1)
 
 
-and compile_code_letrec_binding (IRLetRecBinding(var, irpatbr) : ir_letrec_binding) : (instruction list) ir_letrec_binding_scheme =
+and compile_code_let_rec_binding (IRLetRecBinding(var, irpatbr) : ir_let_rec_binding) : (instruction list) ir_let_rec_binding_scheme =
   let comppatbr = compile_code_pattern_branch irpatbr in
   IRLetRecBinding(var, comppatbr)
 
@@ -274,7 +274,7 @@ and compile (ir : ir) (cont : instruction list) =
 
   | IRCodeLetRecIn(irrecbinds, ir2) ->
       let instrs2 = compile ir2 [] in
-      OpCodeLetRec(List.map compile_code_letrec_binding irrecbinds, instrs2) :: cont
+      OpCodeLetRec(List.map compile_code_let_rec_binding irrecbinds, instrs2) :: cont
 
   | IRCodeLetNonRecIn(irpat, ir1, ir2) ->
       let instrs1 = compile ir1 [] in

--- a/src/frontend/bytecomp/ir.cppo.ml
+++ b/src/frontend/bytecomp/ir.cppo.ml
@@ -274,7 +274,7 @@ and find_in_environment (env : frame) (evid : EvalVarID.t) : varloc option =
   | None                              -> None
 
 
-and add_letrec_bindings_to_environment (env : frame) (recbinds : letrec_binding list) : (varloc * pattern_branch) list * frame =
+and add_let_rec_bindings_to_environment (env : frame) (recbinds : let_rec_binding list) : (varloc * pattern_branch) list * frame =
   recbinds @|> env @|> map_with_env (fun env recbind ->
     let LetRecBinding(evid, patbr) = recbind in
     let (var, env) = add_to_environment env evid in
@@ -628,7 +628,7 @@ and transform_0 (env : frame) (ast : abstract_tree) : ir * frame =
       end
 
   | LetRecIn(recbinds, ast2) ->
-      let (pairs, env) = add_letrec_bindings_to_environment env recbinds in
+      let (pairs, env) = add_let_rec_bindings_to_environment env recbinds in
       let varir_lst =
         pairs |> List.map (fun pair ->
           let (var, patbr) = pair in

--- a/src/frontend/display.ml
+++ b/src/frontend/display.ml
@@ -47,7 +47,7 @@ let collect_ids_scheme (fid_ht : unit FreeIDHashTable.t) (frid_ht : LabelSet.t F
           match tv with
           | Updatable({contents = MonoLink(ty)})  -> aux_mono ty
           | Updatable({contents = MonoFree(fid)}) -> aux_free_id fid
-          | MustBeBound(_mbbid)                   -> ()
+          | MustBeBound(mbbid)                    -> aux_bound_id (MustBeBoundID.to_bound_id mbbid)
         end
 
     | DataType(tys, _tyid) ->
@@ -106,7 +106,7 @@ let collect_ids_scheme (fid_ht : unit FreeIDHashTable.t) (frid_ht : LabelSet.t F
     | RowCons(_rlabel, ty, row)                          -> aux_mono ty; aux_mono_row row
     | RowVar(UpdatableRow{contents = MonoRowLink(row)})  -> aux_mono_row row
     | RowVar(UpdatableRow{contents = MonoRowFree(frid)}) -> aux_free_row_id frid
-    | RowVar(MustBeBoundRow(_mbbrid))                    -> ()
+    | RowVar(MustBeBoundRow(mbbrid))                     -> aux_bound_row_id (MustBeBoundRowID.to_bound_id mbbrid)
     | RowEmpty                                           -> ()
 
   and aux_poly_row : poly_row -> unit = function

--- a/src/frontend/display.ml
+++ b/src/frontend/display.ml
@@ -72,9 +72,10 @@ let collect_ids_scheme (fid_ht : unit FreeIDHashTable.t) (frid_ht : LabelSet.t F
     | TypeVariable(ptv) ->
         begin
           match ptv with
-          | PolyFree({contents = MonoLink(ty)})  -> aux_mono ty
-          | PolyFree({contents = MonoFree(fid)}) -> aux_free_id fid
-          | PolyBound(bid)                       -> aux_bound_id bid
+          | PolyFreeUpdatable({contents = MonoLink(ty)})  -> aux_mono ty
+          | PolyFreeUpdatable({contents = MonoFree(fid)}) -> aux_free_id fid
+          | PolyFreeMustBeBound(mbbid)                    -> aux_bound_id (MustBeBoundID.to_bound_id mbbid)
+          | PolyBound(bid)                                -> aux_bound_id bid
         end
 
     | FuncType(poptrow, ptydom, ptycod) ->
@@ -395,8 +396,9 @@ and show_mono_row_by_map (dispmap : DisplayMap.t) (row : mono_row) : string opti
 
 let tvf_poly (dispmap : DisplayMap.t) (plev : paren_level) (ptv : poly_type_variable) : string =
   match ptv with
-  | PolyFree(tvuref) -> tvf_mono_updatable dispmap plev !tvuref
-  | PolyBound(bid)   -> dispmap |> DisplayMap.find_bound_id bid
+  | PolyFreeUpdatable(tvuref)  -> tvf_mono_updatable dispmap plev !tvuref
+  | PolyFreeMustBeBound(mbbid) -> dispmap |> DisplayMap.find_bound_id (MustBeBoundID.to_bound_id mbbid)
+  | PolyBound(bid)             -> dispmap |> DisplayMap.find_bound_id bid
 
 
 let rvf_poly (dispmap : DisplayMap.t) (prv : poly_row_variable) : string =

--- a/src/frontend/display.ml
+++ b/src/frontend/display.ml
@@ -72,10 +72,10 @@ let collect_ids_scheme (fid_ht : unit FreeIDHashTable.t) (frid_ht : LabelSet.t F
     | TypeVariable(ptv) ->
         begin
           match ptv with
-          | PolyFreeUpdatable({contents = MonoLink(ty)})  -> aux_mono ty
-          | PolyFreeUpdatable({contents = MonoFree(fid)}) -> aux_free_id fid
-          | PolyFreeMustBeBound(mbbid)                    -> aux_bound_id (MustBeBoundID.to_bound_id mbbid)
-          | PolyBound(bid)                                -> aux_bound_id bid
+          | PolyFree(Updatable({contents = MonoLink(ty)}))  -> aux_mono ty
+          | PolyFree(Updatable({contents = MonoFree(fid)})) -> aux_free_id fid
+          | PolyFree(MustBeBound(mbbid))                    -> aux_bound_id (MustBeBoundID.to_bound_id mbbid)
+          | PolyBound(bid)                                  -> aux_bound_id bid
         end
 
     | FuncType(poptrow, ptydom, ptycod) ->
@@ -396,9 +396,9 @@ and show_mono_row_by_map (dispmap : DisplayMap.t) (row : mono_row) : string opti
 
 let tvf_poly (dispmap : DisplayMap.t) (plev : paren_level) (ptv : poly_type_variable) : string =
   match ptv with
-  | PolyFreeUpdatable(tvuref)  -> tvf_mono_updatable dispmap plev !tvuref
-  | PolyFreeMustBeBound(mbbid) -> dispmap |> DisplayMap.find_bound_id (MustBeBoundID.to_bound_id mbbid)
-  | PolyBound(bid)             -> dispmap |> DisplayMap.find_bound_id bid
+  | PolyFree(Updatable(tvuref))  -> tvf_mono_updatable dispmap plev !tvuref
+  | PolyFree(MustBeBound(mbbid)) -> dispmap |> DisplayMap.find_bound_id (MustBeBoundID.to_bound_id mbbid)
+  | PolyBound(bid)               -> dispmap |> DisplayMap.find_bound_id bid
 
 
 let rvf_poly (dispmap : DisplayMap.t) (prv : poly_row_variable) : string =

--- a/src/frontend/errorReporting.ml
+++ b/src/frontend/errorReporting.ml
@@ -595,10 +595,11 @@ let make_type_error_message = function
         NormalLine("tests must be stage-1 non-recursive bindings.");
       ]
 
-  | NonemptyManualQuantifier(rng) ->
+  | TestMustBeUnitToUnit(rng, pty) ->
       [
         NormalLine(Printf.sprintf "at %s:" (Range.to_string rng));
-        NormalLine("no type/row variable should be bound here.");
+        NormalLine("tests must be of type unit -> unit, but this one has type");
+        DisplayLine(Display.show_poly_type pty);
       ]
 
 

--- a/src/frontend/errorReporting.ml
+++ b/src/frontend/errorReporting.ml
@@ -595,6 +595,12 @@ let make_type_error_message = function
         NormalLine("tests must be stage-1 non-recursive bindings.");
       ]
 
+  | NonemptyManualQuantifier(rng) ->
+      [
+        NormalLine(Printf.sprintf "at %s:" (Range.to_string rng));
+        NormalLine("no type/row variable should be bound here.");
+      ]
+
 
 let module_name_chain_to_string (((_, modnm0), modidents) : module_name_chain) =
   let modidents = modidents |> List.map (fun (_, modnm) -> modnm) in

--- a/src/frontend/evaluator.cppo.ml
+++ b/src/frontend/evaluator.cppo.ml
@@ -288,7 +288,7 @@ and interpret_0 (env : environment) (ast : abstract_tree) : syntactic_value =
       end
 
   | LetRecIn(recbinds, ast2) ->
-      let env = add_letrec_bindings_to_environment env recbinds in
+      let env = add_let_rec_bindings_to_environment env recbinds in
       interpret_0 env ast2
 
   | LetNonRecIn(pat, ast1, ast2) ->
@@ -532,7 +532,7 @@ and interpret_1 (env : environment) (ast : abstract_tree) : code_value =
       end
 
   | LetRecIn(recbinds, ast2) ->
-      let (env, cdrecbinds) = interpret_letrec_bindings_1 env recbinds in
+      let (env, cdrecbinds) = interpret_let_rec_bindings_1 env recbinds in
       let code2 = interpret_1 env ast2 in
       CdLetRecIn(cdrecbinds, code2)
 
@@ -1194,7 +1194,7 @@ and check_pattern_matching (env : environment) (pat : pattern_tree) (value_obj :
       None
 
 
-and add_letrec_bindings_to_environment (env : environment) (recbinds : letrec_binding list) : environment =
+and add_let_rec_bindings_to_environment (env : environment) (recbinds : let_rec_binding list) : environment =
   let tris =
     recbinds |> List.map (function LetRecBinding(evid, patbr) ->
       let loc = ref Nil in
@@ -1212,7 +1212,7 @@ and add_letrec_bindings_to_environment (env : environment) (recbinds : letrec_bi
   env
 
 
-and interpret_letrec_bindings_1 (env : environment) (recbinds : letrec_binding list) : environment * code_letrec_binding list =
+and interpret_let_rec_bindings_1 (env : environment) (recbinds : let_rec_binding list) : environment * code_let_rec_binding list =
   (* Generate the symbols for the identifiers and add them to the environment: *)
   let (env, zippedacc) =
     recbinds |> List.fold_left (fun (env, zippedacc) recbind ->
@@ -1245,7 +1245,7 @@ let interpret_bindings_0 ~(run_tests : bool) (env : environment) (binds : bindin
                       add_to_environment env evid (ref value)
 
                   | Rec(recbinds) ->
-                      add_letrec_bindings_to_environment env recbinds
+                      add_let_rec_bindings_to_environment env recbinds
 
                   | Mutable(evid, ast_ini) ->
                       let value_ini = interpret_0 env ast_ini in
@@ -1263,7 +1263,7 @@ let interpret_bindings_0 ~(run_tests : bool) (env : environment) (binds : bindin
                       (env, CdNonRec(symb, code))
 
                   | Rec(recbinds) ->
-                      let (env, cdrecbinds) = interpret_letrec_bindings_1 env recbinds in
+                      let (env, cdrecbinds) = interpret_let_rec_bindings_1 env recbinds in
                       (env, CdRec(cdrecbinds))
 
                   | Mutable(evid, ast) ->

--- a/src/frontend/moduleTypechecker.ml
+++ b/src/frontend/moduleTypechecker.ml
@@ -765,14 +765,12 @@ and typecheck_binding (config : typecheck_config) (tyenv : Typeenv.t) (utbind : 
               in
               return ([ Rec(recbindacc |> Alist.to_list) ], ssig)
 
-          | UTMutable((rng, varnm) as var, utastI) ->
-              let* (eI, tyI) = Typechecker.typecheck { pre with quantifiability = Unquantifiable; } tyenv utastI in
-              let evid = EvalVarID.fresh var in
-              let pty = TypeConv.lift_poly (rng, RefType(tyI)) in
+          | UTMutable(ident, utastI) ->
+              let* (varnm, pty_ref, evid, eI) = Typechecker.typecheck_let_mutable pre tyenv ident utastI in
               let ssig =
                 let ventry =
                   {
-                    val_type  = pty;
+                    val_type  = pty_ref;
                     val_name  = Some(evid);
                     val_stage = pre.stage;
                   }

--- a/src/frontend/moduleTypechecker.ml
+++ b/src/frontend/moduleTypechecker.ml
@@ -119,7 +119,8 @@ let add_macro_parameters_to_type_environment (tyenv : Typeenv.t) (pre : pre) (ma
       let (ptybody, beta) =
         let tvid = fresh_free_id pre.quantifiability (Level.succ pre.level) in
         let tvuref = ref (MonoFree(tvid)) in
-        ((rng, TypeVariable(PolyFreeUpdatable(tvuref))), (rng, TypeVariable(Updatable(tvuref))))
+        let tv = Updatable(tvuref) in
+        ((rng, TypeVariable(PolyFree(tv))), (rng, TypeVariable(tv)))
       in
       let (pty, macparamty) =
       match macparam with

--- a/src/frontend/moduleTypechecker.ml
+++ b/src/frontend/moduleTypechecker.ml
@@ -719,7 +719,9 @@ and typecheck_binding (config : typecheck_config) (tyenv : Typeenv.t) (utbind : 
               let ty_cod = (Range.dummy "test-cod", BaseType(UnitType)) in
               Poly(Range.dummy "test-func", FuncType(RowEmpty, ty_dom, ty_cod))
             in
-            let* (test_name, pty1, evid, e1) = Typechecker.typecheck_nonrec ~always_polymorphic:true pre tyenv utletbind in
+            let* (test_name, pty1, evid, e1) =
+              Typechecker.typecheck_let_nonrec ~always_polymorphic:true pre tyenv utletbind
+            in
             if TypeConv.poly_type_equal pty_expected pty1 then
               return ([ BindTest(evid, test_name, e1) ], (OpaqueIDMap.empty, StructSig.empty))
             else
@@ -731,7 +733,9 @@ and typecheck_binding (config : typecheck_config) (tyenv : Typeenv.t) (utbind : 
         let* (rec_or_nonrecs, ssig) =
           match valbind with
           | UTNonRec(utletbind) ->
-              let* (varnm, pty1, evid, e1) = Typechecker.typecheck_nonrec ~always_polymorphic:true pre tyenv utletbind in
+              let* (varnm, pty1, evid, e1) =
+                Typechecker.typecheck_let_nonrec ~always_polymorphic:true pre tyenv utletbind
+              in
               let ssig =
                 let ventry =
                   {
@@ -745,7 +749,7 @@ and typecheck_binding (config : typecheck_config) (tyenv : Typeenv.t) (utbind : 
               return ([ NonRec(evid, e1) ], ssig)
 
           | UTRec(utrecbinds) ->
-              let* quints = Typechecker.typecheck_letrec pre tyenv utrecbinds in
+              let* quints = Typechecker.typecheck_let_rec pre tyenv utrecbinds in
               let (recbindacc, ssig) =
                 quints |> List.fold_left (fun (recbindacc, ssig) quint ->
                   let (x, pty, evid, recbind) = quint in

--- a/src/frontend/moduleTypechecker.ml
+++ b/src/frontend/moduleTypechecker.ml
@@ -737,7 +737,17 @@ and typecheck_binding (config : typecheck_config) (tyenv : Typeenv.t) (utbind : 
       in
       if valattr.ValueAttribute.is_test then
         match (stage, valbind) with
-        | (Stage1, UTNonRec(ident, mnquant, _retty, utast1)) -> (* TODO: `retty` *)
+        | (Stage1, UTNonRec(utletbind)) ->
+            let
+              UTLetBinding{
+                identifier  = ident;
+                quantifier  = mnquant;
+                parameters  = param_units;
+                return_type = mntyopt_ret;
+                body        = utast_body;
+              } = utletbind
+            in
+            let utast1 = curry_lambda_abstraction param_units utast_body in (* TODO: use `mntyopt_ret` *)
             let* () = check_empty_manual_quantifier rng mnquant in
             let (_, test_name) = ident in
             let ty_expected =
@@ -753,7 +763,17 @@ and typecheck_binding (config : typecheck_config) (tyenv : Typeenv.t) (utbind : 
       else
         let* (rec_or_nonrecs, ssig) =
           match valbind with
-          | UTNonRec(ident, ManualQuantifier(typarams, rowparams), _retty, utast1) -> (* TODO: use `retty` *)
+          | UTNonRec(utletbind) ->
+              let
+                UTLetBinding{
+                  identifier  = ident;
+                  quantifier  = ManualQuantifier(typarams, rowparams);
+                  parameters  = param_units;
+                  return_type = _mntyopt_ret;
+                  body        = utast_body;
+                } = utletbind
+              in
+              let utast1 = curry_lambda_abstraction param_units utast_body in (* TODO: use `mntyopt_ret` *)
               let* (typarammap, _) = TypeParameterMap.empty |> add_type_parameters (Level.succ Level.bottom) typarams in
               let* (rowparammap, _) = pre.row_parameters |> add_row_parameters (Level.succ Level.bottom) rowparams in
               let pre =

--- a/src/frontend/moduleTypechecker.ml
+++ b/src/frontend/moduleTypechecker.ml
@@ -119,7 +119,7 @@ let add_macro_parameters_to_type_environment (tyenv : Typeenv.t) (pre : pre) (ma
       let (ptybody, beta) =
         let tvid = fresh_free_id pre.quantifiability (Level.succ pre.level) in
         let tvuref = ref (MonoFree(tvid)) in
-        ((rng, TypeVariable(PolyFree(tvuref))), (rng, TypeVariable(Updatable(tvuref))))
+        ((rng, TypeVariable(PolyFreeUpdatable(tvuref))), (rng, TypeVariable(Updatable(tvuref))))
       in
       let (pty, macparamty) =
       match macparam with

--- a/src/frontend/moduleTypechecker.ml
+++ b/src/frontend/moduleTypechecker.ml
@@ -719,7 +719,7 @@ and typecheck_binding (config : typecheck_config) (tyenv : Typeenv.t) (utbind : 
               let ty_cod = (Range.dummy "test-cod", BaseType(UnitType)) in
               Poly(Range.dummy "test-func", FuncType(RowEmpty, ty_dom, ty_cod))
             in
-            let* (test_name, pty1, evid, e1) = Typechecker.typecheck_nonrec pre tyenv utletbind in
+            let* (test_name, pty1, evid, e1) = Typechecker.typecheck_nonrec ~always_polymorphic:true pre tyenv utletbind in
             if TypeConv.poly_type_equal pty_expected pty1 then
               return ([ BindTest(evid, test_name, e1) ], (OpaqueIDMap.empty, StructSig.empty))
             else
@@ -731,7 +731,7 @@ and typecheck_binding (config : typecheck_config) (tyenv : Typeenv.t) (utbind : 
         let* (rec_or_nonrecs, ssig) =
           match valbind with
           | UTNonRec(utletbind) ->
-              let* (varnm, pty1, evid, e1) = Typechecker.typecheck_nonrec pre tyenv utletbind in
+              let* (varnm, pty1, evid, e1) = Typechecker.typecheck_nonrec ~always_polymorphic:true pre tyenv utletbind in
               let ssig =
                 let ventry =
                   {

--- a/src/frontend/moduleTypechecker.ml
+++ b/src/frontend/moduleTypechecker.ml
@@ -737,7 +737,7 @@ and typecheck_binding (config : typecheck_config) (tyenv : Typeenv.t) (utbind : 
       in
       if valattr.ValueAttribute.is_test then
         match (stage, valbind) with
-        | (Stage1, UTNonRec(ident, mnquant, utast1)) ->
+        | (Stage1, UTNonRec(ident, mnquant, _retty, utast1)) -> (* TODO: `retty` *)
             let* () = check_empty_manual_quantifier rng mnquant in
             let (_, test_name) = ident in
             let ty_expected =
@@ -753,7 +753,7 @@ and typecheck_binding (config : typecheck_config) (tyenv : Typeenv.t) (utbind : 
       else
         let* (rec_or_nonrecs, ssig) =
           match valbind with
-          | UTNonRec(ident, ManualQuantifier(typarams, rowparams), utast1) ->
+          | UTNonRec(ident, ManualQuantifier(typarams, rowparams), _retty, utast1) -> (* TODO: use `retty` *)
               let* (typarammap, _) = TypeParameterMap.empty |> add_type_parameters (Level.succ Level.bottom) typarams in
               let* (rowparammap, _) = pre.row_parameters |> add_row_parameters (Level.succ Level.bottom) rowparams in
               let pre =

--- a/src/frontend/moduleTypechecker.ml
+++ b/src/frontend/moduleTypechecker.ml
@@ -774,7 +774,7 @@ and typecheck_binding (config : typecheck_config) (tyenv : Typeenv.t) (utbind : 
                 } = utletbind
               in
               let utast1 = curry_lambda_abstraction param_units utast_body in (* TODO: use `mntyopt_ret` *)
-              let* (typarammap, _) = TypeParameterMap.empty |> add_type_parameters (Level.succ Level.bottom) typarams in
+              let* (typarammap, _) = pre.type_parameters |> add_type_parameters (Level.succ Level.bottom) typarams in
               let* (rowparammap, _) = pre.row_parameters |> add_row_parameters (Level.succ Level.bottom) rowparams in
               let pre =
                 { pre with

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -483,18 +483,22 @@ bind_value_rec:
       { valbinds }
 ;
 bind_value_nonrec:
-  | ident=bound_identifier; quant_and_param_units=quant_and_param_units; EXACT_EQ; utast=expr
+  | ident=bound_identifier; quant_and_param_units=quant_and_param_units; retty=return_type; EXACT_EQ; utast=expr
       {
         let (mnquant, param_units) = quant_and_param_units in
         let curried = curry_lambda_abstraction param_units utast in
-        (ident, mnquant, curried)
+        (ident, mnquant, retty, curried)
       }
+;
+return_type:
+  | COLON; mnty=typ { Some(mnty) }
+  |                 { None }
 ;
 bind_inline:
   | ident_ctx=LOWER; cs=BACKSLASH_CMD; quant_and_param_units=quant_and_param_units; EXACT_EQ; utast=expr
       {
         let (mnquant, param_units) = quant_and_param_units in
-        (cs, mnquant,
+        (cs, mnquant, None,
           make_standard (Ranged ident_ctx) (Ranged utast) (UTLambdaInlineCommand{
             parameters       = param_units;
             context_variable = ident_ctx;
@@ -511,7 +515,7 @@ bind_inline:
           let utast_ctx = (rng_ctx, UTContentOf([], ident_ctx)) in
           (Range.dummy "read-inline-of-lightweight-let-inline", UTReadInline(utast_ctx, utast))
         in
-        (cs, mnquant,
+        (cs, mnquant, None,
           make_standard (Ranged cs) (Ranged utast) (UTLambdaInlineCommand{
             parameters       = param_units;
             context_variable = ident_ctx;
@@ -523,7 +527,7 @@ bind_block:
   | ident_ctx=LOWER; cs=PLUS_CMD; quant_and_param_units=quant_and_param_units; EXACT_EQ; utast=expr
       {
         let (mnquant, param_units) = quant_and_param_units in
-        (cs, mnquant,
+        (cs, mnquant, None,
           make_standard (Ranged ident_ctx) (Ranged utast) (UTLambdaBlockCommand{
             parameters       = param_units;
             context_variable = ident_ctx;
@@ -540,7 +544,7 @@ bind_block:
           let utast_ctx = (rng_ctx, UTContentOf([], ident_ctx)) in
           (Range.dummy "read-block-of-lightweight-let-block", UTReadBlock(utast_ctx, utast))
         in
-        (cs, mnquant,
+        (cs, mnquant, None,
           make_standard (Ranged cs) (Ranged utast) (UTLambdaBlockCommand{
             parameters       = param_units;
             context_variable = ident_ctx;
@@ -552,7 +556,7 @@ bind_math:
   | ident_ctx=LOWER; cs=BACKSLASH_CMD; quant_and_param_units=quant_and_param_units; scripts_param_opt=option(scripts_param); EXACT_EQ; utast=expr
       {
         let (mnquant, param_units) = quant_and_param_units in
-        (cs, mnquant,
+        (cs, mnquant, None,
           make_standard (Ranged cs) (Ranged utast) (UTLambdaMathCommand{
             parameters       = param_units;
             context_variable = ident_ctx;

--- a/src/frontend/signatureSubtyping.ml
+++ b/src/frontend/signatureSubtyping.ml
@@ -428,10 +428,8 @@ and subtype_poly_type_impl (internbid : type_intern) (internbrid : row_intern) (
     let (_, ptymain1) = pty1 in
     let (_, ptymain2) = pty2 in
     match (ptymain1, ptymain2) with
-    | (TypeVariable(PolyFreeUpdatable(_)), _)
-    | (_, TypeVariable(PolyFreeUpdatable(_)))
-    | (TypeVariable(PolyFreeMustBeBound(_)), _)
-    | (_, TypeVariable(PolyFreeMustBeBound(_))) ->
+    | (TypeVariable(PolyFree(_)), _)
+    | (_, TypeVariable(PolyFree(_))) ->
         false
 
     | (TypeVariable(PolyBound(bid1)), _) ->

--- a/src/frontend/signatureSubtyping.ml
+++ b/src/frontend/signatureSubtyping.ml
@@ -428,8 +428,10 @@ and subtype_poly_type_impl (internbid : type_intern) (internbrid : row_intern) (
     let (_, ptymain1) = pty1 in
     let (_, ptymain2) = pty2 in
     match (ptymain1, ptymain2) with
-    | (TypeVariable(PolyFree(_)), _)
-    | (_, TypeVariable(PolyFree(_))) ->
+    | (TypeVariable(PolyFreeUpdatable(_)), _)
+    | (_, TypeVariable(PolyFreeUpdatable(_)))
+    | (TypeVariable(PolyFreeMustBeBound(_)), _)
+    | (_, TypeVariable(PolyFreeMustBeBound(_))) ->
         false
 
     | (TypeVariable(PolyBound(bid1)), _) ->

--- a/src/frontend/typeConv.ml
+++ b/src/frontend/typeConv.ml
@@ -101,7 +101,7 @@ fun intern_ty intern_row prow ->
 let make_type_instantiation_intern (lev : level) (qtfbl : quantifiability) (bid_ht : mono_type_variable BoundIDHashTable.t) =
   let intern_ty (rng : Range.t) (ptv : poly_type_variable) : mono_type =
     match ptv with
-    | PolyFree(tvuref) ->
+    | PolyFreeUpdatable(tvuref) ->
         (rng, TypeVariable(Updatable(tvuref)))
 
     | PolyFreeMustBeBound(mbbid) ->
@@ -162,7 +162,7 @@ let instantiate (lev : level) (qtfbl : quantifiability) ((Poly(pty)) : poly_type
 let instantiate_by_map_mono (bidmap : mono_type BoundIDMap.t) (Poly(pty) : poly_type) : mono_type =
   let intern_ty (rng : Range.t) (ptv : poly_type_variable) =
     match ptv with
-    | PolyFree(tvuref) ->
+    | PolyFreeUpdatable(tvuref) ->
         (rng, TypeVariable(Updatable(tvuref)))
 
     | PolyFreeMustBeBound(mbbid) ->
@@ -186,7 +186,7 @@ let instantiate_by_map_mono (bidmap : mono_type BoundIDMap.t) (Poly(pty) : poly_
 let instantiate_by_map_poly (bidmap : poly_type_body BoundIDMap.t) (Poly(pty) : poly_type) : poly_type =
   let intern_ty (rng : Range.t) (ptv : poly_type_variable) : poly_type_body =
     match ptv with
-    | PolyFree(_) | PolyFreeMustBeBound(_) ->
+    | PolyFreeUpdatable(_) | PolyFreeMustBeBound(_) ->
         (rng, TypeVariable(ptv))
 
     | PolyBound(bid) ->
@@ -231,7 +231,7 @@ let lift_poly_general (intern_ty : FreeID.t -> BoundID.t option) (intern_row : F
                 | MonoFree(fid) ->
                     let ptvi =
                       match intern_ty fid with
-                      | None      -> PolyFree(tvuref)
+                      | None      -> PolyFreeUpdatable(tvuref)
                       | Some(bid) -> PolyBound(bid)
                     in
                     (rng, TypeVariable(ptvi))
@@ -489,8 +489,10 @@ let rec poly_type_equal (Poly(pty1) : poly_type) (Poly(pty2) : poly_type) : bool
     | (TypeVariable(PolyBound(bid1)), TypeVariable(PolyBound(bid2))) ->
         BoundID.equal bid1 bid2
 
-    | (TypeVariable(PolyFree(_)), _)
-    | (_, TypeVariable(PolyFree(_))) ->
+    | (TypeVariable(PolyFreeUpdatable(_)), _)
+    | (_, TypeVariable(PolyFreeUpdatable(_)))
+    | (TypeVariable(PolyFreeMustBeBound(_)), _)
+    | (_, TypeVariable(PolyFreeMustBeBound(_))) ->
         false
 
     | (DataType(ptys1, tyid1), DataType(ptys2, tyid2)) ->

--- a/src/frontend/typeConv.ml
+++ b/src/frontend/typeConv.ml
@@ -101,11 +101,8 @@ fun intern_ty intern_row prow ->
 let make_type_instantiation_intern (lev : level) (qtfbl : quantifiability) (bid_ht : mono_type_variable BoundIDHashTable.t) =
   let intern_ty (rng : Range.t) (ptv : poly_type_variable) : mono_type =
     match ptv with
-    | PolyFreeUpdatable(tvuref) ->
-        (rng, TypeVariable(Updatable(tvuref)))
-
-    | PolyFreeMustBeBound(mbbid) ->
-        (rng, TypeVariable(MustBeBound(mbbid)))
+    | PolyFree(tv) ->
+        (rng, TypeVariable(tv))
 
     | PolyBound(bid) ->
         begin
@@ -162,11 +159,8 @@ let instantiate (lev : level) (qtfbl : quantifiability) ((Poly(pty)) : poly_type
 let instantiate_by_map_mono (bidmap : mono_type BoundIDMap.t) (Poly(pty) : poly_type) : mono_type =
   let intern_ty (rng : Range.t) (ptv : poly_type_variable) =
     match ptv with
-    | PolyFreeUpdatable(tvuref) ->
-        (rng, TypeVariable(Updatable(tvuref)))
-
-    | PolyFreeMustBeBound(mbbid) ->
-        (rng, TypeVariable(MustBeBound(mbbid)))
+    | PolyFree(tv) ->
+        (rng, TypeVariable(tv))
 
     | PolyBound(bid) ->
         begin
@@ -186,7 +180,7 @@ let instantiate_by_map_mono (bidmap : mono_type BoundIDMap.t) (Poly(pty) : poly_
 let instantiate_by_map_poly (bidmap : poly_type_body BoundIDMap.t) (Poly(pty) : poly_type) : poly_type =
   let intern_ty (rng : Range.t) (ptv : poly_type_variable) : poly_type_body =
     match ptv with
-    | PolyFreeUpdatable(_) | PolyFreeMustBeBound(_) ->
+    | PolyFree(_) ->
         (rng, TypeVariable(ptv))
 
     | PolyBound(bid) ->
@@ -231,8 +225,8 @@ let lift_poly_general (intern_ty : FreeID.t -> BoundID.t option) (intern_row : F
                 | MonoFree(fid) ->
                     let ptvi =
                       match intern_ty fid with
-                      | None      -> PolyFreeUpdatable(tvuref)
                       | Some(bid) -> PolyBound(bid)
+                      | None      -> PolyFree(tv)
                     in
                     (rng, TypeVariable(ptvi))
               end
@@ -243,7 +237,7 @@ let lift_poly_general (intern_ty : FreeID.t -> BoundID.t option) (intern_row : F
                   let bid = MustBeBoundID.to_bound_id mbbid in
                   PolyBound(bid)
                 else
-                  PolyFreeMustBeBound(mbbid)
+                  PolyFree(tv)
               in
               (rng, TypeVariable(ptvi))
         end
@@ -489,10 +483,8 @@ let rec poly_type_equal (Poly(pty1) : poly_type) (Poly(pty2) : poly_type) : bool
     | (TypeVariable(PolyBound(bid1)), TypeVariable(PolyBound(bid2))) ->
         BoundID.equal bid1 bid2
 
-    | (TypeVariable(PolyFreeUpdatable(_)), _)
-    | (_, TypeVariable(PolyFreeUpdatable(_)))
-    | (TypeVariable(PolyFreeMustBeBound(_)), _)
-    | (_, TypeVariable(PolyFreeMustBeBound(_))) ->
+    | (TypeVariable(PolyFree(_)), _)
+    | (_, TypeVariable(PolyFree(_))) ->
         false
 
     | (DataType(ptys1, tyid1), DataType(ptys2, tyid2)) ->

--- a/src/frontend/typeError.ml
+++ b/src/frontend/typeError.ml
@@ -69,4 +69,4 @@ type type_error =
   | ValueAttributeError                  of ValueAttribute.error
   | ModuleAttributeError                 of ModuleAttribute.error
   | TestMustBeStage1NonRec               of Range.t
-  | NonemptyManualQuantifier             of Range.t
+  | TestMustBeUnitToUnit                 of Range.t * poly_type

--- a/src/frontend/typeError.ml
+++ b/src/frontend/typeError.ml
@@ -69,3 +69,4 @@ type type_error =
   | ValueAttributeError                  of ValueAttribute.error
   | ModuleAttributeError                 of ModuleAttribute.error
   | TestMustBeStage1NonRec               of Range.t
+  | NonemptyManualQuantifier             of Range.t

--- a/src/frontend/typecheckUtil.ml
+++ b/src/frontend/typecheckUtil.ml
@@ -124,13 +124,3 @@ let add_row_parameters (lev : Level.t) (rowvars : (row_variable_name ranged * ma
     ) (rowparammap, Alist.empty)
   in
   return (rowparammap, Alist.to_list bridacc)
-
-
-let check_empty_manual_quantifier (rng : Range.t) (mnquant : manual_quantifier) : unit ok =
-  let open ResultMonad in
-  match mnquant with
-  | ManualQuantifier([], []) ->
-      return ()
-
-  | _ ->
-      err @@ NonemptyManualQuantifier(rng)

--- a/src/frontend/typecheckUtil.ml
+++ b/src/frontend/typecheckUtil.ml
@@ -83,3 +83,54 @@ let add_to_type_environment_by_signature (ssig : StructSig.t) (tyenv : Typeenv.t
     ~m:(fun modnm mentry -> Typeenv.add_module modnm mentry)
     ~s:(fun signm absmodsig -> Typeenv.add_signature signm absmodsig)
     tyenv
+
+
+let decode_manual_row_base_kind (mnrbkd : manual_row_base_kind) : row_base_kind ok =
+  let open ResultMonad in
+  mnrbkd |> foldM (fun labset (rng, label) ->
+    if labset |> LabelSet.mem label then
+      err (LabelUsedMoreThanOnce(rng, label))
+    else
+      return (labset |> LabelSet.add label)
+  ) LabelSet.empty
+
+
+let add_type_parameters (lev : Level.t) (tyvars : (type_variable_name ranged) list) (typarammap : type_parameter_map) : (type_parameter_map * BoundID.t list) ok =
+  let open ResultMonad in
+  let* (typarammap, bidacc) =
+    tyvars |> foldM (fun (typarammap, bidacc) (rng, tyvarnm) ->
+      if typarammap |> TypeParameterMap.mem tyvarnm then
+        err (TypeParameterBoundMoreThanOnce(rng, tyvarnm))
+      else
+        let mbbid = MustBeBoundID.fresh lev in
+        let bid = MustBeBoundID.to_bound_id mbbid in
+        return (typarammap |> TypeParameterMap.add tyvarnm mbbid, Alist.extend bidacc bid)
+    ) (typarammap, Alist.empty)
+  in
+  return (typarammap, Alist.to_list bidacc)
+
+
+let add_row_parameters (lev : Level.t) (rowvars : (row_variable_name ranged * manual_row_base_kind) list) (rowparammap : row_parameter_map) : (row_parameter_map * BoundRowID.t list) ok =
+  let open ResultMonad in
+  let* (rowparammap, bridacc) =
+    rowvars |> foldM (fun (rowparammap, bridacc) ((rng, rowvarnm), mnbrkd) ->
+      if rowparammap |> RowParameterMap.mem rowvarnm then
+        err (LabelUsedMoreThanOnce(rng, rowvarnm))
+      else
+        decode_manual_row_base_kind mnbrkd >>= fun labset ->
+        let mbbrid = MustBeBoundRowID.fresh lev labset in
+        let brid = MustBeBoundRowID.to_bound_id mbbrid in
+        return (rowparammap |> RowParameterMap.add rowvarnm mbbrid, Alist.extend bridacc brid)
+    ) (rowparammap, Alist.empty)
+  in
+  return (rowparammap, Alist.to_list bridacc)
+
+
+let check_empty_manual_quantifier (rng : Range.t) (mnquant : manual_quantifier) : unit ok =
+  let open ResultMonad in
+  match mnquant with
+  | ManualQuantifier([], []) ->
+      return ()
+
+  | _ ->
+      err @@ NonemptyManualQuantifier(rng)

--- a/src/frontend/typechecker.ml
+++ b/src/frontend/typechecker.ml
@@ -648,7 +648,7 @@ let rec typecheck (pre : pre) (tyenv : Typeenv.t) ((rng, utastmain) : untyped_ab
       return (PatternMatch(rng, eO, patbrs), beta)
 
   | UTLetIn(UTNonRec(utletbind), utast2) ->
-      let* (varnm, evid, e1, pty1) = typecheck_nonrec pre tyenv utletbind in
+      let* (varnm, pty1, evid, e1) = typecheck_nonrec pre tyenv utletbind in
       let tyenv =
         let ventry =
           {
@@ -1226,7 +1226,7 @@ and typecheck_letrec (pre : pre) (tyenv : Typeenv.t) (utrecbinds : untyped_let_b
   return tuples
 
 
-and typecheck_nonrec (pre : pre) (tyenv : Typeenv.t) (utletbind : untyped_let_binding) : (var_name * EvalVarID.t * abstract_tree * poly_type) ok =
+and typecheck_nonrec (pre : pre) (tyenv : Typeenv.t) (utletbind : untyped_let_binding) : (var_name * poly_type * EvalVarID.t * abstract_tree) ok =
   let open ResultMonad in
   let
     UTLetBinding{
@@ -1258,7 +1258,7 @@ and typecheck_nonrec (pre : pre) (tyenv : Typeenv.t) (utletbind : untyped_let_bi
     (* If `e1` should be typed monomorphically: *)
       TypeConv.lift_poly (TypeConv.erase_range_of_type ty1)
   in
-  return (varnm, evid, e1, pty1)
+  return (varnm, pty1, evid, e1)
 
 
 and typecheck_let_mutable (pre : pre) (tyenv : Typeenv.t) (ident : var_name ranged) (utastI : untyped_abstract_tree) : (Typeenv.t * EvalVarID.t * abstract_tree * mono_type) ok =

--- a/src/frontend/typechecker.ml
+++ b/src/frontend/typechecker.ml
@@ -100,7 +100,7 @@ let add_optionals_to_type_environment ~(cons : label ranged -> mono_type -> 'a -
       let evid = EvalVarID.fresh ident in
       let fid = fresh_free_id qtfbl lev in
       let tvuref = ref (MonoFree(fid)) in
-      let pbeta = (rng, TypeVariable(PolyFreeUpdatable(tvuref))) in
+      let pbeta = (rng, TypeVariable(PolyFree(Updatable(tvuref)))) in
       let tyenv =
         let ventry =
           {

--- a/src/frontend/typechecker.ml
+++ b/src/frontend/typechecker.ml
@@ -647,7 +647,7 @@ let rec typecheck (pre : pre) (tyenv : Typeenv.t) ((rng, utastmain) : untyped_ab
       Exhchecker.main rng patbrs tyO pre tyenv;
       return (PatternMatch(rng, eO, patbrs), beta)
 
-  | UTLetIn(UTNonRec((ident, ManualQuantifier(typarams, rowparams), utast1)), utast2) ->
+  | UTLetIn(UTNonRec((ident, ManualQuantifier(typarams, rowparams), _retty, utast1)), utast2) -> (* TODO: use `retty` *)
       let* (typarammap, _) = pre.type_parameters |> add_type_parameters (Level.succ pre.level) typarams in
       let* (rowparammap, _) = pre.row_parameters |> add_row_parameters (Level.succ pre.level) rowparams in
       let presub =
@@ -1163,7 +1163,7 @@ and typecheck_letrec (pre : pre) (tyenv : Typeenv.t) (utrecbinds : untyped_let_b
   (* First, adds a type variable for each bound identifier. *)
   let (tyenv, utrecacc) =
     utrecbinds |> List.fold_left (fun (tyenv, utrecacc) utrecbind ->
-      let ((varrng, varnm), _mnquant, astdef) = utrecbind in
+      let ((varrng, varnm), _mnquant, _retty, astdef) = utrecbind in
       let tvuref =
         let tvid = fresh_free_id pre.quantifiability (Level.succ pre.level) in
         ref (MonoFree(tvid))
@@ -1191,7 +1191,7 @@ and typecheck_letrec (pre : pre) (tyenv : Typeenv.t) (utrecbinds : untyped_let_b
   (* Typechecks each body of the definitions: *)
   let* tupleacc =
     utrecacc |> Alist.to_list |> foldM (fun tupleacc utrec ->
-      let (((_, varnm), ManualQuantifier(typarams, rowparams), utast1), beta, evid) = utrec in
+      let (((_, varnm), ManualQuantifier(typarams, rowparams), _retty, utast1), beta, evid) = utrec in (* TODO: use `retty` *)
       let* (typarammap, _) = pre.type_parameters |> add_type_parameters (Level.succ pre.level) typarams in
       let* (rowparammap, _) = pre.row_parameters |> add_row_parameters (Level.succ pre.level) rowparams in
       let presub =

--- a/src/frontend/typechecker.ml
+++ b/src/frontend/typechecker.ml
@@ -1211,7 +1211,7 @@ and typecheck_let_rec (pre : pre) (tyenv : Typeenv.t) (utrecbinds : untyped_let_
       in
       let ty1 =
         List.fold_right (fun (_, _, optrow, ty_pat) ty ->
-          (Range.dummy "typecheck_let_nonrec", FuncType(optrow, ty_pat, ty))
+          (Range.dummy "typecheck_let_rec", FuncType(optrow, ty_pat, ty))
         ) params ty_body
       in
 

--- a/src/frontend/typechecker.ml
+++ b/src/frontend/typechecker.ml
@@ -100,7 +100,7 @@ let add_optionals_to_type_environment ~(cons : label ranged -> mono_type -> 'a -
       let evid = EvalVarID.fresh ident in
       let fid = fresh_free_id qtfbl lev in
       let tvuref = ref (MonoFree(fid)) in
-      let pbeta = (rng, TypeVariable(PolyFree(tvuref))) in
+      let pbeta = (rng, TypeVariable(PolyFreeUpdatable(tvuref))) in
       let tyenv =
         let ventry =
           {

--- a/src/frontend/typechecker.ml
+++ b/src/frontend/typechecker.ml
@@ -278,7 +278,7 @@ let typecheck_abstraction (pre : pre) (tyenv : Typeenv.t) (param_units : untyped
   let open ResultMonad in
   let* (tyenv, acc) =
     param_units |> foldM (fun (tyenv, acc) param_unit ->
-      let* (patvarmap, ty_labmap, ty_pat, evid_labmap, epat) =
+      let* (tyenv, ty_labmap, ty_pat, evid_labmap, epat) =
         let cons (_, label) ty ty_labmap = ty_labmap |> LabelMap.add label ty in
         let nil = LabelMap.empty in
         typecheck_function_parameter_unit ~cons ~nil pre tyenv param_unit

--- a/src/frontend/typechecker.ml
+++ b/src/frontend/typechecker.ml
@@ -651,7 +651,7 @@ let rec typecheck (pre : pre) (tyenv : Typeenv.t) ((rng, utastmain) : untyped_ab
       begin
         match valbind with
         | UTNonRec(utletbind) ->
-            let* (varnm, pty1, evid, e1) = typecheck_nonrec ~always_polymorphic:false pre tyenv utletbind in
+            let* (varnm, pty1, evid, e1) = typecheck_let_nonrec ~always_polymorphic:false pre tyenv utletbind in
             let tyenv =
               let ventry =
                 {
@@ -666,7 +666,7 @@ let rec typecheck (pre : pre) (tyenv : Typeenv.t) ((rng, utastmain) : untyped_ab
             return (LetNonRecIn(PVariable(evid), e1, e2), ty2)
 
         | UTRec(utrecbinds) ->
-            let* quints = typecheck_letrec pre tyenv utrecbinds in
+            let* quints = typecheck_let_rec pre tyenv utrecbinds in
             let (tyenv, recbindacc) =
               quints |> List.fold_left (fun (tyenv, recbindacc) quint ->
                 let (x, pty, evid, recbind) = quint in
@@ -1152,7 +1152,7 @@ and typecheck_pattern_branch_list (pre : pre) (tyenv : Typeenv.t) (utpatbrs : un
   )
 
 
-and typecheck_letrec (pre : pre) (tyenv : Typeenv.t) (utrecbinds : untyped_let_binding list) : ((var_name * poly_type * EvalVarID.t * letrec_binding) list) ok =
+and typecheck_let_rec (pre : pre) (tyenv : Typeenv.t) (utrecbinds : untyped_let_binding list) : ((var_name * poly_type * EvalVarID.t * let_rec_binding) list) ok =
   let open ResultMonad in
 
   (* First, adds a type variable for each bound identifier. *)
@@ -1240,7 +1240,7 @@ and typecheck_letrec (pre : pre) (tyenv : Typeenv.t) (utrecbinds : untyped_let_b
   return tuples
 
 
-and typecheck_nonrec ~(always_polymorphic : bool) (pre : pre) (tyenv : Typeenv.t) (utletbind : untyped_let_binding) : (var_name * poly_type * EvalVarID.t * abstract_tree) ok =
+and typecheck_let_nonrec ~(always_polymorphic : bool) (pre : pre) (tyenv : Typeenv.t) (utletbind : untyped_let_binding) : (var_name * poly_type * EvalVarID.t * abstract_tree) ok =
   let open ResultMonad in
   let
     UTLetBinding{

--- a/src/frontend/typechecker.mli
+++ b/src/frontend/typechecker.mli
@@ -7,6 +7,8 @@ val typecheck : pre -> type_environment -> untyped_abstract_tree -> (abstract_tr
 
 val typecheck_letrec : pre -> type_environment -> untyped_let_binding list -> ((var_name * poly_type * EvalVarID.t * letrec_binding) list, type_error) result
 
+val typecheck_nonrec : pre -> type_environment -> untyped_let_binding -> (var_name * poly_type * EvalVarID.t * abstract_tree, type_error) result
+
 val main : typecheck_config -> stage -> Typeenv.t -> untyped_abstract_tree -> (mono_type * abstract_tree, type_error) result
 
 val are_unifiable : mono_type -> mono_type -> bool

--- a/src/frontend/typechecker.mli
+++ b/src/frontend/typechecker.mli
@@ -9,6 +9,8 @@ val typecheck_letrec : pre -> type_environment -> untyped_let_binding list -> ((
 
 val typecheck_nonrec : always_polymorphic:bool -> pre -> type_environment -> untyped_let_binding -> (var_name * poly_type * EvalVarID.t * abstract_tree, type_error) result
 
+val typecheck_let_mutable : pre -> type_environment -> var_name ranged -> untyped_abstract_tree -> (var_name * poly_type * EvalVarID.t * abstract_tree, type_error) result
+
 val main : typecheck_config -> stage -> Typeenv.t -> untyped_abstract_tree -> (mono_type * abstract_tree, type_error) result
 
 val are_unifiable : mono_type -> mono_type -> bool

--- a/src/frontend/typechecker.mli
+++ b/src/frontend/typechecker.mli
@@ -7,7 +7,7 @@ val typecheck : pre -> type_environment -> untyped_abstract_tree -> (abstract_tr
 
 val typecheck_letrec : pre -> type_environment -> untyped_let_binding list -> ((var_name * poly_type * EvalVarID.t * letrec_binding) list, type_error) result
 
-val typecheck_nonrec : pre -> type_environment -> untyped_let_binding -> (var_name * poly_type * EvalVarID.t * abstract_tree, type_error) result
+val typecheck_nonrec : always_polymorphic:bool -> pre -> type_environment -> untyped_let_binding -> (var_name * poly_type * EvalVarID.t * abstract_tree, type_error) result
 
 val main : typecheck_config -> stage -> Typeenv.t -> untyped_abstract_tree -> (mono_type * abstract_tree, type_error) result
 

--- a/src/frontend/typechecker.mli
+++ b/src/frontend/typechecker.mli
@@ -5,9 +5,9 @@ open TypeError
 
 val typecheck : pre -> type_environment -> untyped_abstract_tree -> (abstract_tree * mono_type, type_error) result
 
-val typecheck_letrec : pre -> type_environment -> untyped_let_binding list -> ((var_name * poly_type * EvalVarID.t * letrec_binding) list, type_error) result
+val typecheck_let_rec : pre -> type_environment -> untyped_let_binding list -> ((var_name * poly_type * EvalVarID.t * let_rec_binding) list, type_error) result
 
-val typecheck_nonrec : always_polymorphic:bool -> pre -> type_environment -> untyped_let_binding -> (var_name * poly_type * EvalVarID.t * abstract_tree, type_error) result
+val typecheck_let_nonrec : always_polymorphic:bool -> pre -> type_environment -> untyped_let_binding -> (var_name * poly_type * EvalVarID.t * abstract_tree, type_error) result
 
 val typecheck_let_mutable : pre -> type_environment -> var_name ranged -> untyped_abstract_tree -> (var_name * poly_type * EvalVarID.t * abstract_tree, type_error) result
 

--- a/src/frontend/types.cppo.ml
+++ b/src/frontend/types.cppo.ml
@@ -240,7 +240,7 @@ and mono_type_variable =
   | MustBeBound of MustBeBoundID.t
 
 and poly_type_variable =
-  | PolyFree            of mono_type_variable_updatable ref
+  | PolyFreeUpdatable   of mono_type_variable_updatable ref
   | PolyFreeMustBeBound of MustBeBoundID.t
   | PolyBound           of BoundID.t
 

--- a/src/frontend/types.cppo.ml
+++ b/src/frontend/types.cppo.ml
@@ -404,7 +404,7 @@ and untyped_declaration_main =
   | UTDeclMacro      of macro_name ranged * manual_macro_type ranged
 
 and manual_quantifier =
-  (type_variable_name ranged) list * (row_variable_name ranged * manual_row_base_kind) list
+  ManualQuantifier of (type_variable_name ranged) list * (row_variable_name ranged * manual_row_base_kind) list
 
 and manual_macro_type =
   | MInlineMacroType of manual_macro_parameter_type list
@@ -423,7 +423,7 @@ and untyped_rec_or_nonrec =
   | UTMutable of untyped_let_mutable_binding
 
 and untyped_let_binding =
-  var_name ranged * untyped_abstract_tree
+  var_name ranged * manual_quantifier * untyped_abstract_tree
 
 and untyped_let_mutable_binding =
   var_name ranged * untyped_abstract_tree

--- a/src/frontend/types.cppo.ml
+++ b/src/frontend/types.cppo.ml
@@ -404,7 +404,7 @@ and untyped_declaration_main =
   | UTDeclMacro      of macro_name ranged * manual_macro_type ranged
 
 and manual_quantifier =
-  ManualQuantifier of (type_variable_name ranged) list * (row_variable_name ranged * manual_row_base_kind) list
+  | ManualQuantifier of (type_variable_name ranged) list * (row_variable_name ranged * manual_row_base_kind) list
 
 and manual_macro_type =
   | MInlineMacroType of manual_macro_parameter_type list
@@ -423,7 +423,13 @@ and untyped_rec_or_nonrec =
   | UTMutable of untyped_let_mutable_binding
 
 and untyped_let_binding =
-  var_name ranged * manual_quantifier * manual_type option * untyped_abstract_tree
+  | UTLetBinding of {
+      identifier  : var_name ranged;
+      quantifier  : manual_quantifier;
+      parameters  : untyped_parameter_unit list;
+      return_type : manual_type option;
+      body        : untyped_abstract_tree;
+    }
 
 and untyped_let_mutable_binding =
   var_name ranged * untyped_abstract_tree
@@ -1565,3 +1571,10 @@ let unlift_rec_or_nonrec (cd_rec_or_nonrec : code_rec_or_nonrec) : rec_or_nonrec
   | CdNonRec(symb, code)  -> NonRec(CodeSymbol.unlift symb, unlift_code code)
   | CdRec(cdrecbinds)     -> Rec(List.map unlift_letrec_binding cdrecbinds)
   | CdMutable(symb, code) -> Mutable(CodeSymbol.unlift symb, unlift_code code)
+
+
+let curry_lambda_abstraction (param_units : untyped_parameter_unit list) (utast : untyped_abstract_tree) : untyped_abstract_tree =
+  let rng = Range.dummy "curry_lambda_abstraction" in
+  utast |> List.fold_right (fun param_unit utast ->
+    (rng, UTFunction(param_unit, utast))
+  ) param_units

--- a/src/frontend/types.cppo.ml
+++ b/src/frontend/types.cppo.ml
@@ -423,7 +423,7 @@ and untyped_rec_or_nonrec =
   | UTMutable of untyped_let_mutable_binding
 
 and untyped_let_binding =
-  var_name ranged * manual_quantifier * untyped_abstract_tree
+  var_name ranged * manual_quantifier * manual_type option * untyped_abstract_tree
 
 and untyped_let_mutable_binding =
   var_name ranged * untyped_abstract_tree

--- a/src/frontend/types.cppo.ml
+++ b/src/frontend/types.cppo.ml
@@ -240,8 +240,9 @@ and mono_type_variable =
   | MustBeBound of MustBeBoundID.t
 
 and poly_type_variable =
-  | PolyFree  of mono_type_variable_updatable ref
-  | PolyBound of BoundID.t
+  | PolyFree            of mono_type_variable_updatable ref
+  | PolyFreeMustBeBound of MustBeBoundID.t
+  | PolyBound           of BoundID.t
 
 and mono_type =
   (mono_type_variable, mono_row_variable) typ

--- a/src/frontend/types.cppo.ml
+++ b/src/frontend/types.cppo.ml
@@ -240,9 +240,8 @@ and mono_type_variable =
   | MustBeBound of MustBeBoundID.t
 
 and poly_type_variable =
-  | PolyFreeUpdatable   of mono_type_variable_updatable ref
-  | PolyFreeMustBeBound of MustBeBoundID.t
-  | PolyBound           of BoundID.t
+  | PolyFree  of mono_type_variable
+  | PolyBound of BoundID.t
 
 and mono_type =
   (mono_type_variable, mono_row_variable) typ

--- a/test/parsing/parser.expected
+++ b/test/parsing/parser.expected
@@ -9,792 +9,846 @@
      [((Range.Normal </path/to/nx.saty:3.3-6>),
        (UTBindValue ([], Stage1,
           (UTNonRec
-             (((Range.Normal </path/to/nx.saty:3.7-9>), "xs"),
-              (ManualQuantifier ([], [])), None,
-              (UTListCons ((UTIntegerConstant 1),
-                 (UTListCons ((UTIntegerConstant 2),
-                    (UTListCons ((UTIntegerConstant 3), UTEndOfList))))
-                 ))))
+             UTLetBinding {
+               identifier = ((Range.Normal </path/to/nx.saty:3.7-9>), "xs");
+               quantifier = (ManualQuantifier ([], [])); parameters = [];
+               return_type = None;
+               body =
+               (UTListCons ((UTIntegerConstant 1),
+                  (UTListCons ((UTIntegerConstant 2),
+                     (UTListCons ((UTIntegerConstant 3), UTEndOfList))))
+                  ))})
           )));
        ((Range.Normal </path/to/nx.saty:4.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
-              (((Range.Normal </path/to/nx.saty:4.7-9>), "ys"),
-               (ManualQuantifier ([], [])), None,
-               (UTListCons ((UTIntegerConstant 1),
-                  (UTListCons ((UTIntegerConstant 2),
-                     (UTListCons ((UTIntegerConstant 3), UTEndOfList))))
-                  ))))
+              UTLetBinding {
+                identifier = ((Range.Normal </path/to/nx.saty:4.7-9>), "ys");
+                quantifier = (ManualQuantifier ([], [])); parameters = [];
+                return_type = None;
+                body =
+                (UTListCons ((UTIntegerConstant 1),
+                   (UTListCons ((UTIntegerConstant 2),
+                      (UTListCons ((UTIntegerConstant 3), UTEndOfList))))
+                   ))})
            )));
        ((Range.Normal </path/to/nx.saty:6.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
-              (((Range.Normal </path/to/nx.saty:6.7-9>), "r0"),
-               (ManualQuantifier ([], [])), None, (UTRecord [])))
+              UTLetBinding {
+                identifier = ((Range.Normal </path/to/nx.saty:6.7-9>), "r0");
+                quantifier = (ManualQuantifier ([], [])); parameters = [];
+                return_type = None; body = (UTRecord [])})
            )));
        ((Range.Normal </path/to/nx.saty:7.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
-              (((Range.Normal </path/to/nx.saty:7.7-9>), "r1"),
-               (ManualQuantifier ([], [])), None,
-               (UTRecord
-                  [(((Range.Normal </path/to/nx.saty:7.15-16>), "x"),
-                    (UTIntegerConstant 1))])))
+              UTLetBinding {
+                identifier = ((Range.Normal </path/to/nx.saty:7.7-9>), "r1");
+                quantifier = (ManualQuantifier ([], [])); parameters = [];
+                return_type = None;
+                body =
+                (UTRecord
+                   [(((Range.Normal </path/to/nx.saty:7.15-16>), "x"),
+                     (UTIntegerConstant 1))])})
            )));
        ((Range.Normal </path/to/nx.saty:8.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
-              (((Range.Normal </path/to/nx.saty:8.7-9>), "r2"),
-               (ManualQuantifier ([], [])), None,
-               (UTRecord
-                  [(((Range.Normal </path/to/nx.saty:8.19-20>), "x"),
-                    (UTIntegerConstant 1));
-                    (((Range.Normal </path/to/nx.saty:8.26-27>), "y"),
-                     (UTIntegerConstant 2))
-                    ])))
+              UTLetBinding {
+                identifier = ((Range.Normal </path/to/nx.saty:8.7-9>), "r2");
+                quantifier = (ManualQuantifier ([], [])); parameters = [];
+                return_type = None;
+                body =
+                (UTRecord
+                   [(((Range.Normal </path/to/nx.saty:8.19-20>), "x"),
+                     (UTIntegerConstant 1));
+                     (((Range.Normal </path/to/nx.saty:8.26-27>), "y"),
+                      (UTIntegerConstant 2))
+                     ])})
            )));
        ((Range.Normal </path/to/nx.saty:9.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
-              (((Range.Normal </path/to/nx.saty:9.7-13>), "r2semi"),
-               (ManualQuantifier ([], [])), None,
-               (UTRecord
-                  [(((Range.Normal </path/to/nx.saty:9.19-20>), "x"),
-                    (UTIntegerConstant 1));
-                    (((Range.Normal </path/to/nx.saty:9.26-27>), "y"),
-                     (UTIntegerConstant 2))
-                    ])))
+              UTLetBinding {
+                identifier =
+                ((Range.Normal </path/to/nx.saty:9.7-13>), "r2semi");
+                quantifier = (ManualQuantifier ([], [])); parameters = [];
+                return_type = None;
+                body =
+                (UTRecord
+                   [(((Range.Normal </path/to/nx.saty:9.19-20>), "x"),
+                     (UTIntegerConstant 1));
+                     (((Range.Normal </path/to/nx.saty:9.26-27>), "y"),
+                      (UTIntegerConstant 2))
+                     ])})
            )));
        ((Range.Normal </path/to/nx.saty:11.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
-              (((Range.Normal </path/to/nx.saty:11.7-10>), "tp2"),
-               (ManualQuantifier ([], [])), None,
-               (UTTuple (UTIntegerConstant 1) (UTIntegerConstant 2) )))
+              UTLetBinding {
+                identifier =
+                ((Range.Normal </path/to/nx.saty:11.7-10>), "tp2");
+                quantifier = (ManualQuantifier ([], [])); parameters = [];
+                return_type = None;
+                body = (UTTuple (UTIntegerConstant 1) (UTIntegerConstant 2) )})
            )));
        ((Range.Normal </path/to/nx.saty:12.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
-              (((Range.Normal </path/to/nx.saty:12.7-10>), "tp3"),
-               (ManualQuantifier ([], [])), None,
-               (UTTuple (UTIntegerConstant 1) (UTIntegerConstant 2)
-                  (UTIntegerConstant 3))))
+              UTLetBinding {
+                identifier =
+                ((Range.Normal </path/to/nx.saty:12.7-10>), "tp3");
+                quantifier = (ManualQuantifier ([], [])); parameters = [];
+                return_type = None;
+                body =
+                (UTTuple (UTIntegerConstant 1) (UTIntegerConstant 2)
+                   (UTIntegerConstant 3))})
            )));
        ((Range.Normal </path/to/nx.saty:14.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
-              (((Range.Normal </path/to/nx.saty:14.7-14>), "op-test"),
-               (ManualQuantifier ([], [])), None,
-               (UTTuple
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:15.14-16>), "||")
-                           )),
-                        (UTApply ([],
-                           (UTApply ([],
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:15.9-11>),
-                                  "||")
-                                 )),
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:15.7-8>),
-                                  "a")
-                                 ))
-                              )),
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:15.12-13>),
-                               "b")
-                              ))
-                           ))
-                        )),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:15.17-18>), "c")))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:16.14-16>), "&&")
-                           )),
-                        (UTApply ([],
-                           (UTApply ([],
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:16.9-11>),
-                                  "&&")
-                                 )),
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:16.7-8>),
-                                  "a")
-                                 ))
-                              )),
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:16.12-13>),
-                               "b")
-                              ))
-                           ))
-                        )),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:16.17-18>), "c")))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:17.9-11>), "==")
-                           )),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:17.7-8>), "a")))
-                        )),
-                     (UTApply ([],
-                        (UTApply ([],
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:17.14-15>),
-                               ">")
-                              )),
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:17.12-13>),
-                               "b")
-                              ))
-                           )),
-                        (UTApply ([],
-                           (UTApply ([],
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:17.18-19>),
-                                  "<")
-                                 )),
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:17.16-17>),
-                                  "c")
-                                 ))
-                              )),
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:17.20-21>),
-                               "d")
-                              ))
-                           ))
-                        ))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:18.9-10>), "^"))),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:18.7-8>), "a")))
-                        )),
-                     (UTApply ([],
-                        (UTApply ([],
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:18.13-15>),
-                               "::")
-                              )),
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:18.11-12>),
-                               "b")
-                              ))
-                           )),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:18.16-17>), "c")
-                           ))
-                        ))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:19.9-10>), "+"))),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:19.7-8>), "a")))
-                        )),
-                     (UTApply ([],
-                        (UTApply ([],
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:19.13-14>),
-                               "+")
-                              )),
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:19.11-12>),
-                               "b")
-                              ))
-                           )),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:19.15-16>), "c")
-                           ))
-                        ))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:20.13-15>), "-'")
-                           )),
-                        (UTApply ([],
-                           (UTApply ([],
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:20.9-10>),
-                                  "-")
-                                 )),
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:20.7-8>),
-                                  "a")
-                                 ))
-                              )),
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:20.11-12>),
-                               "b")
-                              ))
-                           ))
-                        )),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:20.16-17>), "c")))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:21.9-10>), "+"))),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:21.7-8>), "a")))
-                        )),
-                     (UTApply ([],
-                        (UTApply ([],
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:21.17-18>),
-                               "+")
-                              )),
-                           (UTApply ([],
-                              (UTApply ([],
-                                 (UTContentOf ([],
-                                    ((Range.Normal </path/to/nx.saty:21.13-14>),
-                                     "-")
-                                    )),
-                                 (UTContentOf ([],
-                                    ((Range.Normal </path/to/nx.saty:21.11-12>),
-                                     "b")
-                                    ))
-                                 )),
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:21.15-16>),
-                                  "c")
-                                 ))
-                              ))
-                           )),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:21.19-20>), "d")
-                           ))
-                        ))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:22.9-10>), "*"))),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:22.7-8>), "a")))
-                        )),
-                     (UTApply ([],
-                        (UTApply ([],
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:22.13-15>),
-                               "*'")
-                              )),
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:22.11-12>),
-                               "b")
-                              ))
-                           )),
-                        (UTApply ([],
-                           (UTApply ([],
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:22.18-19>),
-                                  "/")
-                                 )),
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:22.16-17>),
-                                  "c")
-                                 ))
-                              )),
-                           (UTApply ([],
-                              (UTApply ([],
-                                 (UTContentOf ([],
-                                    ((Range.Normal </path/to/nx.saty:22.22-25>),
-                                     "mod")
-                                    )),
-                                 (UTContentOf ([],
-                                    ((Range.Normal </path/to/nx.saty:22.20-21>),
-                                     "d")
-                                    ))
-                                 )),
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:22.26-27>),
-                                  "e")
-                                 ))
-                              ))
-                           ))
-                        ))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:23.11-12>), "*")
-                           )),
-                        (UTApply ([],
-                           (UTApply ([],
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:23.7-8>),
-                                  "-")
-                                 )),
-                              (UTIntegerConstant 0))),
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:23.9-10>), "a")
-                              ))
-                           ))
-                        )),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:23.13-14>), "b")))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:24.9-11>), "||")
-                           )),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:24.7-8>), "a")))
-                        )),
-                     (UTApply ([],
-                        (UTApply ([],
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:24.14-16>),
-                               "&&")
-                              )),
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:24.12-13>),
-                               "a")
-                              ))
-                           )),
-                        (UTApply ([],
-                           (UTApply ([],
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:24.23-25>),
-                                  "==")
-                                 )),
-                              (UTApply ([],
-                                 (UTApply ([],
-                                    (UTContentOf ([],
-                                       ((Range.Normal </path/to/nx.saty:24.19-20>),
-                                        "^")
-                                       )),
-                                    (UTContentOf ([],
-                                       ((Range.Normal </path/to/nx.saty:24.17-18>),
-                                        "b")
-                                       ))
-                                    )),
-                                 (UTContentOf ([],
-                                    ((Range.Normal </path/to/nx.saty:24.21-22>),
-                                     "c")
-                                    ))
-                                 ))
-                              )),
-                           (UTApply ([],
-                              (UTApply ([],
-                                 (UTContentOf ([],
-                                    ((Range.Normal </path/to/nx.saty:24.28-29>),
-                                     ">")
-                                    )),
-                                 (UTContentOf ([],
-                                    ((Range.Normal </path/to/nx.saty:24.26-27>),
-                                     "d")
-                                    ))
-                                 )),
-                              (UTApply ([],
-                                 (UTApply ([],
-                                    (UTContentOf ([],
-                                       ((Range.Normal </path/to/nx.saty:24.32-33>),
-                                        "<")
-                                       )),
-                                    (UTContentOf ([],
-                                       ((Range.Normal </path/to/nx.saty:24.30-31>),
-                                        "e")
-                                       ))
-                                    )),
-                                 (UTApply ([],
-                                    (UTApply ([],
-                                       (UTContentOf ([],
-                                          ((Range.Normal </path/to/nx.saty:24.36-37>),
-                                           "^")
-                                          )),
-                                       (UTContentOf ([],
-                                          ((Range.Normal </path/to/nx.saty:24.34-35>),
-                                           "f")
-                                          ))
-                                       )),
-                                    (UTApply ([],
-                                       (UTApply ([],
-                                          (UTContentOf ([],
-                                             ((Range.Normal </path/to/nx.saty:24.40-42>),
-                                              "::")
-                                             )),
-                                          (UTContentOf ([],
-                                             ((Range.Normal </path/to/nx.saty:24.38-39>),
-                                              "g")
-                                             ))
-                                          )),
-                                       (UTApply ([],
-                                          (UTApply ([],
-                                             (UTContentOf ([],
-                                                ((Range.Normal </path/to/nx.saty:24.45-46>),
-                                                 "+")
-                                                )),
-                                             (UTContentOf ([],
-                                                ((Range.Normal </path/to/nx.saty:24.43-44>),
-                                                 "h")
-                                                ))
-                                             )),
-                                          (UTApply ([],
-                                             (UTApply ([],
-                                                (UTContentOf ([],
-                                                   ((Range.Normal </path/to/nx.saty:24.53-55>),
-                                                    "-'")
-                                                   )),
-                                                (UTApply ([],
-                                                   (UTApply ([],
-                                                      (UTContentOf ([],
-                                                         ((Range.Normal </path/to/nx.saty:24.49-50>),
-                                                          "-")
-                                                         )),
-                                                      (UTContentOf ([],
-                                                         ((Range.Normal </path/to/nx.saty:24.47-48>),
-                                                          "i")
-                                                         ))
-                                                      )),
-                                                   (UTContentOf ([],
-                                                      ((Range.Normal </path/to/nx.saty:24.51-52>),
-                                                       "j")
-                                                      ))
-                                                   ))
-                                                )),
-                                             (UTApply ([],
-                                                (UTApply ([],
-                                                   (UTContentOf ([],
-                                                      ((Range.Normal </path/to/nx.saty:24.58-59>),
-                                                       "*")
-                                                      )),
-                                                   (UTContentOf ([],
-                                                      ((Range.Normal </path/to/nx.saty:24.56-57>),
-                                                       "k")
-                                                      ))
-                                                   )),
-                                                (UTApply ([],
-                                                   (UTApply ([],
-                                                      (UTContentOf ([],
-                                                         ((Range.Normal </path/to/nx.saty:24.62-64>),
-                                                          "*'")
-                                                         )),
-                                                      (UTContentOf ([],
-                                                         ((Range.Normal </path/to/nx.saty:24.60-61>),
-                                                          "l")
-                                                         ))
-                                                      )),
-                                                   (UTApply ([],
-                                                      (UTApply ([],
-                                                         (UTContentOf (
-                                                            [],
-                                                            ((Range.Normal </path/to/nx.saty:24.67-68>),
-                                                             "/")
-                                                            )),
-                                                         (UTContentOf (
-                                                            [],
-                                                            ((Range.Normal </path/to/nx.saty:24.65-66>),
-                                                             "m")
-                                                            ))
-                                                         )),
-                                                      (UTApply ([],
-                                                         (UTApply ([],
-                                                            (UTContentOf (
-                                                               [],
-                                                               ((Range.Normal </path/to/nx.saty:24.71-74>),
-                                                                "mod")
-                                                               )),
-                                                            (UTContentOf (
-                                                               [],
-                                                               ((Range.Normal </path/to/nx.saty:24.69-70>),
-                                                                "n")
-                                                               ))
-                                                            )),
-                                                         (UTContentOf (
-                                                            [],
-                                                            ((Range.Normal </path/to/nx.saty:24.75-76>),
-                                                             "o")
-                                                            ))
-                                                         ))
-                                                      ))
-                                                   ))
-                                                ))
-                                             ))
-                                          ))
-                                       ))
-                                    ))
-                                 ))
-                              ))
-                           ))
-                        ))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:25.11-12>), "*")
-                           )),
-                        (UTApply ([],
-                           (UTApply ([],
-                              (UTContentOf ([],
-                                 ((Range.Normal </path/to/nx.saty:25.7-8>),
-                                  "-")
-                                 )),
-                              (UTIntegerConstant 0))),
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:25.9-10>), "a")
-                              ))
-                           ))
-                        )),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:25.13-14>), "b")))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:26.13-14>), "*")
-                           )),
-                        (UTApply ([],
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:26.7-10>),
-                               "not")
-                              )),
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:26.11-12>),
-                               "a")
-                              ))
-                           ))
-                        )),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:26.15-16>), "b")))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:27.11-12>), "*")
-                           )),
-                        (UTConstructor ([], "F",
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:27.9-10>), "a")
-                              ))
-                           ))
-                        )),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:27.13-14>), "b")))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:28.9-10>), "*"))),
-                        (UTConstructor ([], "A", UTUnitConstant)))),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:28.11-12>), "b")))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:29.9-10>), "+"))),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:29.7-8>), "a")))
-                        )),
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:29.11-12>), "f")
-                           )),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:29.13-14>), "b")
-                           ))
-                        ))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:30.9-10>), "-"))),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:30.7-8>), "f")))
-                        )),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:30.10-11>), "b")))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:31.13-15>), "&&")
-                           )),
-                        (UTApply ([],
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:31.7-10>),
-                               "not")
-                              )),
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:31.11-12>),
-                               "a")
-                              ))
-                           ))
-                        )),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:31.16-17>), "b")))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:32.9-11>), "||")
-                           )),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:32.7-8>), "a")))
-                        )),
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:32.12-15>), "not")
-                           )),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:32.16-17>), "b")
-                           ))
-                        ))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:33.9-10>), "*"))),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:33.7-8>), "a")))
-                        )),
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:33.11-14>), "not")
-                           )),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:33.15-16>), "b")
-                           ))
-                        ))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:34.9-10>), "*"))),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:34.7-8>), "a")))
-                        )),
-                     (UTConstructor ([], "F",
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:34.13-14>), "b")
-                           ))
-                        ))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:35.9-10>), "*"))),
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:35.7-8>), "a")))
-                        )),
-                     (UTConstructor ([], "B", UTUnitConstant))))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:36.13-14>), "*")
-                           )),
-                        (UTApply ([],
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:36.7-10>),
-                               "not")
-                              )),
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:36.11-12>),
-                               "a")
-                              ))
-                           ))
-                        )),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:36.15-16>), "b")))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:37.11-12>), "*")
-                           )),
-                        (UTConstructor ([], "F",
-                           (UTContentOf ([],
-                              ((Range.Normal </path/to/nx.saty:37.9-10>), "a")
-                              ))
-                           ))
-                        )),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:37.13-14>), "b")))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:38.9-10>), "*"))),
-                        (UTConstructor ([], "A", UTUnitConstant)))),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:38.11-12>), "b")))
-                     )))))
+              UTLetBinding {
+                identifier =
+                ((Range.Normal </path/to/nx.saty:14.7-14>), "op-test");
+                quantifier = (ManualQuantifier ([], [])); parameters = [];
+                return_type = None;
+                body =
+                (UTTuple
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:15.14-16>), "||")
+                            )),
+                         (UTApply ([],
+                            (UTApply ([],
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:15.9-11>),
+                                   "||")
+                                  )),
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:15.7-8>),
+                                   "a")
+                                  ))
+                               )),
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:15.12-13>),
+                                "b")
+                               ))
+                            ))
+                         )),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:15.17-18>), "c")))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:16.14-16>), "&&")
+                            )),
+                         (UTApply ([],
+                            (UTApply ([],
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:16.9-11>),
+                                   "&&")
+                                  )),
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:16.7-8>),
+                                   "a")
+                                  ))
+                               )),
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:16.12-13>),
+                                "b")
+                               ))
+                            ))
+                         )),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:16.17-18>), "c")))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:17.9-11>), "==")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:17.7-8>), "a")))
+                         )),
+                      (UTApply ([],
+                         (UTApply ([],
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:17.14-15>),
+                                ">")
+                               )),
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:17.12-13>),
+                                "b")
+                               ))
+                            )),
+                         (UTApply ([],
+                            (UTApply ([],
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:17.18-19>),
+                                   "<")
+                                  )),
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:17.16-17>),
+                                   "c")
+                                  ))
+                               )),
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:17.20-21>),
+                                "d")
+                               ))
+                            ))
+                         ))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:18.9-10>), "^")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:18.7-8>), "a")))
+                         )),
+                      (UTApply ([],
+                         (UTApply ([],
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:18.13-15>),
+                                "::")
+                               )),
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:18.11-12>),
+                                "b")
+                               ))
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:18.16-17>), "c")
+                            ))
+                         ))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:19.9-10>), "+")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:19.7-8>), "a")))
+                         )),
+                      (UTApply ([],
+                         (UTApply ([],
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:19.13-14>),
+                                "+")
+                               )),
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:19.11-12>),
+                                "b")
+                               ))
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:19.15-16>), "c")
+                            ))
+                         ))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:20.13-15>), "-'")
+                            )),
+                         (UTApply ([],
+                            (UTApply ([],
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:20.9-10>),
+                                   "-")
+                                  )),
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:20.7-8>),
+                                   "a")
+                                  ))
+                               )),
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:20.11-12>),
+                                "b")
+                               ))
+                            ))
+                         )),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:20.16-17>), "c")))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:21.9-10>), "+")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:21.7-8>), "a")))
+                         )),
+                      (UTApply ([],
+                         (UTApply ([],
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:21.17-18>),
+                                "+")
+                               )),
+                            (UTApply ([],
+                               (UTApply ([],
+                                  (UTContentOf ([],
+                                     ((Range.Normal </path/to/nx.saty:21.13-14>),
+                                      "-")
+                                     )),
+                                  (UTContentOf ([],
+                                     ((Range.Normal </path/to/nx.saty:21.11-12>),
+                                      "b")
+                                     ))
+                                  )),
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:21.15-16>),
+                                   "c")
+                                  ))
+                               ))
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:21.19-20>), "d")
+                            ))
+                         ))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:22.9-10>), "*")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:22.7-8>), "a")))
+                         )),
+                      (UTApply ([],
+                         (UTApply ([],
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:22.13-15>),
+                                "*'")
+                               )),
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:22.11-12>),
+                                "b")
+                               ))
+                            )),
+                         (UTApply ([],
+                            (UTApply ([],
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:22.18-19>),
+                                   "/")
+                                  )),
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:22.16-17>),
+                                   "c")
+                                  ))
+                               )),
+                            (UTApply ([],
+                               (UTApply ([],
+                                  (UTContentOf ([],
+                                     ((Range.Normal </path/to/nx.saty:22.22-25>),
+                                      "mod")
+                                     )),
+                                  (UTContentOf ([],
+                                     ((Range.Normal </path/to/nx.saty:22.20-21>),
+                                      "d")
+                                     ))
+                                  )),
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:22.26-27>),
+                                   "e")
+                                  ))
+                               ))
+                            ))
+                         ))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:23.11-12>), "*")
+                            )),
+                         (UTApply ([],
+                            (UTApply ([],
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:23.7-8>),
+                                   "-")
+                                  )),
+                               (UTIntegerConstant 0))),
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:23.9-10>),
+                                "a")
+                               ))
+                            ))
+                         )),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:23.13-14>), "b")))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:24.9-11>), "||")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:24.7-8>), "a")))
+                         )),
+                      (UTApply ([],
+                         (UTApply ([],
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:24.14-16>),
+                                "&&")
+                               )),
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:24.12-13>),
+                                "a")
+                               ))
+                            )),
+                         (UTApply ([],
+                            (UTApply ([],
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:24.23-25>),
+                                   "==")
+                                  )),
+                               (UTApply ([],
+                                  (UTApply ([],
+                                     (UTContentOf ([],
+                                        ((Range.Normal </path/to/nx.saty:24.19-20>),
+                                         "^")
+                                        )),
+                                     (UTContentOf ([],
+                                        ((Range.Normal </path/to/nx.saty:24.17-18>),
+                                         "b")
+                                        ))
+                                     )),
+                                  (UTContentOf ([],
+                                     ((Range.Normal </path/to/nx.saty:24.21-22>),
+                                      "c")
+                                     ))
+                                  ))
+                               )),
+                            (UTApply ([],
+                               (UTApply ([],
+                                  (UTContentOf ([],
+                                     ((Range.Normal </path/to/nx.saty:24.28-29>),
+                                      ">")
+                                     )),
+                                  (UTContentOf ([],
+                                     ((Range.Normal </path/to/nx.saty:24.26-27>),
+                                      "d")
+                                     ))
+                                  )),
+                               (UTApply ([],
+                                  (UTApply ([],
+                                     (UTContentOf ([],
+                                        ((Range.Normal </path/to/nx.saty:24.32-33>),
+                                         "<")
+                                        )),
+                                     (UTContentOf ([],
+                                        ((Range.Normal </path/to/nx.saty:24.30-31>),
+                                         "e")
+                                        ))
+                                     )),
+                                  (UTApply ([],
+                                     (UTApply ([],
+                                        (UTContentOf ([],
+                                           ((Range.Normal </path/to/nx.saty:24.36-37>),
+                                            "^")
+                                           )),
+                                        (UTContentOf ([],
+                                           ((Range.Normal </path/to/nx.saty:24.34-35>),
+                                            "f")
+                                           ))
+                                        )),
+                                     (UTApply ([],
+                                        (UTApply ([],
+                                           (UTContentOf ([],
+                                              ((Range.Normal </path/to/nx.saty:24.40-42>),
+                                               "::")
+                                              )),
+                                           (UTContentOf ([],
+                                              ((Range.Normal </path/to/nx.saty:24.38-39>),
+                                               "g")
+                                              ))
+                                           )),
+                                        (UTApply ([],
+                                           (UTApply ([],
+                                              (UTContentOf ([],
+                                                 ((Range.Normal </path/to/nx.saty:24.45-46>),
+                                                  "+")
+                                                 )),
+                                              (UTContentOf ([],
+                                                 ((Range.Normal </path/to/nx.saty:24.43-44>),
+                                                  "h")
+                                                 ))
+                                              )),
+                                           (UTApply ([],
+                                              (UTApply ([],
+                                                 (UTContentOf ([],
+                                                    ((Range.Normal </path/to/nx.saty:24.53-55>),
+                                                     "-'")
+                                                    )),
+                                                 (UTApply ([],
+                                                    (UTApply ([],
+                                                       (UTContentOf (
+                                                          [],
+                                                          ((Range.Normal </path/to/nx.saty:24.49-50>),
+                                                           "-")
+                                                          )),
+                                                       (UTContentOf (
+                                                          [],
+                                                          ((Range.Normal </path/to/nx.saty:24.47-48>),
+                                                           "i")
+                                                          ))
+                                                       )),
+                                                    (UTContentOf ([],
+                                                       ((Range.Normal </path/to/nx.saty:24.51-52>),
+                                                        "j")
+                                                       ))
+                                                    ))
+                                                 )),
+                                              (UTApply ([],
+                                                 (UTApply ([],
+                                                    (UTContentOf ([],
+                                                       ((Range.Normal </path/to/nx.saty:24.58-59>),
+                                                        "*")
+                                                       )),
+                                                    (UTContentOf ([],
+                                                       ((Range.Normal </path/to/nx.saty:24.56-57>),
+                                                        "k")
+                                                       ))
+                                                    )),
+                                                 (UTApply ([],
+                                                    (UTApply ([],
+                                                       (UTContentOf (
+                                                          [],
+                                                          ((Range.Normal </path/to/nx.saty:24.62-64>),
+                                                           "*'")
+                                                          )),
+                                                       (UTContentOf (
+                                                          [],
+                                                          ((Range.Normal </path/to/nx.saty:24.60-61>),
+                                                           "l")
+                                                          ))
+                                                       )),
+                                                    (UTApply ([],
+                                                       (UTApply ([],
+                                                          (UTContentOf (
+                                                             [],
+                                                             ((Range.Normal </path/to/nx.saty:24.67-68>),
+                                                              "/")
+                                                             )),
+                                                          (UTContentOf (
+                                                             [],
+                                                             ((Range.Normal </path/to/nx.saty:24.65-66>),
+                                                              "m")
+                                                             ))
+                                                          )),
+                                                       (UTApply ([],
+                                                          (UTApply ([],
+                                                             (UTContentOf (
+                                                                [],
+                                                                ((Range.Normal </path/to/nx.saty:24.71-74>),
+                                                                 "mod")
+                                                                )),
+                                                             (UTContentOf (
+                                                                [],
+                                                                ((Range.Normal </path/to/nx.saty:24.69-70>),
+                                                                 "n")
+                                                                ))
+                                                             )),
+                                                          (UTContentOf (
+                                                             [],
+                                                             ((Range.Normal </path/to/nx.saty:24.75-76>),
+                                                              "o")
+                                                             ))
+                                                          ))
+                                                       ))
+                                                    ))
+                                                 ))
+                                              ))
+                                           ))
+                                        ))
+                                     ))
+                                  ))
+                               ))
+                            ))
+                         ))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:25.11-12>), "*")
+                            )),
+                         (UTApply ([],
+                            (UTApply ([],
+                               (UTContentOf ([],
+                                  ((Range.Normal </path/to/nx.saty:25.7-8>),
+                                   "-")
+                                  )),
+                               (UTIntegerConstant 0))),
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:25.9-10>),
+                                "a")
+                               ))
+                            ))
+                         )),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:25.13-14>), "b")))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:26.13-14>), "*")
+                            )),
+                         (UTApply ([],
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:26.7-10>),
+                                "not")
+                               )),
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:26.11-12>),
+                                "a")
+                               ))
+                            ))
+                         )),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:26.15-16>), "b")))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:27.11-12>), "*")
+                            )),
+                         (UTConstructor ([], "F",
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:27.9-10>),
+                                "a")
+                               ))
+                            ))
+                         )),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:27.13-14>), "b")))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:28.9-10>), "*")
+                            )),
+                         (UTConstructor ([], "A", UTUnitConstant)))),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:28.11-12>), "b")))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:29.9-10>), "+")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:29.7-8>), "a")))
+                         )),
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:29.11-12>), "f")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:29.13-14>), "b")
+                            ))
+                         ))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:30.9-10>), "-")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:30.7-8>), "f")))
+                         )),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:30.10-11>), "b")))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:31.13-15>), "&&")
+                            )),
+                         (UTApply ([],
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:31.7-10>),
+                                "not")
+                               )),
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:31.11-12>),
+                                "a")
+                               ))
+                            ))
+                         )),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:31.16-17>), "b")))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:32.9-11>), "||")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:32.7-8>), "a")))
+                         )),
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:32.12-15>),
+                             "not")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:32.16-17>), "b")
+                            ))
+                         ))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:33.9-10>), "*")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:33.7-8>), "a")))
+                         )),
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:33.11-14>),
+                             "not")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:33.15-16>), "b")
+                            ))
+                         ))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:34.9-10>), "*")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:34.7-8>), "a")))
+                         )),
+                      (UTConstructor ([], "F",
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:34.13-14>), "b")
+                            ))
+                         ))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:35.9-10>), "*")
+                            )),
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:35.7-8>), "a")))
+                         )),
+                      (UTConstructor ([], "B", UTUnitConstant))))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:36.13-14>), "*")
+                            )),
+                         (UTApply ([],
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:36.7-10>),
+                                "not")
+                               )),
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:36.11-12>),
+                                "a")
+                               ))
+                            ))
+                         )),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:36.15-16>), "b")))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:37.11-12>), "*")
+                            )),
+                         (UTConstructor ([], "F",
+                            (UTContentOf ([],
+                               ((Range.Normal </path/to/nx.saty:37.9-10>),
+                                "a")
+                               ))
+                            ))
+                         )),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:37.13-14>), "b")))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:38.9-10>), "*")
+                            )),
+                         (UTConstructor ([], "A", UTUnitConstant)))),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:38.11-12>), "b")))
+                      )))})
            )));
        ((Range.Normal </path/to/nx.saty:41.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
-              (((Range.Normal </path/to/nx.saty:41.7-13>), "uminus"),
-               (ManualQuantifier ([], [])), None,
-               (UTTuple
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:41.17-18>), "-")
-                           )),
-                        (UTIntegerConstant 0))),
-                     (UTIntegerConstant 1)))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:41.21-22>), "-")
-                           )),
-                        (UTIntegerConstant 0))),
-                     (UTIntegerConstant 42)))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:41.27-28>), "-.")
-                           )),
-                        (UTFloatConstant 0.))),
-                     (UTFloatConstant 1.)))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:41.33-34>), "-.")
-                           )),
-                        (UTFloatConstant 0.))),
-                     (UTFloatConstant 3.14)))
-                  (UTLengthDescription (-1., "mm"))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:41.47-48>), "-'")
-                           )),
-                        (UTLengthDescription (0., "cm")))),
-                     (UTLengthDescription (2.71828, "cm"))))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:41.60-61>), "-")
-                           )),
-                        (UTIntegerConstant 0))),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:41.61-62>), "x")))
-                     ))
-                  (UTApply ([],
-                     (UTApply ([],
-                        (UTContentOf ([],
-                           ((Range.Normal </path/to/nx.saty:41.64-65>), "-")
-                           )),
-                        (UTIntegerConstant 0))),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/nx.saty:41.66-67>), "x")))
-                     )))))
+              UTLetBinding {
+                identifier =
+                ((Range.Normal </path/to/nx.saty:41.7-13>), "uminus");
+                quantifier = (ManualQuantifier ([], [])); parameters = [];
+                return_type = None;
+                body =
+                (UTTuple
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:41.17-18>), "-")
+                            )),
+                         (UTIntegerConstant 0))),
+                      (UTIntegerConstant 1)))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:41.21-22>), "-")
+                            )),
+                         (UTIntegerConstant 0))),
+                      (UTIntegerConstant 42)))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:41.27-28>), "-.")
+                            )),
+                         (UTFloatConstant 0.))),
+                      (UTFloatConstant 1.)))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:41.33-34>), "-.")
+                            )),
+                         (UTFloatConstant 0.))),
+                      (UTFloatConstant 3.14)))
+                   (UTLengthDescription (-1., "mm"))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:41.47-48>), "-'")
+                            )),
+                         (UTLengthDescription (0., "cm")))),
+                      (UTLengthDescription (2.71828, "cm"))))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:41.60-61>), "-")
+                            )),
+                         (UTIntegerConstant 0))),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:41.61-62>), "x")))
+                      ))
+                   (UTApply ([],
+                      (UTApply ([],
+                         (UTContentOf ([],
+                            ((Range.Normal </path/to/nx.saty:41.64-65>), "-")
+                            )),
+                         (UTIntegerConstant 0))),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/nx.saty:41.66-67>), "x")))
+                      )))})
            )))
        ])))
 
@@ -999,37 +1053,45 @@
      [((Range.Normal </path/to/pats.saty:3.3-6>),
        (UTBindValue ([], Stage1,
           (UTNonRec
-             (((Range.Normal </path/to/pats.saty:3.7-17>), "pats-test1"),
-              (ManualQuantifier ([], [])), None,
-              (UTPatternMatch (
-                 (UTContentOf ([],
-                    ((Range.Normal </path/to/pats.saty:4.11-12>), "a"))),
-                 [(UTPatternBranch (
-                     ((Range.Normal </path/to/pats.saty:5.7-8>),
-                      (UTPVariable "b")),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/pats.saty:5.12-13>), "d")))
-                     ))
-                   ]
-                 ))))
+             UTLetBinding {
+               identifier =
+               ((Range.Normal </path/to/pats.saty:3.7-17>), "pats-test1");
+               quantifier = (ManualQuantifier ([], [])); parameters = [];
+               return_type = None;
+               body =
+               (UTPatternMatch (
+                  (UTContentOf ([],
+                     ((Range.Normal </path/to/pats.saty:4.11-12>), "a"))),
+                  [(UTPatternBranch (
+                      ((Range.Normal </path/to/pats.saty:5.7-8>),
+                       (UTPVariable "b")),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/pats.saty:5.12-13>), "d")))
+                      ))
+                    ]
+                  ))})
           )));
        ((Range.Normal </path/to/pats.saty:8.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
-              (((Range.Normal </path/to/pats.saty:8.7-17>), "pats-test2"),
-               (ManualQuantifier ([], [])), None,
-               (UTPatternMatch (
-                  (UTContentOf ([],
-                     ((Range.Normal </path/to/pats.saty:9.11-12>), "a"))),
-                  [(UTPatternBranch (
-                      ((Range.Normal </path/to/pats.saty:10.7-8>),
-                       (UTPVariable "b")),
-                      (UTContentOf ([],
-                         ((Range.Normal </path/to/pats.saty:10.12-13>), "d")
-                         ))
-                      ))
-                    ]
-                  ))))
+              UTLetBinding {
+                identifier =
+                ((Range.Normal </path/to/pats.saty:8.7-17>), "pats-test2");
+                quantifier = (ManualQuantifier ([], [])); parameters = [];
+                return_type = None;
+                body =
+                (UTPatternMatch (
+                   (UTContentOf ([],
+                      ((Range.Normal </path/to/pats.saty:9.11-12>), "a"))),
+                   [(UTPatternBranch (
+                       ((Range.Normal </path/to/pats.saty:10.7-8>),
+                        (UTPVariable "b")),
+                       (UTContentOf ([],
+                          ((Range.Normal </path/to/pats.saty:10.12-13>), "d")
+                          ))
+                       ))
+                     ]
+                   ))})
            )))
        ])))
 
@@ -1041,26 +1103,31 @@
      [((Range.Normal </path/to/pattuple.saty:3.3-6>),
        (UTBindValue ([], Stage1,
           (UTNonRec
-             (((Range.Normal </path/to/pattuple.saty:3.7-20>),
-               "pattuple-test"),
-              (ManualQuantifier ([], [])), None,
-              (UTPatternMatch (
-                 (UTContentOf ([],
-                    ((Range.Normal </path/to/pattuple.saty:4.11-12>), "a"))),
-                 [(UTPatternBranch (
-                     ((Range.Normal </path/to/pattuple.saty:5.7-13>),
-                      (UTPTuple
-                         ((Range.Normal </path/to/pattuple.saty:5.8-9>),
-                          (UTPVariable "b"))
-                         ((Range.Normal </path/to/pattuple.saty:5.11-12>),
-                          (UTPVariable "c"))
-                         )),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/pattuple.saty:5.17-18>), "d")
-                        ))
-                     ))
-                   ]
-                 ))))
+             UTLetBinding {
+               identifier =
+               ((Range.Normal </path/to/pattuple.saty:3.7-20>),
+                "pattuple-test");
+               quantifier = (ManualQuantifier ([], [])); parameters = [];
+               return_type = None;
+               body =
+               (UTPatternMatch (
+                  (UTContentOf ([],
+                     ((Range.Normal </path/to/pattuple.saty:4.11-12>), "a"))),
+                  [(UTPatternBranch (
+                      ((Range.Normal </path/to/pattuple.saty:5.7-13>),
+                       (UTPTuple
+                          ((Range.Normal </path/to/pattuple.saty:5.8-9>),
+                           (UTPVariable "b"))
+                          ((Range.Normal </path/to/pattuple.saty:5.11-12>),
+                           (UTPVariable "c"))
+                          )),
+                      (UTContentOf ([],
+                         ((Range.Normal </path/to/pattuple.saty:5.17-18>),
+                          "d")
+                         ))
+                      ))
+                    ]
+                  ))})
           )))
        ])))
 
@@ -1072,55 +1139,63 @@
      [((Range.Normal </path/to/patlist.saty:3.3-6>),
        (UTBindValue ([], Stage1,
           (UTNonRec
-             (((Range.Normal </path/to/patlist.saty:3.7-15>), "pat-test"),
-              (ManualQuantifier ([], [])), None,
-              (UTPatternMatch (
-                 (UTContentOf ([],
-                    ((Range.Normal </path/to/patlist.saty:4.11-12>), "a"))),
-                 [(UTPatternBranch (
-                     ((Range.Normal </path/to/patlist.saty:5.7-10>),
-                      (UTPListCons (
-                         ((Range.Normal </path/to/patlist.saty:5.8-9>),
-                          (UTPVariable "b")),
-                         ((Range.Dummy "list-pattern-nil"), UTPEndOfList)))),
-                     (UTContentOf ([],
-                        ((Range.Normal </path/to/patlist.saty:5.14-15>), "c")
-                        ))
-                     ));
-                   (UTPatternBranch (
-                      ((Range.Normal </path/to/patlist.saty:6.7-13>),
+             UTLetBinding {
+               identifier =
+               ((Range.Normal </path/to/patlist.saty:3.7-15>), "pat-test");
+               quantifier = (ManualQuantifier ([], [])); parameters = [];
+               return_type = None;
+               body =
+               (UTPatternMatch (
+                  (UTContentOf ([],
+                     ((Range.Normal </path/to/patlist.saty:4.11-12>), "a"))),
+                  [(UTPatternBranch (
+                      ((Range.Normal </path/to/patlist.saty:5.7-10>),
                        (UTPListCons (
-                          ((Range.Normal </path/to/patlist.saty:6.8-9>),
+                          ((Range.Normal </path/to/patlist.saty:5.8-9>),
                            (UTPVariable "b")),
-                          ((Range.Dummy "list-pattern-cons"),
-                           (UTPListCons (
-                              ((Range.Normal </path/to/patlist.saty:6.11-12>),
-                               (UTPVariable "c")),
-                              ((Range.Dummy "list-pattern-nil"), UTPEndOfList)
-                              )))
-                          ))),
+                          ((Range.Dummy "list-pattern-nil"), UTPEndOfList)))),
                       (UTContentOf ([],
-                         ((Range.Normal </path/to/patlist.saty:6.17-18>), "d")
+                         ((Range.Normal </path/to/patlist.saty:5.14-15>), "c")
                          ))
                       ));
-                   (UTPatternBranch (
-                      ((Range.Normal </path/to/patlist.saty:7.7-14>),
-                       (UTPListCons (
-                          ((Range.Normal </path/to/patlist.saty:7.8-9>),
-                           (UTPVariable "b")),
-                          ((Range.Dummy "list-pattern-cons"),
-                           (UTPListCons (
-                              ((Range.Normal </path/to/patlist.saty:7.11-12>),
-                               (UTPVariable "c")),
-                              ((Range.Dummy "list-pattern-nil"), UTPEndOfList)
-                              )))
-                          ))),
-                      (UTContentOf ([],
-                         ((Range.Normal </path/to/patlist.saty:7.18-19>), "d")
-                         ))
-                      ))
-                   ]
-                 ))))
+                    (UTPatternBranch (
+                       ((Range.Normal </path/to/patlist.saty:6.7-13>),
+                        (UTPListCons (
+                           ((Range.Normal </path/to/patlist.saty:6.8-9>),
+                            (UTPVariable "b")),
+                           ((Range.Dummy "list-pattern-cons"),
+                            (UTPListCons (
+                               ((Range.Normal </path/to/patlist.saty:6.11-12>),
+                                (UTPVariable "c")),
+                               ((Range.Dummy "list-pattern-nil"),
+                                UTPEndOfList)
+                               )))
+                           ))),
+                       (UTContentOf ([],
+                          ((Range.Normal </path/to/patlist.saty:6.17-18>),
+                           "d")
+                          ))
+                       ));
+                    (UTPatternBranch (
+                       ((Range.Normal </path/to/patlist.saty:7.7-14>),
+                        (UTPListCons (
+                           ((Range.Normal </path/to/patlist.saty:7.8-9>),
+                            (UTPVariable "b")),
+                           ((Range.Dummy "list-pattern-cons"),
+                            (UTPListCons (
+                               ((Range.Normal </path/to/patlist.saty:7.11-12>),
+                                (UTPVariable "c")),
+                               ((Range.Dummy "list-pattern-nil"),
+                                UTPEndOfList)
+                               )))
+                           ))),
+                       (UTContentOf ([],
+                          ((Range.Normal </path/to/patlist.saty:7.18-19>),
+                           "d")
+                          ))
+                       ))
+                    ]
+                  ))})
           )))
        ])))
 
@@ -1132,16 +1207,23 @@
      [((Range.Normal </path/to/sxlist.saty:3.3-6>),
        (UTBindValue ([], Stage1,
           (UTNonRec
-             (((Range.Normal </path/to/sxlist.saty:3.7-8>), "x"),
-              (ManualQuantifier ([], [])), None, UTEndOfList))
+             UTLetBinding {
+               identifier =
+               ((Range.Normal </path/to/sxlist.saty:3.7-8>), "x");
+               quantifier = (ManualQuantifier ([], [])); parameters = [];
+               return_type = None; body = UTEndOfList})
           )));
        ((Range.Normal </path/to/sxlist.saty:4.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
-              (((Range.Normal </path/to/sxlist.saty:4.7-8>), "y"),
-               (ManualQuantifier ([], [])), None,
-               (UTListCons ((UTInlineText [IT:aa]),
-                  (UTListCons ((UTInlineText [IT:bb]), UTEndOfList))))))
+              UTLetBinding {
+                identifier =
+                ((Range.Normal </path/to/sxlist.saty:4.7-8>), "y");
+                quantifier = (ManualQuantifier ([], [])); parameters = [];
+                return_type = None;
+                body =
+                (UTListCons ((UTInlineText [IT:aa]),
+                   (UTListCons ((UTInlineText [IT:bb]), UTEndOfList))))})
            )))
        ])))
 
@@ -1153,272 +1235,284 @@
      [((Range.Normal </path/to/mathlist.saty:3.3-6>),
        (UTBindValue ([], Stage1,
           (UTNonRec
-             (((Range.Normal </path/to/mathlist.saty:3.7-8>), "x"),
-              (ManualQuantifier ([], [])), None, UTEndOfList))
+             UTLetBinding {
+               identifier =
+               ((Range.Normal </path/to/mathlist.saty:3.7-8>), "x");
+               quantifier = (ManualQuantifier ([], [])); parameters = [];
+               return_type = None; body = UTEndOfList})
           )));
        ((Range.Normal </path/to/mathlist.saty:4.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
-              (((Range.Normal </path/to/mathlist.saty:4.7-8>), "y"),
-               (ManualQuantifier ([], [])), None,
-               (UTListCons (
-                  (UTMathText
-                     [((Range.Normal </path/to/mathlist.saty:4.14-15>),
-                       UTMathTextElement {base = (UTMathTextChar "a");
-                         sup = None; sub = None})
-                       ]),
-                  (UTListCons (
-                     (UTMathText
-                        [((Range.Normal </path/to/mathlist.saty:4.16-17>),
-                          UTMathTextElement {base = (UTMathTextChar "a");
-                            sup = None; sub = None});
-                          ((Range.Normal </path/to/mathlist.saty:4.17-18>),
-                           UTMathTextElement {base = (UTMathTextChar "b");
-                             sup = None; sub = None})
-                          ]),
-                     UTEndOfList))
-                  ))))
+              UTLetBinding {
+                identifier =
+                ((Range.Normal </path/to/mathlist.saty:4.7-8>), "y");
+                quantifier = (ManualQuantifier ([], [])); parameters = [];
+                return_type = None;
+                body =
+                (UTListCons (
+                   (UTMathText
+                      [((Range.Normal </path/to/mathlist.saty:4.14-15>),
+                        UTMathTextElement {base = (UTMathTextChar "a");
+                          sup = None; sub = None})
+                        ]),
+                   (UTListCons (
+                      (UTMathText
+                         [((Range.Normal </path/to/mathlist.saty:4.16-17>),
+                           UTMathTextElement {base = (UTMathTextChar "a");
+                             sup = None; sub = None});
+                           ((Range.Normal </path/to/mathlist.saty:4.17-18>),
+                            UTMathTextElement {base = (UTMathTextChar "b");
+                              sup = None; sub = None})
+                           ]),
+                      UTEndOfList))
+                   ))})
            )));
        ((Range.Normal </path/to/mathlist.saty:6.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
-              (((Range.Normal </path/to/mathlist.saty:6.7-8>), "z"),
-               (ManualQuantifier ([], [])), None,
-               (UTBlockText
-                  [BC:(UTContentOf ([],
-                         ((Range.Normal </path/to/mathlist.saty:7.5-7>), "+p")
-                         )) (UTCommandArg ([],
-                               (UTInlineText
-                                  [(UTInlineTextEmbeddedMath
-                                      (UTMathText
-                                         [((Range.Normal </path/to/mathlist.saty:8.9-10>),
-                                           UTMathTextElement {
-                                             base = (UTMathTextChar "a");
-                                             sup = None; sub = None})
-                                           ]));
-                                    IT:
-;
-                                    (UTInlineTextEmbeddedMath
+              UTLetBinding {
+                identifier =
+                ((Range.Normal </path/to/mathlist.saty:6.7-8>), "z");
+                quantifier = (ManualQuantifier ([], [])); parameters = [];
+                return_type = None;
+                body =
+                (UTBlockText
+                   [BC:(UTContentOf ([],
+                          ((Range.Normal </path/to/mathlist.saty:7.5-7>),
+                           "+p")
+                          )) (UTCommandArg ([],
+                                (UTInlineText
+                                   [(UTInlineTextEmbeddedMath
                                        (UTMathText
-                                          [((Range.Normal </path/to/mathlist.saty:9.9-12>),
+                                          [((Range.Normal </path/to/mathlist.saty:8.9-10>),
                                             UTMathTextElement {
                                               base = (UTMathTextChar "a");
-                                              sup =
-                                              (Some (false,
-                                                     [((Range.Normal </path/to/mathlist.saty:9.11-12>),
-                                                       UTMathTextElement {
-                                                         base =
-                                                         (UTMathTextChar "1");
-                                                         sup = None;
-                                                         sub = None})
-                                                       ]));
-                                              sub = None})
+                                              sup = None; sub = None})
                                             ]));
-                                    IT:
+                                     IT:
 ;
-                                    (UTInlineTextEmbeddedMath
-                                       (UTMathText
-                                          [((Range.Normal </path/to/mathlist.saty:10.9-12>),
-                                            UTMathTextElement {
-                                              base = (UTMathTextChar "a");
-                                              sup = None;
-                                              sub =
-                                              (Some (false,
-                                                     [((Range.Normal </path/to/mathlist.saty:10.11-12>),
-                                                       UTMathTextElement {
-                                                         base =
-                                                         (UTMathTextChar "2");
-                                                         sup = None;
-                                                         sub = None})
-                                                       ]))})
-                                            ]));
-                                    IT:
-;
-                                    (UTInlineTextEmbeddedMath
-                                       (UTMathText
-                                          [((Range.Normal </path/to/mathlist.saty:11.9-14>),
-                                            UTMathTextElement {
-                                              base = (UTMathTextChar "a");
-                                              sup =
-                                              (Some (false,
-                                                     [((Range.Normal </path/to/mathlist.saty:11.13-14>),
-                                                       UTMathTextElement {
-                                                         base =
-                                                         (UTMathTextChar "1");
-                                                         sup = None;
-                                                         sub = None})
-                                                       ]));
-                                              sub =
-                                              (Some (false,
-                                                     [((Range.Normal </path/to/mathlist.saty:11.11-12>),
-                                                       UTMathTextElement {
-                                                         base =
-                                                         (UTMathTextChar "2");
-                                                         sup = None;
-                                                         sub = None})
-                                                       ]))})
-                                            ]));
-                                    IT:
-;
-                                    (UTInlineTextEmbeddedMath
-                                       (UTMathText
-                                          [((Range.Normal </path/to/mathlist.saty:12.9-14>),
-                                            UTMathTextElement {
-                                              base = (UTMathTextChar "a");
-                                              sup =
-                                              (Some (false,
-                                                     [((Range.Normal </path/to/mathlist.saty:12.11-12>),
-                                                       UTMathTextElement {
-                                                         base =
-                                                         (UTMathTextChar "1");
-                                                         sup = None;
-                                                         sub = None})
-                                                       ]));
-                                              sub =
-                                              (Some (false,
-                                                     [((Range.Normal </path/to/mathlist.saty:12.13-14>),
-                                                       UTMathTextElement {
-                                                         base =
-                                                         (UTMathTextChar "2");
-                                                         sup = None;
-                                                         sub = None})
-                                                       ]))})
-                                            ]));
-                                    IT:
-;
-                                    (UTInlineTextEmbeddedMath
-                                       (UTMathText
-                                          [((Range.Normal </path/to/mathlist.saty:13.9-11>),
-                                            UTMathTextElement {
-                                              base = (UTMathTextChar "a");
-                                              sup =
-                                              (Some (true,
-                                                     [((Range.Normal </path/to/mathlist.saty:13.10-11>),
-                                                       UTMathTextElement {
-                                                         base =
-                                                         (UTMathTextChar "′");
-                                                         sup = None;
-                                                         sub = None})
-                                                       ]));
-                                              sub = None})
-                                            ]));
-                                    IT:
-;
-                                    (UTInlineTextEmbeddedMath
-                                       (UTMathText
-                                          [((Range.Normal </path/to/mathlist.saty:14.9-13>),
-                                            UTMathTextElement {
-                                              base = (UTMathTextChar "a");
-                                              sup =
-                                              (Some (false,
-                                                     [((Range.Normal </path/to/mathlist.saty:14.10-11>),
-                                                       UTMathTextElement {
-                                                         base =
-                                                         (UTMathTextChar "′");
-                                                         sup = None;
-                                                         sub = None});
-                                                       ((Range.Normal </path/to/mathlist.saty:14.12-13>),
+                                     (UTInlineTextEmbeddedMath
+                                        (UTMathText
+                                           [((Range.Normal </path/to/mathlist.saty:9.9-12>),
+                                             UTMathTextElement {
+                                               base = (UTMathTextChar "a");
+                                               sup =
+                                               (Some (false,
+                                                      [((Range.Normal </path/to/mathlist.saty:9.11-12>),
                                                         UTMathTextElement {
                                                           base =
                                                           (UTMathTextChar "1");
                                                           sup = None;
                                                           sub = None})
-                                                       ]));
-                                              sub = None})
-                                            ]));
-                                    IT:
+                                                        ]));
+                                               sub = None})
+                                             ]));
+                                     IT:
 ;
-                                    (UTInlineTextEmbeddedMath
-                                       (UTMathText
-                                          [((Range.Normal </path/to/mathlist.saty:15.9-13>),
-                                            UTMathTextElement {
-                                              base = (UTMathTextChar "a");
-                                              sup =
-                                              (Some (true,
-                                                     [((Range.Normal </path/to/mathlist.saty:15.10-11>),
-                                                       UTMathTextElement {
-                                                         base =
-                                                         (UTMathTextChar "′");
-                                                         sup = None;
-                                                         sub = None})
-                                                       ]));
-                                              sub =
-                                              (Some (false,
-                                                     [((Range.Normal </path/to/mathlist.saty:15.12-13>),
-                                                       UTMathTextElement {
-                                                         base =
-                                                         (UTMathTextChar "2");
-                                                         sup = None;
-                                                         sub = None})
-                                                       ]))})
-                                            ]));
-                                    IT:
+                                     (UTInlineTextEmbeddedMath
+                                        (UTMathText
+                                           [((Range.Normal </path/to/mathlist.saty:10.9-12>),
+                                             UTMathTextElement {
+                                               base = (UTMathTextChar "a");
+                                               sup = None;
+                                               sub =
+                                               (Some (false,
+                                                      [((Range.Normal </path/to/mathlist.saty:10.11-12>),
+                                                        UTMathTextElement {
+                                                          base =
+                                                          (UTMathTextChar "2");
+                                                          sup = None;
+                                                          sub = None})
+                                                        ]))})
+                                             ]));
+                                     IT:
 ;
-                                    (UTInlineTextEmbeddedMath
-                                       (UTMathText
-                                          [((Range.Normal </path/to/mathlist.saty:16.9-15>),
-                                            UTMathTextElement {
-                                              base = (UTMathTextChar "a");
-                                              sup =
-                                              (Some (false,
-                                                     [((Range.Normal </path/to/mathlist.saty:16.10-11>),
-                                                       UTMathTextElement {
-                                                         base =
-                                                         (UTMathTextChar "′");
-                                                         sup = None;
-                                                         sub = None});
-                                                       ((Range.Normal </path/to/mathlist.saty:16.14-15>),
+                                     (UTInlineTextEmbeddedMath
+                                        (UTMathText
+                                           [((Range.Normal </path/to/mathlist.saty:11.9-14>),
+                                             UTMathTextElement {
+                                               base = (UTMathTextChar "a");
+                                               sup =
+                                               (Some (false,
+                                                      [((Range.Normal </path/to/mathlist.saty:11.13-14>),
                                                         UTMathTextElement {
                                                           base =
                                                           (UTMathTextChar "1");
                                                           sup = None;
                                                           sub = None})
-                                                       ]));
-                                              sub =
-                                              (Some (false,
-                                                     [((Range.Normal </path/to/mathlist.saty:16.12-13>),
-                                                       UTMathTextElement {
-                                                         base =
-                                                         (UTMathTextChar "2");
-                                                         sup = None;
-                                                         sub = None})
-                                                       ]))})
-                                            ]));
-                                    IT:
+                                                        ]));
+                                               sub =
+                                               (Some (false,
+                                                      [((Range.Normal </path/to/mathlist.saty:11.11-12>),
+                                                        UTMathTextElement {
+                                                          base =
+                                                          (UTMathTextChar "2");
+                                                          sup = None;
+                                                          sub = None})
+                                                        ]))})
+                                             ]));
+                                     IT:
 ;
-                                    (UTInlineTextEmbeddedMath
-                                       (UTMathText
-                                          [((Range.Normal </path/to/mathlist.saty:17.9-15>),
-                                            UTMathTextElement {
-                                              base = (UTMathTextChar "a");
-                                              sup =
-                                              (Some (false,
-                                                     [((Range.Normal </path/to/mathlist.saty:17.10-11>),
-                                                       UTMathTextElement {
-                                                         base =
-                                                         (UTMathTextChar "′");
-                                                         sup = None;
-                                                         sub = None});
-                                                       ((Range.Normal </path/to/mathlist.saty:17.12-13>),
+                                     (UTInlineTextEmbeddedMath
+                                        (UTMathText
+                                           [((Range.Normal </path/to/mathlist.saty:12.9-14>),
+                                             UTMathTextElement {
+                                               base = (UTMathTextChar "a");
+                                               sup =
+                                               (Some (false,
+                                                      [((Range.Normal </path/to/mathlist.saty:12.11-12>),
                                                         UTMathTextElement {
                                                           base =
                                                           (UTMathTextChar "1");
                                                           sup = None;
                                                           sub = None})
-                                                       ]));
-                                              sub =
-                                              (Some (false,
-                                                     [((Range.Normal </path/to/mathlist.saty:17.14-15>),
-                                                       UTMathTextElement {
-                                                         base =
-                                                         (UTMathTextChar "2");
-                                                         sup = None;
-                                                         sub = None})
-                                                       ]))})
-                                            ]))
-                                    ])
-                               ))
-                    ])))
+                                                        ]));
+                                               sub =
+                                               (Some (false,
+                                                      [((Range.Normal </path/to/mathlist.saty:12.13-14>),
+                                                        UTMathTextElement {
+                                                          base =
+                                                          (UTMathTextChar "2");
+                                                          sup = None;
+                                                          sub = None})
+                                                        ]))})
+                                             ]));
+                                     IT:
+;
+                                     (UTInlineTextEmbeddedMath
+                                        (UTMathText
+                                           [((Range.Normal </path/to/mathlist.saty:13.9-11>),
+                                             UTMathTextElement {
+                                               base = (UTMathTextChar "a");
+                                               sup =
+                                               (Some (true,
+                                                      [((Range.Normal </path/to/mathlist.saty:13.10-11>),
+                                                        UTMathTextElement {
+                                                          base =
+                                                          (UTMathTextChar "′");
+                                                          sup = None;
+                                                          sub = None})
+                                                        ]));
+                                               sub = None})
+                                             ]));
+                                     IT:
+;
+                                     (UTInlineTextEmbeddedMath
+                                        (UTMathText
+                                           [((Range.Normal </path/to/mathlist.saty:14.9-13>),
+                                             UTMathTextElement {
+                                               base = (UTMathTextChar "a");
+                                               sup =
+                                               (Some (false,
+                                                      [((Range.Normal </path/to/mathlist.saty:14.10-11>),
+                                                        UTMathTextElement {
+                                                          base =
+                                                          (UTMathTextChar "′");
+                                                          sup = None;
+                                                          sub = None});
+                                                        ((Range.Normal </path/to/mathlist.saty:14.12-13>),
+                                                         UTMathTextElement {
+                                                           base =
+                                                           (UTMathTextChar "1");
+                                                           sup = None;
+                                                           sub = None})
+                                                        ]));
+                                               sub = None})
+                                             ]));
+                                     IT:
+;
+                                     (UTInlineTextEmbeddedMath
+                                        (UTMathText
+                                           [((Range.Normal </path/to/mathlist.saty:15.9-13>),
+                                             UTMathTextElement {
+                                               base = (UTMathTextChar "a");
+                                               sup =
+                                               (Some (true,
+                                                      [((Range.Normal </path/to/mathlist.saty:15.10-11>),
+                                                        UTMathTextElement {
+                                                          base =
+                                                          (UTMathTextChar "′");
+                                                          sup = None;
+                                                          sub = None})
+                                                        ]));
+                                               sub =
+                                               (Some (false,
+                                                      [((Range.Normal </path/to/mathlist.saty:15.12-13>),
+                                                        UTMathTextElement {
+                                                          base =
+                                                          (UTMathTextChar "2");
+                                                          sup = None;
+                                                          sub = None})
+                                                        ]))})
+                                             ]));
+                                     IT:
+;
+                                     (UTInlineTextEmbeddedMath
+                                        (UTMathText
+                                           [((Range.Normal </path/to/mathlist.saty:16.9-15>),
+                                             UTMathTextElement {
+                                               base = (UTMathTextChar "a");
+                                               sup =
+                                               (Some (false,
+                                                      [((Range.Normal </path/to/mathlist.saty:16.10-11>),
+                                                        UTMathTextElement {
+                                                          base =
+                                                          (UTMathTextChar "′");
+                                                          sup = None;
+                                                          sub = None});
+                                                        ((Range.Normal </path/to/mathlist.saty:16.14-15>),
+                                                         UTMathTextElement {
+                                                           base =
+                                                           (UTMathTextChar "1");
+                                                           sup = None;
+                                                           sub = None})
+                                                        ]));
+                                               sub =
+                                               (Some (false,
+                                                      [((Range.Normal </path/to/mathlist.saty:16.12-13>),
+                                                        UTMathTextElement {
+                                                          base =
+                                                          (UTMathTextChar "2");
+                                                          sup = None;
+                                                          sub = None})
+                                                        ]))})
+                                             ]));
+                                     IT:
+;
+                                     (UTInlineTextEmbeddedMath
+                                        (UTMathText
+                                           [((Range.Normal </path/to/mathlist.saty:17.9-15>),
+                                             UTMathTextElement {
+                                               base = (UTMathTextChar "a");
+                                               sup =
+                                               (Some (false,
+                                                      [((Range.Normal </path/to/mathlist.saty:17.10-11>),
+                                                        UTMathTextElement {
+                                                          base =
+                                                          (UTMathTextChar "′");
+                                                          sup = None;
+                                                          sub = None});
+                                                        ((Range.Normal </path/to/mathlist.saty:17.12-13>),
+                                                         UTMathTextElement {
+                                                           base =
+                                                           (UTMathTextChar "1");
+                                                           sup = None;
+                                                           sub = None})
+                                                        ]));
+                                               sub =
+                                               (Some (false,
+                                                      [((Range.Normal </path/to/mathlist.saty:17.14-15>),
+                                                        UTMathTextElement {
+                                                          base =
+                                                          (UTMathTextChar "2");
+                                                          sup = None;
+                                                          sub = None})
+                                                        ]))})
+                                             ]))
+                                     ])
+                                ))
+                     ])})
            )))
        ])))
 

--- a/test/parsing/parser.expected
+++ b/test/parsing/parser.expected
@@ -10,6 +10,7 @@
        (UTBindValue ([], Stage1,
           (UTNonRec
              (((Range.Normal </path/to/nx.saty:3.7-9>), "xs"),
+              (ManualQuantifier ([], [])), None,
               (UTListCons ((UTIntegerConstant 1),
                  (UTListCons ((UTIntegerConstant 2),
                     (UTListCons ((UTIntegerConstant 3), UTEndOfList))))
@@ -19,6 +20,7 @@
         (UTBindValue ([], Stage1,
            (UTNonRec
               (((Range.Normal </path/to/nx.saty:4.7-9>), "ys"),
+               (ManualQuantifier ([], [])), None,
                (UTListCons ((UTIntegerConstant 1),
                   (UTListCons ((UTIntegerConstant 2),
                      (UTListCons ((UTIntegerConstant 3), UTEndOfList))))
@@ -27,12 +29,14 @@
        ((Range.Normal </path/to/nx.saty:6.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
-              (((Range.Normal </path/to/nx.saty:6.7-9>), "r0"), (UTRecord [])))
+              (((Range.Normal </path/to/nx.saty:6.7-9>), "r0"),
+               (ManualQuantifier ([], [])), None, (UTRecord [])))
            )));
        ((Range.Normal </path/to/nx.saty:7.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
               (((Range.Normal </path/to/nx.saty:7.7-9>), "r1"),
+               (ManualQuantifier ([], [])), None,
                (UTRecord
                   [(((Range.Normal </path/to/nx.saty:7.15-16>), "x"),
                     (UTIntegerConstant 1))])))
@@ -41,6 +45,7 @@
         (UTBindValue ([], Stage1,
            (UTNonRec
               (((Range.Normal </path/to/nx.saty:8.7-9>), "r2"),
+               (ManualQuantifier ([], [])), None,
                (UTRecord
                   [(((Range.Normal </path/to/nx.saty:8.19-20>), "x"),
                     (UTIntegerConstant 1));
@@ -52,6 +57,7 @@
         (UTBindValue ([], Stage1,
            (UTNonRec
               (((Range.Normal </path/to/nx.saty:9.7-13>), "r2semi"),
+               (ManualQuantifier ([], [])), None,
                (UTRecord
                   [(((Range.Normal </path/to/nx.saty:9.19-20>), "x"),
                     (UTIntegerConstant 1));
@@ -63,12 +69,14 @@
         (UTBindValue ([], Stage1,
            (UTNonRec
               (((Range.Normal </path/to/nx.saty:11.7-10>), "tp2"),
+               (ManualQuantifier ([], [])), None,
                (UTTuple (UTIntegerConstant 1) (UTIntegerConstant 2) )))
            )));
        ((Range.Normal </path/to/nx.saty:12.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
               (((Range.Normal </path/to/nx.saty:12.7-10>), "tp3"),
+               (ManualQuantifier ([], [])), None,
                (UTTuple (UTIntegerConstant 1) (UTIntegerConstant 2)
                   (UTIntegerConstant 3))))
            )));
@@ -76,6 +84,7 @@
         (UTBindValue ([], Stage1,
            (UTNonRec
               (((Range.Normal </path/to/nx.saty:14.7-14>), "op-test"),
+               (ManualQuantifier ([], [])), None,
                (UTTuple
                   (UTApply ([],
                      (UTApply ([],
@@ -730,6 +739,7 @@
         (UTBindValue ([], Stage1,
            (UTNonRec
               (((Range.Normal </path/to/nx.saty:41.7-13>), "uminus"),
+               (ManualQuantifier ([], [])), None,
                (UTTuple
                   (UTApply ([],
                      (UTApply ([],
@@ -990,6 +1000,7 @@
        (UTBindValue ([], Stage1,
           (UTNonRec
              (((Range.Normal </path/to/pats.saty:3.7-17>), "pats-test1"),
+              (ManualQuantifier ([], [])), None,
               (UTPatternMatch (
                  (UTContentOf ([],
                     ((Range.Normal </path/to/pats.saty:4.11-12>), "a"))),
@@ -1006,6 +1017,7 @@
         (UTBindValue ([], Stage1,
            (UTNonRec
               (((Range.Normal </path/to/pats.saty:8.7-17>), "pats-test2"),
+               (ManualQuantifier ([], [])), None,
                (UTPatternMatch (
                   (UTContentOf ([],
                      ((Range.Normal </path/to/pats.saty:9.11-12>), "a"))),
@@ -1031,6 +1043,7 @@
           (UTNonRec
              (((Range.Normal </path/to/pattuple.saty:3.7-20>),
                "pattuple-test"),
+              (ManualQuantifier ([], [])), None,
               (UTPatternMatch (
                  (UTContentOf ([],
                     ((Range.Normal </path/to/pattuple.saty:4.11-12>), "a"))),
@@ -1060,6 +1073,7 @@
        (UTBindValue ([], Stage1,
           (UTNonRec
              (((Range.Normal </path/to/patlist.saty:3.7-15>), "pat-test"),
+              (ManualQuantifier ([], [])), None,
               (UTPatternMatch (
                  (UTContentOf ([],
                     ((Range.Normal </path/to/patlist.saty:4.11-12>), "a"))),
@@ -1118,12 +1132,14 @@
      [((Range.Normal </path/to/sxlist.saty:3.3-6>),
        (UTBindValue ([], Stage1,
           (UTNonRec
-             (((Range.Normal </path/to/sxlist.saty:3.7-8>), "x"), UTEndOfList))
+             (((Range.Normal </path/to/sxlist.saty:3.7-8>), "x"),
+              (ManualQuantifier ([], [])), None, UTEndOfList))
           )));
        ((Range.Normal </path/to/sxlist.saty:4.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
               (((Range.Normal </path/to/sxlist.saty:4.7-8>), "y"),
+               (ManualQuantifier ([], [])), None,
                (UTListCons ((UTInlineText [IT:aa]),
                   (UTListCons ((UTInlineText [IT:bb]), UTEndOfList))))))
            )))
@@ -1138,12 +1154,13 @@
        (UTBindValue ([], Stage1,
           (UTNonRec
              (((Range.Normal </path/to/mathlist.saty:3.7-8>), "x"),
-              UTEndOfList))
+              (ManualQuantifier ([], [])), None, UTEndOfList))
           )));
        ((Range.Normal </path/to/mathlist.saty:4.3-6>),
         (UTBindValue ([], Stage1,
            (UTNonRec
               (((Range.Normal </path/to/mathlist.saty:4.7-8>), "y"),
+               (ManualQuantifier ([], [])), None,
                (UTListCons (
                   (UTMathText
                      [((Range.Normal </path/to/mathlist.saty:4.14-15>),
@@ -1166,6 +1183,7 @@
         (UTBindValue ([], Stage1,
            (UTNonRec
               (((Range.Normal </path/to/mathlist.saty:6.7-8>), "z"),
+               (ManualQuantifier ([], [])), None,
                (UTBlockText
                   [BC:(UTContentOf ([],
                          ((Range.Normal </path/to/mathlist.saty:7.5-7>), "+p")

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,6 +20,7 @@ DOC_TARGETS = \
 	staged1.pdf \
 	macro1.pdf \
 	rename-dep1.pdf \
+	type-annot.pdf \
 	$(INIT_DOC_DIR)/$(INIT_DOC_BASE).pdf \
 	$(INIT_MD_DIR)/$(INIT_MD_BASE).pdf \
 	$(LOCAL_FIXED_DIR)/$(LOCAL_FIXED_BASE).pdf \

--- a/tests/type-annot-local.satyh
+++ b/tests/type-annot-local.satyh
@@ -1,0 +1,12 @@
+module Local = struct
+
+  val persistent ~rec fold 'a 'b (f : 'a -> 'b -> 'a) (acc : 'a) (ys : list 'b) : 'a =
+    match ys with
+    | []      -> acc
+    | x :: xs -> fold f (f acc x) xs
+    end
+
+  val inline \show-int (n : int) =
+    embed-string (arabic n)
+
+end

--- a/tests/type-annot.saphe.lock.yaml.expected
+++ b/tests/type-annot.saphe.lock.yaml.expected
@@ -1,0 +1,122 @@
+saphe: ^0.1.0-alpha.1
+locks:
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.annot.0.0.1
+  dependencies:
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.stdlib.0.0.1
+    used_as: Stdlib
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: annot
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.code.0.0.1
+  dependencies:
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.stdlib.0.0.1
+    used_as: Stdlib
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-latin-modern.0.0.1
+    used_as: FontLatinModern
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: code
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-ipa-ex.0.0.1
+  dependencies: []
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: font-ipa-ex
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-junicode.0.0.1
+  dependencies: []
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: font-junicode
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-latin-modern.0.0.1
+  dependencies: []
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: font-latin-modern
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-latin-modern-math.0.0.1
+  dependencies: []
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: font-latin-modern-math
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.footnote-scheme.0.0.1
+  dependencies:
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.stdlib.0.0.1
+    used_as: Stdlib
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: footnote-scheme
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.hyph-english.0.0.1
+  dependencies: []
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: hyph-english
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.math.0.0.1
+  dependencies:
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.stdlib.0.0.1
+    used_as: Stdlib
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: math
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.std-ja-report.0.0.1
+  dependencies:
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.stdlib.0.0.1
+    used_as: Stdlib
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.math.0.0.1
+    used_as: Math
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.annot.0.0.1
+    used_as: Annot
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.code.0.0.1
+    used_as: Code
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.footnote-scheme.0.0.1
+    used_as: FootnoteScheme
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-junicode.0.0.1
+    used_as: FontJunicode
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-latin-modern.0.0.1
+    used_as: FontLatinModern
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-ipa-ex.0.0.1
+    used_as: FontIpaEx
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.font-latin-modern-math.0.0.1
+    used_as: FontLatinModernMath
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.hyph-english.0.0.1
+    used_as: HyphEnglish
+  - name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.unidata.0.0.1
+    used_as: Unidata
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: std-ja-report
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.stdlib.0.0.1
+  dependencies: []
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: stdlib
+    version: 0.0.1
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.unidata.0.0.1
+  dependencies: []
+  test_only: false
+  registered:
+    registry_hash_value: 6f2b80e9bb7c4e8af2104999fc25dbb3
+    package_name: unidata
+    version: 0.0.1
+dependencies:
+- name: registered.6f2b80e9bb7c4e8af2104999fc25dbb3.std-ja-report.0.0.1
+  used_as: StdJaReport
+test_dependencies: []

--- a/tests/type-annot.saphe.yaml
+++ b/tests/type-annot.saphe.yaml
@@ -1,0 +1,17 @@
+saphe: "^0.1.0-alpha.1"
+satysfi: "^0.1.0-alpha.1"
+authors:
+  - "Takashi Suwa"
+registries:
+  - name: "default"
+    git:
+      url: "https://github.com/SATySFi/default-registry"
+      branch: "temp-dev-saphe"
+contents:
+  document: {}
+dependencies:
+  - used_as: "StdJaReport"
+    registered:
+      registry: "default"
+      name: "std-ja-report"
+      requirement: "^0.0.1"

--- a/tests/type-annot.saty
+++ b/tests/type-annot.saty
@@ -1,0 +1,11 @@
+use package open StdJaReport
+use open Local of `./type-annot-local`
+
+document (|
+  title = {Type Annotations},
+  author = {Takashi Suwa},
+|) '<
+  +p{
+    Result: \show-int(fold ( + ) 0 [3, 1, 4, 1, 5, 9, 2]);
+  }
+>


### PR DESCRIPTION
- Add the syntax of explicit type variable binders to `let`-expressions
- Add the syntax of return type annotations
- Fix how to track `MustBeBoundID` and `MustBeBoundRowID` in type environments

```diff
-val ~rec lift lf xs =
+val ~rec lift 'a (lf : 'a -> code 'a) (xs : list 'a) : code (list 'a) =
   match xs with
   | []      -> &[]
   | x :: xs -> &(~(lf x) :: ~(lift lf xs))
   end
```