### PR TITLE
Extend `Stdlib.{String,List}`

### DIFF
--- a/default-registry-commit-hash.txt
+++ b/default-registry-commit-hash.txt
@@ -1,1 +1,1 @@
-bd52856b9da11fd774a6450ab8fc525d7a0abb50	refs/heads/temp-dev-saphe
+e8a1811c398721b1c5a66ffe0c422429748c2804	refs/heads/temp-dev-saphe

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/list.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/list.satyg
@@ -31,6 +31,8 @@ module List :> sig
   val persistent ~length 'a : list 'a -> int
   val persistent ~nth 'a : int -> list 'a -> option 'a
   val persistent ~is-empty 'a : list 'a -> bool
+  val persistent ~zip-exact 'a 'b : list 'a -> list 'b -> option (list ('a * 'b))
+  val persistent ~zip-shorter 'a 'b : list 'a -> list 'b -> list ('a * 'b)
 end = struct
 
   type t 'a = list 'a
@@ -236,5 +238,25 @@ end = struct
     | []     -> true
     | _ :: _ -> false
     end
+
+  val persistent ~zip-exact ys1 ys2 =
+    let rec aux acc ys1 ys2 =
+      match (ys1, ys2) with
+      | (x1 :: xs1, x2 :: xs2) -> aux ((x1, x2) :: acc) xs1 xs2
+      | ([], [])               -> Some(reverse acc)
+      | _                      -> None
+      end
+    in
+    aux [] ys1 ys2
+
+  val persistent ~zip-shorter ys1 ys2 =
+    let rec aux acc ys1 ys2 =
+      match (ys1, ys2) with
+      | (x1 :: xs1, x2 :: xs2) -> aux ((x1, x2) :: acc) xs1 xs2
+      | ([], _)                -> reverse acc
+      | (_, [])                -> reverse acc
+      end
+    in
+    aux [] ys1 ys2
 
 end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/list.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/list.satyg
@@ -110,9 +110,9 @@ end = struct
 
   val persistent ~fold-indexed-adjacent f init xs =
     let (_, acc) =
-      xs |> fold-adjacent (fun (i, acc) x prev-opt next-opt -> (
+      xs |> fold-adjacent (fun (i, acc) x prev-opt next-opt ->
         (i + 1, f acc i x prev-opt next-opt)
-      )) (0, init)
+      ) (0, init)
     in
     acc
 
@@ -135,22 +135,22 @@ end = struct
     aux 0 f
 
   val persistent ~map-adjacent f xs =
-    xs |> fold-adjacent (fun acc x prev-opt next-opt -> (
+    xs |> fold-adjacent (fun acc x prev-opt next-opt ->
       f x prev-opt next-opt :: acc
-    )) [] |> reverse
+    ) [] |> reverse
 
   val persistent ~map-indexed-adjacent f xs =
-    xs |> fold-indexed-adjacent (fun acc i x prev-opt next-opt -> (
+    xs |> fold-indexed-adjacent (fun acc i x prev-opt next-opt ->
       f i x prev-opt next-opt :: acc
-    )) [] |> reverse
+    ) [] |> reverse
 
   val persistent ~map-with-ends f xs =
-    fold-adjacent (fun acc x prev-opt next-opt -> (
+    fold-adjacent (fun acc x prev-opt next-opt ->
       let is-first = Option.is-none prev-opt in
       let is-last = Option.is-none next-opt in
       let y = f is-first is-last x in
       y :: acc
-    )) [] xs |> reverse
+    ) [] xs |> reverse
 
   val persistent ~rec append xs1 xs2 =
     match xs1 with

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/map.satyg
@@ -197,10 +197,10 @@ end = struct
             end
         end
       in
-      (fun mp -> (
+      (fun mp ->
         let (_, mp-new) = aux mp in
         mp-new
-      ))
+      )
 
     val trim-minimum =
       let rec aux n =
@@ -214,12 +214,12 @@ end = struct
             (kv-min, rebalance tL n#key n#data n#right)
         end
       in
-      (fun t -> (
+      (fun t ->
         match t with
         | Empty   -> None
         | Node(n) -> Some(aux n)
         end
-      ))
+      )
 
     % Merges two trees `t1` and `t2`,
     % where the maximum key in `t1` is less than the minimum key in `t2`
@@ -256,12 +256,12 @@ end = struct
             end
         end
       in
-      (fun mp -> (
+      (fun mp ->
         match aux mp with
         | None          -> mp
         | Some(mp-new) -> mp-new
         end
-      ))
+      )
 
     val find k =
       let rec aux mp =
@@ -422,7 +422,7 @@ end = struct
 
     #[test]
     val add-test () =
-      List.iter (fun r -> (
+      List.iter (fun r ->
         let title = r#title in
         let input = r#input in
         let expected = r#expected in
@@ -431,7 +431,7 @@ end = struct
         let got = r#operation r#input in
         let () = assert ?(title = title ^ `: output well-formedness`) (is-well-formed got) in
         assert-equal ?(title = title) (eq-internal Equality.string) expected got
-      )) [
+      ) [
         (|
           title = `added to the left`,
           input =

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/path.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/path.satyh
@@ -99,14 +99,14 @@ end = struct
       |> close-with-line
 
   val poly-line pt-init pts =
-    pts |> List.fold (fun acc pt -> (
+    pts |> List.fold (fun acc pt ->
       acc |> line-to pt
-    )) (start-path pt-init) |> terminate-path
+    ) (start-path pt-init) |> terminate-path
 
   val polygon pt-init pts =
-    pts |> List.fold (fun acc pt -> (
+    pts |> List.fold (fun acc pt ->
       acc |> line-to pt
-    )) (start-path pt-init) |> close-with-line
+    ) (start-path pt-init) |> close-with-line
 
   val line pt1 pt2 =
     start-path pt1 |> line-to pt2 |> terminate-path

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -70,6 +70,9 @@ module Stdlib :> sig
     val persistent ~split-into-grapheme-clusters : string -> list string
     val persistent ~empty : string
     val persistent ~split-into-lines : string -> list (int * string)
+    val persistent ~concat : string -> list string -> string
+    val persistent ~chop-prefix : string -> string -> option string
+    val persistent ~chop-suffix : string -> string -> option string
   end
   module Ordering : sig
     type t = ordering

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/stdlib.satyh
@@ -122,6 +122,8 @@ module Stdlib :> sig
     val persistent ~length 'a : list 'a -> int
     val persistent ~nth 'a : int -> list 'a -> option 'a
     val persistent ~is-empty 'a : list 'a -> bool
+    val persistent ~zip-exact 'a 'b : list 'a -> list 'b -> option (list ('a * 'b))
+    val persistent ~zip-shorter 'a 'b : list 'a -> list 'b -> list ('a * 'b)
   end
   module Pair : sig
     val ~lift 'a 'b : ('a -> code 'a) -> ('b -> code 'b) -> 'a * 'b -> code ('a * 'b)

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/string.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/string.satyg
@@ -19,6 +19,9 @@ module String :> sig
   val persistent ~split-into-grapheme-clusters : string -> list string
   val persistent ~empty : string
   val persistent ~split-into-lines : string -> list (int * string)
+  val persistent ~concat : string -> list string -> string
+  val persistent ~chop-prefix : string -> string -> option string
+  val persistent ~chop-suffix : string -> string -> option string
 end = struct
 
   type t = string
@@ -54,5 +57,34 @@ end = struct
     ` `
 
   val persistent ~split-into-lines = split-into-lines %PRIMITIVE
+
+  val persistent ~concat sep elems =
+    elems |> List.fold-adjacent (fun s elem _ next-opt ->
+      match next-opt with
+      | None    -> s ^ elem
+      | Some(_) -> s ^ elem ^ sep
+      end
+    ) ` `
+
+  val persistent ~rec chop-aux chars-prefix chars-target =
+    match (chars-prefix, chars-target) with
+    | ([], _) ->
+        Some(chars-target)
+    | (prefix-head :: prefix-tail, target-head :: target-tail) ->
+        if prefix-head == target-head then
+          chop-aux prefix-tail target-tail
+        else
+          None
+    | (_, []) ->
+        None
+    end
+
+  val persistent ~chop-prefix prefix target =
+    Option.map from-scalar-values (chop-aux (to-scalar-values prefix) (to-scalar-values target))
+
+  val persistent ~chop-suffix suffix target =
+    let decompose s = List.reverse (to-scalar-values s) in
+    let compose chars = from-scalar-values (List.reverse chars) in
+    Option.map compose (chop-aux (decompose suffix) (decompose target))
 
 end

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/string.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/src/string.satyg
@@ -1,5 +1,6 @@
 use open Basic
 use Int
+use Option
 use List
 
 module String :> sig

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/test/list-test.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/test/list-test.satyg
@@ -18,9 +18,9 @@ module ListTest = struct
     let mutable r <- [3] in
     let inputs = [1, 4, 1, 5, 9, 2] in
     let () =
-      List.iter (fun n -> (
+      List.iter (fun n ->
         r <- n :: !r
-      )) inputs
+      ) inputs
     in
     let got = !r in
     let expected = [2, 9, 5, 1, 4, 1, 3] in
@@ -28,10 +28,10 @@ module ListTest = struct
 
   #[test]
   val compare-test () =
-    List.iter (fun r -> (
+    List.iter (fun r ->
       let got = List.compare Int.compare r#input1 r#input2 in
       assert-equal ?(title = r#title) eq-ordering r#expected got
-    )) [
+    ) [
       (|
         title = `prefix is smaller 1`,
         input1 = [],
@@ -60,10 +60,10 @@ module ListTest = struct
 
   #[test]
   val show-test () =
-    List.iter (fun r -> (
+    List.iter (fun r ->
       let got = List.show arabic r#input in
       assert-equal ?(title = r#title) Equality.string r#expected got
-    )) [
+    ) [
       (|
         title = `empty`,
         input = [],
@@ -109,11 +109,11 @@ module ListTest = struct
     let input = [`a`, `b`, `c`, `d`] in
     let expected = [`cdY`, `bcd`, `abc`, `Xab`] in
     let got =
-      List.fold-adjacent (fun acc s prev next -> (
+      List.fold-adjacent (fun acc s prev next ->
         let s-prev = Option.from `X` prev in
         let s-next = Option.from `Y` next in
         (s-prev ^ s ^ s-next) :: acc
-      )) [] input
+      ) [] input
     in
     assert-equal Equality.(list string) expected got
 
@@ -122,11 +122,11 @@ module ListTest = struct
     let input = [`a`, `b`, `c`, `d`] in
     let expected = [`3cdY`, `2bcd`, `1abc`, `0Xab`] in
     let got =
-      List.fold-indexed-adjacent (fun acc i s prev next -> (
+      List.fold-indexed-adjacent (fun acc i s prev next ->
         let s-prev = Option.from `X` prev in
         let s-next = Option.from `Y` next in
         (arabic i ^ s-prev ^ s ^ s-next) :: acc
-      )) [] input
+      ) [] input
     in
     assert-equal Equality.(list string) expected got
 
@@ -149,11 +149,11 @@ module ListTest = struct
     let input = [3, 1, 4, 1, 5, 9, 2] in
     let expected = [`X31`, `314`, `141`, `415`, `159`, `592`, `92Y`] in
     let got =
-      List.map-adjacent (fun n prev next -> (
+      List.map-adjacent (fun n prev next ->
         let s-prev = Option.from `X` (Option.map arabic prev) in
         let s-next = Option.from `Y` (Option.map arabic next) in
         s-prev ^ arabic n ^ s-next
-      )) input
+      ) input
     in
     assert-equal Equality.(list string) expected got
 

--- a/lib-satysfi/packages/stdlib/stdlib.0.0.1/test/string-test.satyg
+++ b/lib-satysfi/packages/stdlib/stdlib.0.0.1/test/string-test.satyg
@@ -1,0 +1,34 @@
+use package open Testing
+use String
+use List
+
+module StringTest = struct
+
+  #[test]
+  val chop-prefix-test () =
+    List.iter (fun r ->
+      assert-equal ?(title = r#title) Equality.(option string)
+        r#expected
+        (String.chop-prefix r#prefix r#data)
+    ) [
+      (|
+        title = `removes a prefix (1)`,
+        prefix = `foo`,
+        data = `foobar`,
+        expected = Some(`bar`),
+      |),
+      (|
+        title = `removes a prefix (2)`,
+        prefix = `foo`,
+        data = `foo`,
+        expected = Some(` `),
+      |),
+      (|
+        title = `fail`,
+        prefix = `foo`,
+        data = `fob`,
+        expected = None,
+      |),
+    ]
+
+end


### PR DESCRIPTION
Adds the following functions:

- `String.concat`
- `String.chop-prefix`
- `String.chop-suffix`
- `List.zip-exact`
- `List.zip-shorter`