### PR TITLE
Fix an issue where PNG images cannot be loaded on Ubuntu

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -38,6 +38,7 @@
     (< 5.0.5)))
   (camlpdf
    (= 2.3.1+satysfi))
+  conf-libpng
   (core_kernel
    (and
     (>= v0.15)

--- a/satysfi.opam
+++ b/satysfi.opam
@@ -14,6 +14,7 @@ depends: [
   "batteries" {>= "3.6.0" & < "4.0"}
   "camlimages" {>= "5.0.1" & < "5.0.5"}
   "camlpdf" {= "2.3.1+satysfi"}
+  "conf-libpng"
   "core_kernel" {>= "v0.15" & < "v0.18"}
   "cppo" {>= "1.6.4" & < "1.7"}
   "dune-build-info"


### PR DESCRIPTION
# Problem

The latest CI failed because SATySFi failed to load PNG images on Ubuntu.

https://github.com/gfngfn/SATySFi/actions/runs/12861909507/job/35855999813

SATySFi manually built on Ubuntu failed to load PNG too.

# Cause

It is because `camlimages`, which provides functionalities to load PNG images, was built *without* `libpng`.

As `conf-libpng` is optional for `camlimages`, `libpng` (technically, `libpng-dev` apt package on Ubuntu) is not installed by `opam install . --deps-only` in CI.

https://gitlab.com/camlspotter/camlimages/-/blob/83c53c196fc1e7766ed5c636c3f1d2418ce41293/dune-project#L27-38

```dune
 (depopts
  lablgtk
  graphics
  conf-libpng
  conf-libjpeg
  ; conf-libexif
  ; conf-libtiff
  ; conf-libxpm
  conf-libwebp
  conf-freetype
  conf-libgif
  conf-ghostscript))
```


# Solution

Add `conf-libpng` to `package.depends` of `dune-project`.


P.S. I am completely new to OCaml and its ecosystem and am not sure about the correctness of the changes.